### PR TITLE
Ensure that unstable network tests pass for valid code

### DIFF
--- a/client/tests/tests/unstable_network.rs
+++ b/client/tests/tests/unstable_network.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::restriction)]
 
-use std::thread;
+use std::{thread, time::Duration};
 
 use iroha_client::client;
 use iroha_core::config::Configuration;
@@ -12,18 +12,40 @@ const MAXIMUM_TRANSACTIONS_IN_BLOCK: u32 = 1;
 
 #[test]
 fn unstable_network_4_peers_1_fault() {
-    unstable_network(4, 1, 20, 50);
+    let n_peers = 4;
+    let n_transactions = 20;
+    // Given that the topology will resolve view changes by shift for `n_peers` consequent times
+    // and having only 1 faulty peer guarantees us that at maximum in `n_peers` tries the block will be committed.
+    // So for the worst case scenario for `n_transactions` given 1 transaction per block
+    // the network will commit all of them in `n_peers * n_transactions` tries.
+    let polling_max_attempts = n_peers * n_transactions;
+    unstable_network(
+        n_peers,
+        1,
+        n_transactions as usize,
+        polling_max_attempts,
+        Configuration::pipeline_time(),
+    );
 }
 
 #[test]
 fn unstable_network_7_peers_1_fault() {
-    unstable_network(7, 1, 20, 50);
+    let n_peers = 7;
+    let n_transactions = 20;
+    let polling_max_attempts = n_peers * n_transactions;
+    unstable_network(
+        n_peers,
+        1,
+        n_transactions as usize,
+        polling_max_attempts,
+        Configuration::pipeline_time(),
+    );
 }
 
 #[test]
 #[ignore = "This test does not guarantee to have positive outcome given a fixed time."]
 fn unstable_network_7_peers_2_faults() {
-    unstable_network(7, 2, 5, 100);
+    unstable_network(7, 2, 5, 100, Configuration::pipeline_time());
 }
 
 fn unstable_network(
@@ -31,15 +53,17 @@ fn unstable_network(
     n_offline_peers: u32,
     n_transactions: usize,
     polling_max_attempts: u32,
+    polling_period: Duration,
 ) {
     drop(iroha_logger::install_panic_hook());
     let rt = Runtime::test();
     // Given
     let (_network, mut iroha_client) =
-        rt.block_on(<Network>::start_test_with_offline_and_set_max_faults(
+        rt.block_on(<Network>::start_test_with_offline_and_set_n_shifts(
             n_peers,
             MAXIMUM_TRANSACTIONS_IN_BLOCK,
             n_offline_peers,
+            u64::from(n_peers),
         ));
 
     let pipeline_time = Configuration::pipeline_time();
@@ -67,12 +91,12 @@ fn unstable_network(
         thread::sleep(pipeline_time);
     }
 
-    thread::sleep(pipeline_time * n_peers);
+    thread::sleep(pipeline_time);
 
     //Then
     iroha_client.poll_request_with_period(
         client::asset::by_account_id(account_id),
-        Configuration::pipeline_time(),
+        polling_period,
         polling_max_attempts,
         |result| {
             result.iter().any(|asset| {

--- a/core/src/sumeragi/mod.rs
+++ b/core/src/sumeragi/mod.rs
@@ -1614,7 +1614,7 @@ pub mod config {
             (self.trusted_peers.peers.len() as u32 - 1) / 3
         }
 
-        /// Time estimation from receiving a transaction to storing it in a block on all peers.
+        /// Time estimation from receiving a transaction to storing it in a block on all peers for the "sunny day" scenario.
         pub const fn pipeline_time_ms(&self) -> u64 {
             self.tx_receipt_time_ms + self.block_time_ms + self.commit_time_ms
         }

--- a/core/test_network/src/lib.rs
+++ b/core/test_network/src/lib.rs
@@ -170,15 +170,19 @@ where
 
     /// Starts network with peers with default configuration and specified options.
     /// Returns its info and client for connecting to it.
-    pub async fn start_test_with_offline_and_set_max_faults(
+    pub async fn start_test_with_offline_and_set_n_shifts(
         n_peers: u32,
         max_txs_in_block: u32,
         offline_peers: u32,
+        n_shifts: u64,
     ) -> (Self, Client) {
         let mut configuration = Configuration::test();
         configuration
             .queue_configuration
             .maximum_transactions_in_block = max_txs_in_block;
+        configuration
+            .sumeragi_configuration
+            .n_topology_shifts_before_reshuffle = n_shifts;
         let network = Network::new_with_offline_peers(Some(configuration), n_peers, offline_peers)
             .await
             .expect("Failed to init peers");
@@ -193,10 +197,11 @@ where
         maximum_transactions_in_block: u32,
         offline_peers: u32,
     ) -> (Self, Client) {
-        Self::start_test_with_offline_and_set_max_faults(
+        Self::start_test_with_offline_and_set_n_shifts(
             n_peers,
             maximum_transactions_in_block,
             offline_peers,
+            SumeragiConfiguration::default().n_topology_shifts_before_reshuffle,
         )
         .await
     }


### PR DESCRIPTION
Signed-off-by: Egor Ivkov <e.o.ivkov@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
Ensure that unstable network tests pass for valid code. Previously unstable network tests could fail due to random reshuffling of topology even for the valid code.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->


<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits
Tests should indicate code correctness and for correct code should not fail randomly.
<!-- What benefits will be realized by the code change? -->
