### PR TITLE
Docs: Remove Doxygen Build in RTD

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,10 +6,10 @@ from sphinx.highlighting import lexers
 from pygments_lexer_solidity import SolidityLexer
 lexers['solidity'] = SolidityLexer()
 from pathlib import Path
-import subprocess
+# import subprocess
 
 root_dir = Path(__file__).resolve().parents[2]
-subprocess.run('doxygen', shell=True, cwd=root_dir)
+# subprocess.run('doxygen', shell=True, cwd=root_dir)
 
 sys.path.insert(0, os.path.abspath('.'))
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,9 +31,3 @@ As Hyperledger Iroha is an open-source project, we will also cover contribution 
     develop/index.rst
     community/index.rst
     faq/index.rst
-
-Doxygen Technical Documentation
-*******************************
-
-We have auto-generated Doxygen documentation describing the technical components of HL Iroha v1.
-`Here it is <doxygen/index.html>`_.


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

ReadTheDocs started to fail documentation builds due to time out. Doxygen is taking ~20 min of build. 
The quick fix would be to remove Doxygen for now so the documentation could be built - later, if there is a need for Doxygen (that seems not too popular too) we could submit an issue to RTD and ask for help with resources or in other ways they could help. It is also possible to just return to the way we used to host doxygen - in a separate place.

### Benefits

Built docs

### Possible Drawbacks

Someone might need doxygen