### PR TITLE
RocksDBWsvQuery: fix buffer reuse in getPeerByPublicKey

### DIFF
--- a/irohad/ametsuchi/impl/rocksdb_wsv_query.cpp
+++ b/irohad/ametsuchi/impl/rocksdb_wsv_query.cpp
@@ -139,13 +139,16 @@ namespace iroha::ametsuchi {
               opt_addr,
               forPeerAddress<kDbOperation::kGet, kDbEntry::kMustExist>(common,
                                                                        result));
+          auto peer = std::make_shared<shared_model::plain::Peer>(
+              std::move(*opt_addr), std::string(pubkey), std::nullopt);
 
           RDB_TRY_GET_VALUE(opt_tls,
                             forPeerTLS<kDbOperation::kGet, kDbEntry::kCanExist>(
                                 common, result));
+          if (opt_tls)
+            peer->setTlsCertificate(*opt_tls);
 
-          return std::make_shared<shared_model::plain::Peer>(
-              std::move(*opt_addr), std::string(pubkey), opt_tls);
+          return peer;
         },
         [&]() {
           return fmt::format("Get peer by pubkey {}",

--- a/test/module/irohad/ametsuchi/rdb_wsv_query_test.cpp
+++ b/test/module/irohad/ametsuchi/rdb_wsv_query_test.cpp
@@ -71,6 +71,42 @@ namespace iroha {
     }
 
     /**
+     * @given storage with peer without TLS certificate
+     * @when stored peer is queried
+     * @then stored peer is successfully returned
+     */
+    TEST_F(RdbWsvQueryTest, GetPeerWithoutTls) {
+      shared_model::plain::Peer peer1{"some-address", "0a", std::nullopt};
+      command->insertPeer(peer1);
+
+      auto result = query->getPeerByPublicKey(
+          shared_model::interface::types::PublicKeyHexStringView{
+              peer1.pubkey()});
+      ASSERT_TRUE(result);
+      ASSERT_THAT(*result, testing::Pointee(testing::Eq(peer1)))
+          << "Inserted " << peer1.toString() << ", got "
+          << (*result)->toString();
+    }
+
+    /**
+     * @given storage with peer with TLS certificate
+     * @when stored peer is queried
+     * @then stored peer is successfully returned
+     */
+    TEST_F(RdbWsvQueryTest, GetPeerWithTls) {
+      shared_model::plain::Peer peer1{"some-address", "0a", "tls"};
+      command->insertPeer(peer1);
+
+      auto result = query->getPeerByPublicKey(
+          shared_model::interface::types::PublicKeyHexStringView{
+              peer1.pubkey()});
+      ASSERT_TRUE(result);
+      ASSERT_THAT(*result, testing::Pointee(testing::Eq(peer1)))
+          << "Inserted " << peer1.toString() << ", got "
+          << (*result)->toString();
+    }
+
+    /**
      * @given storage with signatories
      * @when trying to get signatories of one account
      * @then signature list for one account successfully received


### PR DESCRIPTION
### Description of the Change
Create the result peer object before the TLS certificate query to avoid buffer reuse.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Issue

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits
Query works correctly instead of having a null byte as the first character, such as:
```
[2021-10-07 01:47:49.040684995][th:3669471][info] Irohad/Storage/Storage/WsvQuery Got address  27.0.0.1:10001
```
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
