### PR TITLE
Addition of typed crypto primitives and migration to typesafe cryptography

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,9 +295,9 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bstr"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -317,15 +317,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.7.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+checksum = "d9df67f7bf9ef8498769f994239c45613ef0c5899415fb58e9add412d2c1a538"
 
 [[package]]
 name = "byte-slice-cast"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c1bf4a04a88c54f589125563643d773f3254b5c38571395e2b591c693bbc81"
+checksum = "ca0796d76a983651b4a0ddda16203032759f2fd9103d9181f7c65c06ee8872e6"
 
 [[package]]
 name = "byte-tools"
@@ -369,14 +369,14 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
+checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
 
 [[package]]
 name = "cfg-if"
@@ -491,6 +491,12 @@ name = "const-oid"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdab415d6744056100f40250a66bc430c1a46f7a02e20bc11c94c79a0f0464df"
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
@@ -710,9 +716,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2adca118c71ecd9ae094d4b68257b3fdfcb711a612b9eec7b5a0d27a5a70a5b4"
+checksum = "28e98c534e9c8a0483aa01d6f6913bc063de254311bd267c9cf535e9b70e15b2"
 dependencies = [
  "const-oid",
 ]
@@ -723,8 +729,10 @@ version = "0.99.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
+ "rustc_version 0.3.3",
  "syn",
 ]
 
@@ -760,9 +768,9 @@ dependencies = [
 
 [[package]]
 name = "dissimilar"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4b29f4b9bb94bf267d57269fd0706d343a160937108e9619fe380645428abb"
+checksum = "31ad93652f40969dead8d4bf897a41e9462095152eb21c56e5830537e41179dd"
 
 [[package]]
 name = "ecdsa"
@@ -889,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80edafed416a46fb378521624fab1cfa2eb514784fd8921adbe8a8d8321da811"
+checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
 dependencies = [
  "cfg-if",
  "crc32fast",
@@ -1118,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f3675cfef6a30c8031cf9e6493ebdc3bb3272a3fea3923c4210d1830e6a472"
+checksum = "6c06815895acec637cd6ed6e9662c935b866d20a106f8361892893a7d9234964"
 dependencies = [
  "bytes",
  "fnv",
@@ -1237,9 +1245,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
+checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
 dependencies = [
  "bytes",
  "fnv",
@@ -1271,9 +1279,9 @@ checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "hyper"
-version = "0.14.12"
+version = "0.14.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13f67199e765030fa08fe0bd581af683f0d5bc04ea09c2b1102012c5fb90e7fd"
+checksum = "15d1cfb9e4f68655fa04c01f59edb405b6074a0f7118ea881e5026e4a1cd8593"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1499,6 +1507,7 @@ dependencies = [
 name = "iroha_crypto"
 version = "0.1.0"
 dependencies = [
+ "derive_more",
  "eyre",
  "hex",
  "hex-literal",
@@ -1762,9 +1771,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "js-sys"
-version = "0.3.53"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4bf49d50e2961077d9c99f4b7997d770a1114f087c3c2e0069b36c13fc2979d"
+checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1795,9 +1804,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.101"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
+checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
 
 [[package]]
 name = "log"
@@ -2027,9 +2036,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.66"
+version = "0.9.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1996d2d305e561b70d1ee0c53f1542833f4e1ac6ce9a6708b6ff2738ca67dc82"
+checksum = "69df2d8dfc6ce3aaf44b40dec6f487d5a886516cf6879c49e98e0710f310a058"
 dependencies = [
  "autocfg 1.0.1",
  "cc",
@@ -2047,9 +2056,9 @@ checksum = "2386b4ebe91c2f7f51082d4cefa145d030e33a1842a96b12e4885cc3c01f7a55"
 
 [[package]]
 name = "parity-scale-codec"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8975095a2a03bbbdc70a74ab11a4f76a6d0b84680d87c68d722531b0ac28e8a9"
+checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -2061,9 +2070,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40dbbfef7f0a1143c5b06e0d76a6278e25dac0bc1af4be51a0fbb73f07e7ad09"
+checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2076,6 +2085,15 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
 
 [[package]]
 name = "petgraph"
@@ -2131,9 +2149,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+checksum = "7c9b1041b4387893b91ee6746cddfc28516aff326a3519fb2adf820932c5e6cb"
 
 [[package]]
 name = "plotters"
@@ -2198,9 +2216,9 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
+checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
 dependencies = [
  "thiserror",
  "toml",
@@ -2259,9 +2277,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
@@ -2516,11 +2534,20 @@ checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver",
+ "semver 1.0.4",
 ]
 
 [[package]]
@@ -2611,9 +2638,27 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -2656,9 +2701,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
+checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
  "itoa",
  "ryu",
@@ -2692,9 +2737,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.6"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9204c41a1597a8c5af23c82d1c921cb01ec0a4c59e07a9c7306062829a3903f3"
+checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
@@ -2755,9 +2800,9 @@ checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
 
 [[package]]
 name = "socket2"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
+checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
 dependencies = [
  "libc",
  "winapi",
@@ -2834,9 +2879,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.76"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
+checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2845,9 +2890,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2906,6 +2951,7 @@ dependencies = [
  "iroha_client",
  "iroha_config",
  "iroha_core",
+ "iroha_crypto",
  "iroha_data_model",
  "iroha_logger",
  "iroha_p2p",
@@ -2927,18 +2973,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2976,9 +3022,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.3.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848a1e1181b9f6753b5e96a092749e29b11d19ede67dfbbd6c7dc7e0f49b5338"
+checksum = "f83b2a3d4d9091d0abd7eba4dc2710b1718583bd4d8992e2190720ea38f391f7"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2991,9 +3037,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4efe6fc2395938c8155973d7be49fe8d03a843726e285e100a8a383cc0154ce"
+checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
 dependencies = [
  "autocfg 1.0.1",
  "bytes",
@@ -3008,9 +3054,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
+checksum = "154794c8f499c2619acd19e839294703e9e32e7630ef5f46ea80d4ef0fbee5eb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3072,9 +3118,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.26"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
+checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if",
  "log",
@@ -3085,9 +3131,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.15"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
+checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3113,9 +3159,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ca517f43f0fb96e0c3072ed5c275fe5eece87e8cb52f4a77b69226d3b1c9df8"
+checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static",
 ]
@@ -3153,9 +3199,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.20"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9cbe87a2fa7e35900ce5de20220a582a9483a7063811defce79d7cbd59d4cfe"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
 dependencies = [
  "ansi_term 0.12.1",
  "sharded-slab",
@@ -3171,9 +3217,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "trybuild"
-version = "1.0.45"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bdaf2a1d317f3d58b44b31c7f6436b9b9acafe7bddfeace50897c2b804d7792"
+checksum = "11b533b653278ed89f93da2508e324ce9c7ef4af686521ebe4e6516fc9f3fd8d"
 dependencies = [
  "dissimilar",
  "glob",
@@ -3220,6 +3266,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
 name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3230,9 +3282,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
 
 [[package]]
 name = "unicode-normalization"
@@ -3251,9 +3303,9 @@ checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
@@ -3425,9 +3477,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.76"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce9b1b516211d33767048e5d47fa2a381ed8b76fc48d2ce4aa39877f9f183e0"
+checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3435,9 +3487,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.76"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe8dc78e2326ba5f845f4b5bf548401604fa20b1dd1d365fb73b6c1d6364041"
+checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3450,9 +3502,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.76"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44468aa53335841d9d6b6c023eaab07c0cd4bddbcfdee3e2bb1e8d2cb8069fef"
+checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3460,9 +3512,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.76"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0195807922713af1e67dc66132c7328206ed9766af3858164fb583eedc25fbad"
+checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3473,15 +3525,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.76"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdb075a845574a1fa5f09fd77e43f7747599301ea3417a9fbffdeedfc1f4a29"
+checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "web-sys"
-version = "0.3.53"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224b2f6b67919060055ef1a67807367c2066ed520c3862cc013d26cf893a783c"
+checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3532,9 +3584,9 @@ checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "x25519-dalek"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f"
+checksum = "2392b6b94a576b4e2bf3c5b2757d63f10ada8020a2e4d08ac849ebcf6ea8e077"
 dependencies = [
  "curve25519-dalek",
  "rand_core 0.5.1",
@@ -3543,18 +3595,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.4.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
+checksum = "bdff2024a851a322b08f179173ae2ba620445aef1e838f0c196820eade4ae0c7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/client/tests/tests/permissions.rs
+++ b/client/tests/tests/permissions.rs
@@ -54,7 +54,7 @@ fn permissions_disallow_asset_transfer() {
         Value::U32(quantity),
         IdBox::AssetId(AssetId::new(asset_definition_id.clone(), bob_id.clone())),
     );
-    let _ = iroha_client
+    iroha_client
         .submit(mint_asset)
         .expect("Failed to create asset.");
     thread::sleep(pipeline_time * 2);

--- a/client/tests/tests/restart_peer.rs
+++ b/client/tests/tests/restart_peer.rs
@@ -34,7 +34,7 @@ fn restarted_peer_should_have_the_same_asset_amount() {
         AssetDefinition::new_quantity(asset_definition_id.clone()).into(),
     ));
     let mut iroha_client = Client::test(&peer.api_address);
-    let _ = iroha_client
+    iroha_client
         .submit(create_asset)
         .expect("Failed to prepare state.");
     thread::sleep(pipeline_time * 2);
@@ -47,7 +47,7 @@ fn restarted_peer_should_have_the_same_asset_amount() {
             account_id.clone(),
         )),
     );
-    let _ = iroha_client
+    iroha_client
         .submit(mint_asset)
         .expect("Failed to create asset.");
     thread::sleep(pipeline_time * 2);

--- a/client_cli/src/main.rs
+++ b/client_cli/src/main.rs
@@ -145,7 +145,7 @@ pub fn submit(
         _ => tx,
     };
 
-    let _ = iroha_client
+    iroha_client
         .submit_transaction(tx)
         .wrap_err("Failed to submit transaction.")?;
     Ok(())

--- a/core/benches/kura.rs
+++ b/core/benches/kura.rs
@@ -39,7 +39,7 @@ async fn measure_block_size_for_n_validators(n_validators: u32) {
     );
     for _ in 0..n_validators {
         block = block
-            .sign(&KeyPair::generate().expect("Failed to generate KeyPair."))
+            .sign(KeyPair::generate().expect("Failed to generate KeyPair."))
             .unwrap();
     }
     let block = block.commit();
@@ -49,7 +49,7 @@ async fn measure_block_size_for_n_validators(n_validators: u32) {
     )
     .await
     .unwrap();
-    let _ = block_store.write(&block).await.unwrap();
+    block_store.write(&block).await.unwrap();
     let metadata = fs::metadata(
         block_store
             .get_block_path(NonZeroU64::new(1_u64).unwrap())

--- a/core/benches/sumeragi.rs
+++ b/core/benches/sumeragi.rs
@@ -2,7 +2,7 @@
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use iroha_core::sumeragi::network_topology;
-use iroha_crypto::{Hash, KeyPair};
+use iroha_crypto::{Hash, HashOf, KeyPair};
 use iroha_data_model::prelude::*;
 
 const N_PEERS: usize = 255;
@@ -21,7 +21,8 @@ fn get_n_peers(n: usize) -> Vec<PeerId> {
 fn sort_peers(criterion: &mut Criterion) {
     let peers = get_n_peers(N_PEERS);
     let _ = criterion.bench_function("sort_peers", |b| {
-        b.iter(|| network_topology::sort_peers_by_hash(peers.clone(), Hash([0_u8; 32])));
+        let hash = HashOf::from_hash(Hash([0_u8; 32]));
+        b.iter(|| network_topology::sort_peers_by_hash(peers.clone(), &hash));
     });
 }
 

--- a/core/benches/validation.rs
+++ b/core/benches/validation.rs
@@ -132,7 +132,7 @@ fn chain_blocks(criterion: &mut Criterion) {
             success_count += 1;
             let new_block = block.clone().chain(
                 success_count,
-                previous_block_hash,
+                previous_block_hash.transmute(),
                 view_change::ProofChain::empty(),
                 Vec::new(),
             );
@@ -154,7 +154,7 @@ fn sign_blocks(criterion: &mut Criterion) {
     let mut success_count = 0;
     let mut failures_count = 0;
     let _ = criterion.bench_function("sign_block", |b| {
-        b.iter(|| match block.clone().sign(&key_pair) {
+        b.iter(|| match block.clone().sign(key_pair.clone()) {
             Ok(_) => success_count += 1,
             Err(_) => failures_count += 1,
         });

--- a/core/src/block_sync.rs
+++ b/core/src/block_sync.rs
@@ -3,6 +3,7 @@
 use std::{fmt::Debug, sync::Arc, time::Duration};
 
 use iroha_actor::{broker::*, prelude::*, Context};
+use iroha_crypto::SignatureOf;
 use iroha_data_model::prelude::*;
 
 use self::{
@@ -187,7 +188,7 @@ impl<S: SumeragiTrait + Debug, W: WorldTrait> BlockSynchronizer<S, W> {
             && network_topology
                 .filter_signatures_by_roles(
                     &[Role::ValidatingPeer, Role::Leader, Role::ProxyTail],
-                    &block.verified_signatures(),
+                    block.verified_signatures().map(SignatureOf::transmute_ref),
                 )
                 .len()
                 >= network_topology.min_votes_for_commit() as usize
@@ -248,14 +249,14 @@ pub mod message {
     #[derive(Io, Decode, Encode, Debug, Clone)]
     pub struct LatestBlock {
         /// Block hash
-        pub hash: Hash,
+        pub hash: HashOf<VersionedCommittedBlock>,
         /// Peer id
         pub peer_id: PeerId,
     }
 
     impl LatestBlock {
         /// Default constructor
-        pub const fn new(hash: Hash, peer_id: PeerId) -> Self {
+        pub const fn new(hash: HashOf<VersionedCommittedBlock>, peer_id: PeerId) -> Self {
             Self { hash, peer_id }
         }
     }
@@ -264,14 +265,14 @@ pub mod message {
     #[derive(Io, Decode, Encode, Debug, Clone)]
     pub struct GetBlocksAfter {
         /// Block hash
-        pub hash: Hash,
+        pub hash: HashOf<VersionedCommittedBlock>,
         /// Peer id
         pub peer_id: PeerId,
     }
 
     impl GetBlocksAfter {
         /// Default constructor
-        pub const fn new(hash: Hash, peer_id: PeerId) -> Self {
+        pub const fn new(hash: HashOf<VersionedCommittedBlock>, peer_id: PeerId) -> Self {
             Self { hash, peer_id }
         }
     }

--- a/core/src/smartcontracts/isi/mod.rs
+++ b/core/src/smartcontracts/isi/mod.rs
@@ -15,6 +15,7 @@ use std::{
 };
 
 use eyre::{eyre, Result};
+use iroha_crypto::HashOf;
 use iroha_data_model::{expression::prelude::*, isi::*, prelude::*};
 use iroha_derive::FromVariant;
 use thiserror::Error;
@@ -113,7 +114,7 @@ pub enum MathError {
 
 /// Block with parent hash not found struct
 #[derive(Debug, Clone, Copy)]
-pub struct ParentHashNotFound(pub Hash);
+pub struct ParentHashNotFound(pub HashOf<VersionedCommittedBlock>);
 
 impl Display for ParentHashNotFound {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {

--- a/core/src/smartcontracts/isi/tx.rs
+++ b/core/src/smartcontracts/isi/tx.rs
@@ -23,6 +23,7 @@ impl<W: WorldTrait> Query<W> for FindTransactionByHash {
             .hash
             .evaluate(wsv, &Context::default())
             .wrap_err("Failed to get hash")?;
+        let hash = HashOf::from_hash(hash);
         if !wsv.has_transaction(&hash) {
             return Err(eyre!("Transaction not found"));
         };

--- a/core/src/torii/mod.rs
+++ b/core/src/torii/mod.rs
@@ -503,7 +503,7 @@ mod tests {
                 QueryBox::FindAllDomains(Default::default()),
                 AccountId::new("alice", "wonderland"),
             )
-            .sign(&keys)
+            .sign(keys.clone())
             .expect("Failed to sign query with keys")
             .try_into()
             .expect("Failed to verify");
@@ -536,7 +536,7 @@ mod tests {
             QueryBox::FindAllDomains(Default::default()),
             AccountId::new("bob", "wonderland"),
         )
-        .sign(&keys)
+        .sign(keys.clone())
         .expect("Failed to sign query with keys")
         .try_into()
         .expect("Failed to verify");

--- a/core/test_network/Cargo.toml
+++ b/core/test_network/Cargo.toml
@@ -25,6 +25,8 @@ rand = "0.7.3"
 futures = "0.3"
 
 [dev-dependencies]
+iroha_crypto = { path = "../../crypto" }
+
 async-trait = "0.1"
 color-eyre = "0.5.11"
 once_cell = "1"

--- a/core/test_network/src/lib.rs
+++ b/core/test_network/src/lib.rs
@@ -604,6 +604,7 @@ pub trait TestQueryResult {
 impl TestRuntime for Runtime {
     fn test() -> Self {
         runtime::Builder::new_multi_thread()
+            .thread_stack_size(32 * 1024 * 1024)
             .enable_all()
             .build()
             .unwrap()

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -7,14 +7,16 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+iroha_schema = { path = "../schema"}
+
+derive_more = "0.99.16"
 eyre = "0.6.5"
-ursa = "=0.3.7"
+hex = "0.4.0"
 openssl-sys = { version = "0", features = ["vendored"] }
+parity-scale-codec = { version = "2", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
-parity-scale-codec = { version = "2", features = ["derive"] }
-hex = "0.4.0"
-iroha_schema = { path = "../schema"}
+ursa = "=0.3.7"
 
 [dev-dependencies]
 hex-literal = "0.2.1"

--- a/crypto/src/hash.rs
+++ b/crypto/src/hash.rs
@@ -1,0 +1,172 @@
+use std::{
+    fmt::{self, Debug, Display, Formatter},
+    hash,
+    marker::PhantomData,
+};
+
+use derive_more::{Deref, DerefMut, Display};
+use iroha_schema::IntoSchema;
+use parity_scale_codec::{Decode, Encode};
+use serde::{Deserialize, Serialize};
+use ursa::blake2::{
+    digest::{Update, VariableOutput},
+    VarBlake2b,
+};
+
+/// Hash of Iroha entities. Currently supports only blake2b-32.
+#[derive(
+    Eq,
+    PartialEq,
+    Clone,
+    Encode,
+    Decode,
+    Serialize,
+    Deserialize,
+    Ord,
+    PartialOrd,
+    Copy,
+    Hash,
+    IntoSchema,
+)]
+pub struct Hash(pub [u8; Self::LENGTH]);
+
+impl Hash {
+    /// Length of hash
+    pub const LENGTH: usize = 32;
+
+    /// new hash from bytes
+    #[allow(clippy::expect_used)]
+    pub fn new(bytes: &[u8]) -> Self {
+        let vec_hash = VarBlake2b::new(Self::LENGTH)
+            .expect("Failed to initialize variable size hash")
+            .chain(bytes)
+            .finalize_boxed();
+        let mut hash = [0; Self::LENGTH];
+        hash.copy_from_slice(&vec_hash);
+        Hash(hash)
+    }
+}
+
+impl Display for Hash {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let Hash(bytes) = self;
+        write!(f, "{}", hex::encode(bytes))
+    }
+}
+
+impl Debug for Hash {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let Hash(bytes) = self;
+        write!(f, "{}", hex::encode(bytes))
+    }
+}
+
+impl AsRef<[u8]> for Hash {
+    fn as_ref(&self) -> &[u8] {
+        let Hash(bytes) = self;
+        bytes
+    }
+}
+
+/// Represents hash of Iroha entities like `Block` or `Transaction`. Currently supports only blake2b-32.
+#[derive(Debug, Encode, Decode, Serialize, Deserialize, Deref, DerefMut, Display)]
+#[display(fmt = "{}", _0)]
+pub struct HashOf<T>(
+    #[deref]
+    #[deref_mut]
+    Hash,
+    PhantomData<T>,
+);
+
+impl<T> AsRef<[u8]> for HashOf<T> {
+    fn as_ref(&self) -> &[u8] {
+        Hash::as_ref(&self.0)
+    }
+}
+
+impl<T> From<HashOf<T>> for Hash {
+    fn from(HashOf(hash, _): HashOf<T>) -> Self {
+        hash
+    }
+}
+
+impl<T> Clone for HashOf<T> {
+    fn clone(&self) -> Self {
+        Self(self.0, PhantomData)
+    }
+}
+impl<T> Copy for HashOf<T> {}
+
+impl<T> PartialEq for HashOf<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.eq(other)
+    }
+}
+impl<T> Eq for HashOf<T> {}
+
+impl<T> PartialOrd for HashOf<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(&other.0)
+    }
+}
+impl<T> Ord for HashOf<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl<T> hash::Hash for HashOf<T> {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state)
+    }
+}
+
+impl<T> HashOf<T> {
+    /// Unsafe constructor for typed hash
+    pub fn from_hash(hash: Hash) -> Self {
+        Self(hash, PhantomData)
+    }
+
+    /// Transmutes hash to some specific type
+    /// SAFETY:
+    /// Do at your own risk
+    pub fn transmute<F>(self) -> HashOf<F> {
+        HashOf(self.0, PhantomData)
+    }
+}
+
+impl<T: Encode> HashOf<T> {
+    /// Constructor for typed hash
+    pub fn new(value: &T) -> Self {
+        Self(Hash::new(&value.encode()), PhantomData)
+    }
+}
+
+impl<T> IntoSchema for HashOf<T> {
+    fn schema(metamap: &mut iroha_schema::MetaMap) {
+        Hash::schema(metamap)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::restriction)]
+
+    use hex_literal::hex;
+    use ursa::blake2::{
+        digest::{Update, VariableOutput},
+        VarBlake2b,
+    };
+
+    #[test]
+    fn blake2_32b() {
+        let mut hasher = VarBlake2b::new(32).unwrap();
+        hasher.update(hex!("6920616d2064617461"));
+        hasher.finalize_variable(|res| {
+            assert_eq!(
+                res[..],
+                hex!("ba67336efd6a3df3a70eeb757860763036785c182ff4cf587541a0068d09f5b2")[..]
+            );
+        })
+    }
+}

--- a/crypto/src/signature.rs
+++ b/crypto/src/signature.rs
@@ -1,0 +1,492 @@
+use std::{
+    collections::BTreeMap,
+    error::Error as StdError,
+    fmt::{self, Debug, Display, Formatter},
+    marker::PhantomData,
+};
+
+use derive_more::{Deref, DerefMut};
+use eyre::{eyre, Context, Result};
+use iroha_schema::IntoSchema;
+use parity_scale_codec::{Decode, Encode};
+use serde::{Deserialize, Serialize};
+use ursa::{
+    keys::{PrivateKey as UrsaPrivateKey, PublicKey as UrsaPublicKey},
+    signatures::{
+        bls::{normal::Bls as BlsNormal, small::Bls as BlsSmall},
+        ed25519::Ed25519Sha512,
+        secp256k1::EcdsaSecp256k1Sha256,
+        SignatureScheme,
+    },
+};
+
+use super::{Algorithm, KeyPair, PublicKey};
+use crate::HashOf;
+
+/// Represents signature of the data (`Block` or `Transaction` for example).
+#[derive(Clone, Encode, Decode, Serialize, Deserialize, PartialOrd, Ord, IntoSchema)]
+pub struct Signature {
+    /// Public key that is used for verification. Payload is verified by algorithm
+    /// that corresponds with the public key's digest function.
+    pub public_key: PublicKey,
+    /// Actual signature payload is placed here.
+    signature: Vec<u8>,
+}
+
+impl Signature {
+    /// Creates new [`Signature`] by signing payload via [`KeyPair::private_key`].
+    ///
+    /// # Errors
+    /// Fails if decoding digest of key pair fails
+    pub fn new(
+        KeyPair {
+            public_key,
+            private_key,
+        }: KeyPair,
+        payload: &[u8],
+    ) -> Result<Signature> {
+        let private_key = UrsaPrivateKey(private_key.payload);
+        let algorithm: Algorithm = public_key.digest_function.parse()?;
+        let signature = match algorithm {
+            Algorithm::Ed25519 => Ed25519Sha512::new().sign(payload, &private_key),
+            Algorithm::Secp256k1 => EcdsaSecp256k1Sha256::new().sign(payload, &private_key),
+            Algorithm::BlsSmall => BlsSmall::new().sign(payload, &private_key),
+            Algorithm::BlsNormal => BlsNormal::new().sign(payload, &private_key),
+        }
+        .map_err(|e| eyre!("Failed to sign payload: {}", e))?;
+        Ok(Signature {
+            public_key,
+            signature,
+        })
+    }
+
+    /// Verify `message` using signed data and [`KeyPair::public_key`].
+    ///
+    /// # Errors
+    /// Fails if decoding digest of key pair fails or if message didn't pass verification
+    pub fn verify(&self, payload: &[u8]) -> Result<()> {
+        let public_key = UrsaPublicKey(self.public_key.payload.clone());
+        let algorithm: Algorithm = self.public_key.digest_function.parse()?;
+        let result = match algorithm {
+            Algorithm::Ed25519 => {
+                Ed25519Sha512::new().verify(payload, &self.signature, &public_key)
+            }
+            Algorithm::Secp256k1 => {
+                EcdsaSecp256k1Sha256::new().verify(payload, &self.signature, &public_key)
+            }
+            Algorithm::BlsSmall => BlsSmall::new().verify(payload, &self.signature, &public_key),
+            Algorithm::BlsNormal => BlsNormal::new().verify(payload, &self.signature, &public_key),
+        };
+        match result {
+            Ok(true) => Ok(()),
+            _ => Err(eyre!("Signature did not pass verification: {}")),
+        }
+    }
+}
+
+impl PartialEq for Signature {
+    fn eq(&self, other: &Self) -> bool {
+        self.public_key == other.public_key && self.signature.clone() == other.signature.clone()
+    }
+}
+
+impl Eq for Signature {}
+
+impl Debug for Signature {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Signature")
+            .field("public_key", &self.public_key)
+            .field("signature", &hex::encode_upper(self.signature.as_slice()))
+            .finish()
+    }
+}
+
+/// Represents signature of the data (`Block` or `Transaction` for example).
+#[allow(clippy::unsafe_derive_deserialize)]
+#[derive(Debug, Serialize, Deserialize, Deref, DerefMut)]
+#[serde(transparent)]
+pub struct SignatureOf<T>(
+    #[deref]
+    #[deref_mut]
+    Signature,
+    #[serde(skip)] PhantomData<T>,
+);
+
+impl<T> PartialEq for SignatureOf<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.signature.eq(&other.signature)
+    }
+}
+
+impl<T> Eq for SignatureOf<T> {}
+impl<T> PartialOrd for SignatureOf<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.signature.partial_cmp(&other.signature)
+    }
+}
+impl<T> Ord for SignatureOf<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.signature.cmp(&other.signature)
+    }
+}
+
+impl<T> Encode for SignatureOf<T> {
+    fn size_hint(&self) -> usize {
+        Signature::size_hint(&self.0)
+    }
+    fn encode_to<U: parity_scale_codec::Output + ?Sized>(&self, dest: &mut U) {
+        self.0.encode_to(dest)
+    }
+    fn encode(&self) -> Vec<u8> {
+        self.0.encode()
+    }
+    fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
+        self.0.using_encoded(f)
+    }
+    fn encoded_size(&self) -> usize {
+        self.0.encoded_size()
+    }
+}
+
+impl<T> Decode for SignatureOf<T> {
+    fn decode<I: parity_scale_codec::Input>(
+        input: &mut I,
+    ) -> Result<Self, parity_scale_codec::Error> {
+        Ok(Self(Signature::decode(input)?, PhantomData))
+    }
+    fn skip<I: parity_scale_codec::Input>(input: &mut I) -> Result<(), parity_scale_codec::Error> {
+        Signature::skip(input)
+    }
+    fn encoded_fixed_size() -> Option<usize> {
+        Signature::encoded_fixed_size()
+    }
+}
+
+impl<T> SignatureOf<T> {
+    /// Verifies signature for this hash
+    /// # Errors
+    /// Fails if verification fails
+    pub fn verify_hash(&self, hash: &HashOf<T>) -> Result<(), SignatureVerificationFail<T>> {
+        self.0
+            .verify(hash.as_ref())
+            .map_err(|err| SignatureVerificationFail {
+                signature: Box::new(self.clone()),
+                reason: err.to_string(),
+            })
+    }
+
+    /// Transmutes signature to some specific type
+    /// SAFETY:
+    /// Do at your own risk
+    pub fn transmute<F>(self) -> SignatureOf<F> {
+        SignatureOf(self.0, PhantomData)
+    }
+
+    /// Transmutes signature to some specific type
+    /// SAFETY:
+    /// Do at your own risk
+    pub fn transmute_ref<F>(&self) -> &SignatureOf<F> {
+        #[allow(unsafe_code, trivial_casts)]
+        unsafe {
+            &*((self as *const Self).cast::<SignatureOf<F>>())
+        }
+    }
+
+    /// Creates new [`SignatureOf`] by signing value via [`KeyPair::private_key`].
+    /// # Errors
+    /// Fails if decoding digest of key pair fails
+    pub fn from_hash(key_pair: KeyPair, hash: &HashOf<T>) -> Result<Self> {
+        Ok(Self(Signature::new(key_pair, hash.as_ref())?, PhantomData))
+    }
+}
+
+impl<T: Encode> SignatureOf<T> {
+    /// Creates new [`SignatureOf`] by signing value via [`KeyPair::private_key`].
+    /// # Errors
+    /// Fails if decoding digest of key pair fails
+    pub fn new(key_pair: KeyPair, value: &T) -> Result<Self> {
+        Self::from_hash(key_pair, &HashOf::new(value))
+    }
+
+    /// Verifies signature for this item
+    /// # Errors
+    /// Fails if verification fails
+    pub fn verify(&self, value: &T) -> Result<(), SignatureVerificationFail<T>> {
+        self.verify_hash(&HashOf::new(value))
+    }
+}
+
+impl<T> Clone for SignatureOf<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), PhantomData)
+    }
+}
+
+impl<T> IntoSchema for SignatureOf<T> {
+    fn schema(metamap: &mut iroha_schema::MetaMap) {
+        Signature::schema(metamap)
+    }
+}
+
+/// Container for multiple signatures.
+#[allow(clippy::unsafe_derive_deserialize)]
+#[derive(Debug, Encode, PartialEq, Eq, Serialize, Deserialize, IntoSchema)]
+#[serde(transparent)]
+pub struct SignaturesOf<T> {
+    signatures: BTreeMap<PublicKey, SignatureOf<T>>,
+}
+
+impl<T> Clone for SignaturesOf<T> {
+    fn clone(&self) -> Self {
+        let signatures = self.signatures.clone();
+        Self { signatures }
+    }
+}
+
+impl<T> IntoIterator for SignaturesOf<T> {
+    type Item = SignatureOf<T>;
+    type IntoIter = std::collections::btree_map::IntoValues<PublicKey, Self::Item>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.signatures.into_values()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a SignaturesOf<T> {
+    type Item = &'a SignatureOf<T>;
+    type IntoIter = std::collections::btree_map::Values<'a, PublicKey, SignatureOf<T>>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.signatures.values()
+    }
+}
+
+// SAFETY: As this container should always have at least 1 signature
+#[allow(clippy::len_without_is_empty)]
+impl<T> SignaturesOf<T> {
+    /// Transmutes signature generic type
+    /// SAFETY: Check complience of hashes of this types
+    pub fn transmute<F>(self) -> SignaturesOf<F> {
+        #[allow(unsafe_code)]
+        let signatures = unsafe { std::mem::transmute(self.signatures) };
+        SignaturesOf { signatures }
+    }
+
+    /// Builds container using single signature
+    pub fn from_signature(sign: SignatureOf<T>) -> Self {
+        let mut me = Self {
+            signatures: BTreeMap::new(),
+        };
+        me.add(sign);
+        me
+    }
+
+    /// Constructs from iterator.
+    ///
+    /// SAFETY: Doesn't check number of signatures (should be >= 1) and signatures themselves
+    pub fn from_iter_unchecked(iter: impl IntoIterator<Item = SignatureOf<T>>) -> Self
+    where
+        T: Send + Sync + 'static,
+    {
+        let signatures = iter
+            .into_iter()
+            .map(|sign| (sign.public_key.clone(), sign))
+            .collect::<BTreeMap<_, _>>();
+        Self { signatures }
+    }
+
+    /// Merges 2 signature collections
+    pub fn merge(&mut self, mut other: Self) {
+        self.signatures.append(&mut other.signatures)
+    }
+
+    /// Adds multiple signatures and replaces the duplicates.
+    pub fn append(&mut self, signatures: &[SignatureOf<T>]) {
+        for signature in signatures.iter().cloned() {
+            self.add(signature.clone());
+        }
+    }
+
+    /// Adds a signature. If the signature with this key was present, replaces it.
+    pub fn add(&mut self, signature: SignatureOf<T>) {
+        self.signatures
+            .insert(signature.public_key.clone(), signature);
+    }
+
+    /// Whether signatures contain a signature with the specified `public_key`
+    pub fn contains(&self, public_key: &PublicKey) -> bool {
+        self.signatures.contains_key(public_key)
+    }
+
+    /// Returns signatures that have passed verification.
+    pub fn verified_by_hash(
+        &'_ self,
+        hash: HashOf<T>,
+    ) -> impl Iterator<Item = &'_ SignatureOf<T>> + '_ {
+        self.signatures
+            .values()
+            .filter(move |sign| sign.verify_hash(&hash).is_ok())
+    }
+
+    /// Returns all signatures.
+    pub fn values(&self) -> Vec<SignatureOf<T>> {
+        self.signatures.values().cloned().collect()
+    }
+
+    /// Number of signatures.
+    pub fn len(&self) -> usize {
+        self.signatures.len()
+    }
+}
+
+impl<T: Encode> SignaturesOf<T> {
+    /// Creates new signatures container.
+    /// # Errors
+    /// Might fail in signature creation
+    pub fn new(key_pair: KeyPair, value: &T) -> Result<Self> {
+        SignatureOf::new(key_pair, value).map(Self::from_signature)
+    }
+
+    /// Constructs from iterator and also validates signatures
+    /// # Errors
+    /// Might fail in validation of signatures
+    pub fn from_iter(value: &T, iter: impl IntoIterator<Item = SignatureOf<T>>) -> Result<Self>
+    where
+        T: Send + Sync + 'static,
+    {
+        let signatures = iter
+            .into_iter()
+            .map(|sign| (sign.public_key.clone(), sign))
+            .collect::<BTreeMap<_, _>>();
+        if signatures.is_empty() {
+            return Err(eyre!("Please supply at least one signature"));
+        }
+
+        let hash = HashOf::new(value);
+        signatures
+            .values()
+            .try_for_each(|sign| sign.verify_hash(&hash))
+            .wrap_err("Failed to verify signatures")?;
+        Ok(Self { signatures })
+    }
+
+    /// Verifies all signatures
+    /// # Errors
+    /// Fails if validation of any signature fails
+    pub fn verify(&self, item: &T) -> Result<(), SignatureVerificationFail<T>> {
+        let hash = HashOf::new(item);
+        self.signatures
+            .values()
+            .try_for_each(|sign| sign.verify_hash(&hash))
+    }
+
+    /// Returns signatures that have passed verification.
+    pub fn verified(&'_ self, value: &T) -> impl Iterator<Item = &'_ SignatureOf<T>> + '_ {
+        let payload = HashOf::new(value);
+        self.verified_by_hash(payload)
+    }
+}
+
+impl<T: Encode> Decode for SignaturesOf<T> {
+    fn decode<I: parity_scale_codec::Input>(
+        input: &mut I,
+    ) -> Result<Self, parity_scale_codec::Error> {
+        Ok(Self {
+            signatures: BTreeMap::decode(input)?,
+        })
+    }
+    fn skip<I: parity_scale_codec::Input>(input: &mut I) -> Result<(), parity_scale_codec::Error> {
+        BTreeMap::<PublicKey, SignatureOf<T>>::skip(input)
+    }
+    fn encoded_fixed_size() -> Option<usize> {
+        BTreeMap::<PublicKey, SignatureOf<T>>::encoded_fixed_size()
+    }
+}
+
+/// Verification failed of some signature due to following reason
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Decode, Encode, IntoSchema)]
+pub struct SignatureVerificationFail<T> {
+    /// Signature which verification has failed
+    pub signature: Box<SignatureOf<T>>,
+    /// Error which happened during verification
+    pub reason: String,
+}
+
+impl<T> Debug for SignatureVerificationFail<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SignatureVerificationFail")
+            .field("signature", &self.signature.0)
+            .field("reason", &self.reason)
+            .finish()
+    }
+}
+
+impl<T> Display for SignatureVerificationFail<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Failed to verify signatures because of signature {}: {}",
+            self.signature.public_key, self.reason,
+        )
+    }
+}
+
+impl<T> StdError for SignatureVerificationFail<T> {}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::restriction)]
+
+    use super::*;
+    use crate::KeyGenConfiguration;
+
+    #[test]
+    fn create_signature_ed25519() {
+        let key_pair = KeyPair::generate_with_configuration(
+            KeyGenConfiguration::default().with_algorithm(Algorithm::Ed25519),
+        )
+        .expect("Failed to generate key pair.");
+        let message = b"Test message to sign.";
+        let signature =
+            Signature::new(key_pair.clone(), message).expect("Failed to create signature.");
+        assert_eq!(signature.public_key, key_pair.public_key);
+        assert!(signature.verify(message).is_ok())
+    }
+
+    #[test]
+    fn create_signature_secp256k1() {
+        let key_pair = KeyPair::generate_with_configuration(
+            KeyGenConfiguration::default().with_algorithm(Algorithm::Secp256k1),
+        )
+        .expect("Failed to generate key pair.");
+        let message = b"Test message to sign.";
+        let signature =
+            Signature::new(key_pair.clone(), message).expect("Failed to create signature.");
+        assert_eq!(signature.public_key, key_pair.public_key);
+        assert!(signature.verify(message).is_ok())
+    }
+
+    #[test]
+    fn create_signature_bls_normal() {
+        let key_pair = KeyPair::generate_with_configuration(
+            KeyGenConfiguration::default().with_algorithm(Algorithm::BlsNormal),
+        )
+        .expect("Failed to generate key pair.");
+        let message = b"Test message to sign.";
+        let signature =
+            Signature::new(key_pair.clone(), message).expect("Failed to create signature.");
+        assert_eq!(signature.public_key, key_pair.public_key);
+        assert!(signature.verify(message).is_ok())
+    }
+
+    #[test]
+    fn create_signature_bls_small() {
+        let key_pair = KeyPair::generate_with_configuration(
+            KeyGenConfiguration::default().with_algorithm(Algorithm::BlsSmall),
+        )
+        .expect("Failed to generate key pair.");
+        let message = b"Test message to sign.";
+        let signature =
+            Signature::new(key_pair.clone(), message).expect("Failed to create signature.");
+        assert_eq!(signature.public_key, key_pair.public_key);
+        assert!(signature.verify(message).is_ok())
+    }
+}

--- a/dsl/Cargo.toml
+++ b/dsl/Cargo.toml
@@ -22,6 +22,7 @@ iroha_data_model = { path = "../data_model" }
 [dev-dependencies]
 iroha_core = { path = "../core" }
 iroha_client = { version = "=0.1.0", path = "../client" }
+
 test_network = { path = "../core/test_network" }
 port_check = "0.1.5"
 tempfile = "3"

--- a/dsl/tests/dsl.rs
+++ b/dsl/tests/dsl.rs
@@ -130,7 +130,7 @@ fn find_rate_and_make_exchange_isi_should_succeed() {
         .expect("Failed to load configuration.");
     configuration.torii_api_url = "http://".to_owned() + &peer.api_address;
     let mut iroha_client = Client::new(&configuration);
-    let _ = iroha_client
+    iroha_client
         .submit_all(vec![
             RegisterBox::new(IdentifiableBox::Domain(Domain::new("exchange").into())).into(),
             RegisterBox::new(IdentifiableBox::Domain(Domain::new("company").into())).into(),

--- a/lints.toml
+++ b/lints.toml
@@ -16,6 +16,7 @@ deny = [
     'rust_2018_idioms',
     'trivial_casts',
     'trivial_numeric_casts',
+    'unconditional_recursion',
     'unsafe_code',
     'unused',
     'unused_import_braces',

--- a/macro/derive/tests/from_variant/02-double-from.stderr
+++ b/macro/derive/tests/from_variant/02-double-from.stderr
@@ -1,12 +1,12 @@
 error[E0119]: conflicting implementations of trait `std::convert::From<Variant1>` for type `Enum`
-  --> $DIR/01-big-enum.rs:11:10
+  --> tests/from_variant/01-big-enum.rs:11:10
    |
 11 | #[derive(iroha_derive::FromVariant)]
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Enum`
    |
-  ::: $WORKSPACE/macro/derive/tests/from_variant/02-double-from.rs
+  ::: tests/from_variant/02-double-from.rs:3:1
    |
-   | impl std::convert::From<Variant1> for Enum {
+3  | impl std::convert::From<Variant1> for Enum {
    | ------------------------------------------ first implementation here
    |
    = note: this error originates in the derive macro `iroha_derive::FromVariant` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/macro/derive/tests/from_variant/04-container-from.stderr
+++ b/macro/derive/tests/from_variant/04-container-from.stderr
@@ -1,12 +1,12 @@
 error[E0119]: conflicting implementations of trait `std::convert::From<Variant1>` for type `Enum`
-  --> $DIR/03-container-enums.rs:16:10
+  --> tests/from_variant/03-container-enums.rs:16:10
    |
 16 | #[derive(iroha_derive::FromVariant)]
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Enum`
    |
-  ::: $WORKSPACE/macro/derive/tests/from_variant/04-container-from.rs
+  ::: tests/from_variant/04-container-from.rs:3:1
    |
-   | impl std::convert::From<Variant1> for Enum {
+3  | impl std::convert::From<Variant1> for Enum {
    | ------------------------------------------ first implementation here
    |
    = note: this error originates in the derive macro `iroha_derive::FromVariant` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/schema/derive/src/lib.rs
+++ b/schema/derive/src/lib.rs
@@ -91,6 +91,15 @@ fn generics(generics: &Generics) -> (TokenStream2, Vec<TokenStream2>, TokenStrea
         ..
     } = generics;
     let ident_params = params.iter().map(generic_ident).collect::<Vec<_>>();
+
+    let where_clause = match where_clause {
+        Some(where_clause) => quote! {
+            #where_clause
+            #(#ident_params : iroha_schema::IntoSchema,)*
+        },
+        None => quote! { where #(#ident_params : iroha_schema::IntoSchema,)* },
+    };
+
     if params.is_empty() {
         (quote! {}, vec![], quote! {})
     } else {

--- a/schema/tests/struct_with_generic_bounds.rs
+++ b/schema/tests/struct_with_generic_bounds.rs
@@ -1,5 +1,5 @@
 #[derive(iroha_schema::IntoSchema)]
-struct Foo<V: iroha_schema::IntoSchema + Sized> {
+struct Foo<V> {
     _value: Option<V>,
 }
 


### PR DESCRIPTION
### Description of the Change

This commit introduces typed hashes and signatures. It will allow us to typecheck and differ things like hash of transaction and hash of block.

### Issue

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
