### PR TITLE
Add handler for getting specific block hash

### DIFF
--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -231,14 +231,16 @@ impl ChainedBlock {
             }
         }
         let mut header = self.header;
-        header.transactions_merkle_root_hash =
-            MerkleTree::build(transactions.iter().map(VersionedValidTransaction::hash)).root_hash();
-        header.rejected_transactions_merkle_root_hash = MerkleTree::build(
-            rejected_transactions
-                .iter()
-                .map(VersionedRejectedTransaction::hash),
-        )
-        .root_hash();
+        header.transactions_merkle_root_hash = transactions
+            .iter()
+            .map(VersionedValidTransaction::hash)
+            .collect::<MerkleTree>()
+            .root_hash();
+        header.rejected_transactions_merkle_root_hash = rejected_transactions
+            .iter()
+            .map(VersionedRejectedTransaction::hash)
+            .collect::<MerkleTree>()
+            .root_hash();
         ValidBlock {
             header,
             rejected_transactions,

--- a/core/test_network/tests/sumeragi_with_mock.rs
+++ b/core/test_network/tests/sumeragi_with_mock.rs
@@ -72,7 +72,10 @@ pub mod utils {
     }
 
     pub mod kura {
-        use iroha_core::{kura::Mode, sumeragi};
+        use iroha_core::{
+            kura::{GetBlockHash, Mode},
+            sumeragi,
+        };
 
         use super::*;
 
@@ -118,6 +121,14 @@ pub mod utils {
                 self.wsv.apply(block).await;
                 self.broker.issue_send(UpdateNetworkTopology).await;
                 self.broker.issue_send(ContinueSync).await;
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl<W: WorldTrait> Handler<GetBlockHash> for CountStored<W> {
+            type Result = Option<Hash>;
+            async fn handle(&mut self, _: GetBlockHash) -> Self::Result {
+                panic!("Shouldn't be called here!")
             }
         }
 

--- a/permissions_validators/src/lib.rs
+++ b/permissions_validators/src/lib.rs
@@ -1317,7 +1317,8 @@ pub mod public_blockchain {
             }
         }
 
-        /// Allows setting user's assets key value map from a different account if the corresponding user granted this permission token.
+        /// Allows setting user's assets key value map from a different account
+        /// if the corresponding user granted this permission token.
         #[derive(Debug, Clone, Copy)]
         pub struct SetGrantedByAssetOwner;
 


### PR DESCRIPTION
Signed-off-by: i1i1 <vanyarybin1@live.ru>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Adds a way to query kura and get hash of specific block.

### Issue

There was no way of getting genesis block hash.

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

This solution will be useful in future for querying various blocks' hashes

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
