### PR TITLE
Iroha2 CI improvements

### DIFF
--- a/.github/workflows/iroha2-add-label.yml
+++ b/.github/workflows/iroha2-add-label.yml
@@ -3,6 +3,7 @@ name: Add Iroha2 label
 on:
   pull_request_target:
     branches: [iroha2-dev, iroha2]
+    types: [opened]
 
 jobs:
   add_label:

--- a/.github/workflows/iroha2-dev-pr-heavy.yml
+++ b/.github/workflows/iroha2-dev-pr-heavy.yml
@@ -1,0 +1,87 @@
+name: I2::Dev::Tests (Heavy)
+
+on:
+  pull_request:
+    branches: [iroha2-dev]
+    paths:
+      - '**.rs'
+      - '**.json'
+      - '**.toml'
+      - '**.yml'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test-docker:
+    #runs-on: [ self-hosted, Linux ] #ubuntu-latest
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+              ~/.cargo
+              target/
+          key: iroha2-rust-docker-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+              iroha2-rust-docker-
+
+      - name: Install latest rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.55
+      - name: Install dependencies
+        if: ${{ false }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            ca-certificates \
+            clang \
+            llvm-dev
+      - name: Build Client CLI
+        run: cargo build
+        working-directory: client_cli
+      - name: Build and push Iroha Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: false
+          tags: hyperledger/iroha2:dev
+
+      - name: Setup docker test environment
+        run: ./scripts/setup_docker_test_env.sh
+      - name: Docker compose genesis test
+        run: bash -c './scripts/test_genesis_docker_compose.sh || ( docker-compose logs; false )'
+      - name: Docker compose test
+        run: bash -c './scripts/test_docker_compose.sh || ( docker-compose logs; false )'
+      - name: Cleanup docker test environment
+        run: ./scripts/cleanup_docker_test_env.sh
+
+  bench:
+    runs-on: [self-hosted, Linux]
+    container: rust:1.55-buster
+    if: ${{ false }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+              ${{ env.CARGO_HOME }}
+              target/
+          key: iroha2-rust-bench-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+              iroha2-rust-bench-
+
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential \
+            ca-certificates \
+            clang \
+            llvm-dev
+      - name: Run benchmarks
+        run: cargo bench --workspace --verbose

--- a/.github/workflows/iroha2-dev-pr-static.yml
+++ b/.github/workflows/iroha2-dev-pr-static.yml
@@ -1,0 +1,50 @@
+name: I2::Dev::Static Analysis
+
+on:
+  pull_request:
+    branches: [iroha2-dev]
+
+
+jobs:
+  check:
+    runs-on: [self-hosted, Linux] #ubuntu-latest
+    container: rust:1.55-buster
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+              ${{ env.CARGO_HOME }}
+              target/
+          key: iroha2-rust-check-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+              iroha2-rust-check
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential \
+            ca-certificates \
+            clang \
+            llvm-dev
+      - name: Install clippy
+        run: rustup component add clippy
+      - name: Print all info
+        run: |
+          cargo version
+          lscpu
+          free -h
+      - name: Install cargo-lints
+        run: cargo install cargo-lints
+      - name: Install nightly for rustfmt
+        run: rustup install --profile default nightly-2021-03-24
+      - name: Format check
+        run: cargo +nightly-2021-03-24 fmt --all -- --check
+      - name: Static analysis without features
+        run: cargo lints clippy --workspace --benches --tests
+      - name: Static analysis with all features enabled
+        run: cargo lints clippy --workspace --benches --tests --all-features
+      - name: Documentation check
+        run: |
+          cargo doc --no-deps
+          ./scripts/check_docs.sh

--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -1,57 +1,18 @@
-name: Iroha 2 dev branch pull requests workflow
+name: I2::Dev::Tests
 
 on:
   pull_request:
     branches: [iroha2-dev]
+    paths:
+      - '**.rs'
+      - '**.json'
+      - '**.toml'
+      - '**.yml'
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  check:
-    runs-on: [self-hosted, Linux] #ubuntu-latest
-    container: rust:1.55-buster
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-              ${{ env.CARGO_HOME }}
-              target/
-          key: iroha2-rust-check-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-              iroha2-rust-check
-
-      - name: Install dependencies
-        run: |
-          apt-get update
-          apt-get install -y --no-install-recommends \
-            build-essential \
-            ca-certificates \
-            clang \
-            llvm-dev
-      - name: Install clippy
-        run: rustup component add clippy
-      - name: Print all info
-        run: |
-          cargo version
-          lscpu
-          free -h
-      - name: Install cargo-lints
-        run: cargo install cargo-lints
-      - name: Install nightly for rustfmt
-        run: rustup install --profile default nightly-2021-03-24
-      - name: Format check
-        run: cargo +nightly-2021-03-24 fmt --all -- --check
-      - name: Static analysis without features
-        run: cargo lints clippy --workspace --benches --tests
-      - name: Static analysis with all features enabled
-        run: cargo lints clippy --workspace --benches --tests --all-features
-      - name: Documentation check
-        run: |
-          cargo doc --no-deps
-          ./scripts/check_docs.sh
-
   test:
     runs-on: [self-hosted, Linux] #ubuntu-latest
     container: rust:1.55-buster
@@ -131,111 +92,6 @@ jobs:
         run: cargo test --features deadlock_detection
         working-directory: actor
 
-  test-docker:
-    #runs-on: [ self-hosted, Linux ] #ubuntu-latest
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-              ~/.cargo
-              target/
-          key: iroha2-rust-docker-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-              iroha2-rust-docker-
-
-      - name: Install latest rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.55
-      - name: Install dependencies
-        if: ${{ false }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential \
-            ca-certificates \
-            clang \
-            llvm-dev
-      - name: Build Client CLI
-        run: cargo build
-        working-directory: client_cli
-      - name: Build and push Iroha Docker image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: false
-          tags: hyperledger/iroha2:dev
-
-      - name: Setup docker test environment
-        run: ./scripts/setup_docker_test_env.sh
-      - name: Docker compose genesis test
-        run: bash -c './scripts/test_genesis_docker_compose.sh || ( docker-compose logs; false )'
-      - name: Docker compose test
-        run: bash -c './scripts/test_docker_compose.sh || ( docker-compose logs; false )'
-      - name: Cleanup docker test environment
-        run: ./scripts/cleanup_docker_test_env.sh
-
-
-  print-telemetry:
-    runs-on: [self-hosted, Linux] #ubuntu-latest
-    container: rust:1.55-buster
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-              ${{ env.CARGO_HOME }}
-              target/
-          key: iroha2-rust-telemetry-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-              iroha2-rust-telemetry-
-
-      - name: Run debug tests and save telemetry
-        env:
-          TELEMETRY_FILE: ../target/telemetry/debug.json.lz4
-        run: |
-          mkdir -p target/telemetry
-          cargo test -p iroha_client --all-features -- unstable_network || true
-      - name: Run release tests and save telemetry
-        env:
-          TELEMETRY_FILE: ../target/telemetry/release.json.lz4
-        run: cargo test -p iroha_client --all-features --release -- unstable_network || true
-      - name: Install script dependencies
-        run: |
-          apt-get update
-          apt-get install -y --no-install-recommends lz4 jq
-      - name: Print debug telemetry info
-        run: ./scripts/analyze_telemetry.sh target/telemetry/debug.json.lz4 >target/telemetry/debug.md
-      - name: Print release telemetry info
-        run: ./scripts/analyze_telemetry.sh target/telemetry/release.json.lz4 >target/telemetry/release.md
-      - name: Print debug telemetry info
-        run: |
-          echo '## Debug build'
-          cat target/telemetry/debug.md
-      - name: Print release telemetry info
-        run: |
-          echo '## Release build'
-          cat target/telemetry/release.md
-      - name: Create telemetry comment
-        uses: actions-ecosystem/action-create-comment@v1
-        if: ${{ false }}
-        with:
-          body: |
-            \# Telemetry info
-            \## Debug build
-            ${{ steps.debug-telemetry.outputs.body }}
-            \## Release build
-            ${{ steps.release-telemetry.outputs.body }}
-          github_token: ${{ secrets.github_token }}
-      - name: Archive telemetry
-        uses: actions/upload-artifact@v2
-        with:
-          name: telemetry
-          path: target/telemetry
-
   test-api:
     runs-on: [self-hosted, Linux] #ubuntu-latest
     if: ${{ false }}
@@ -293,11 +149,12 @@ jobs:
         run: rustup component add llvm-tools-preview
       - name: Cargo build
         run: cargo build
+        if: ${{ false }}
         env:
           RUSTFLAGS: "-Zinstrument-coverage"
           RUSTC_BOOTSTRAP: 1
       - name: Run tests
-        run: cargo test --workspace --no-fail-fast -- --test-threads=1 || true
+        run: cargo test --workspace --no-fail-fast -- --test-threads 1 || true
         env:
           RUSTFLAGS: "-Zinstrument-coverage"
           RUSTC_BOOTSTRAP: 1
@@ -309,28 +166,4 @@ jobs:
         with:
           file: lcov.info
 
-  bench:
-    runs-on: [self-hosted, Linux]
-    container: rust:1.55-buster
-    if: ${{ false }}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-              ${{ env.CARGO_HOME }}
-              target/
-          key: iroha2-rust-bench-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-              iroha2-rust-bench-
 
-      - name: Install dependencies
-        run: |
-          apt-get update
-          apt-get install -y --no-install-recommends \
-            build-essential \
-            ca-certificates \
-            clang \
-            llvm-dev
-      - name: Run benchmarks
-        run: cargo bench --workspace --verbose

--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -39,6 +39,63 @@ jobs:
           name: cargo-crypto-cli-build-release
           path: target/release/iroha_crypto_cli
 
+  print-telemetry:
+    runs-on: [self-hosted, Linux] #ubuntu-latest
+    container: rust:1.55-buster
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+              ${{ env.CARGO_HOME }}
+              target/
+          key: iroha2-rust-telemetry-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+              iroha2-rust-telemetry-
+
+      - name: Run debug tests and save telemetry
+        env:
+          TELEMETRY_FILE: ../target/telemetry/debug.json.lz4
+        run: |
+          mkdir -p target/telemetry
+          cargo test -p iroha_client --all-features -- unstable_network || true
+      - name: Run release tests and save telemetry
+        env:
+          TELEMETRY_FILE: ../target/telemetry/release.json.lz4
+        run: cargo test -p iroha_client --all-features --release -- unstable_network || true
+      - name: Install script dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends lz4 jq
+      - name: Print debug telemetry info
+        run: ./scripts/analyze_telemetry.sh target/telemetry/debug.json.lz4 >target/telemetry/debug.md
+      - name: Print release telemetry info
+        run: ./scripts/analyze_telemetry.sh target/telemetry/release.json.lz4 >target/telemetry/release.md
+      - name: Print debug telemetry info
+        run: |
+          echo '## Debug build'
+          cat target/telemetry/debug.md
+      - name: Print release telemetry info
+        run: |
+          echo '## Release build'
+          cat target/telemetry/release.md
+      - name: Create telemetry comment
+        uses: actions-ecosystem/action-create-comment@v1
+        if: ${{ false }}
+        with:
+          body: |
+            \# Telemetry info
+            \## Debug build
+            ${{ steps.debug-telemetry.outputs.body }}
+            \## Release build
+            ${{ steps.release-telemetry.outputs.body }}
+          github_token: ${{ secrets.github_token }}
+      - name: Archive telemetry
+        uses: actions/upload-artifact@v2
+        with:
+          name: telemetry
+          path: target/telemetry
+
   deploy:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Description of the Change

Refactored the pr-workflows to be more parallelisable and granular. This should help in case a heavy workload needs to be re-run (e.g. it exited with `SIGKILL`). This should also reduce waiting times for longer workloads as more workflows can be run concurrently.

### Issue

#1526 

### Benefits

Shorter CI turnaround. Ability to re-run only the heavy workflows. 

### Possible Drawbacks

None at the moment

### Usage Examples 

Suppose PR #XXXX is blocked by a failing `print-telemetry` job, which exited with SIGKILL. This is likely because of using too much memory and being killed by the server, so instead of pushing, it's better to just re-run the heavy workflow, rather than re-run all the workflows. 

### THIS IS A DRAFT PR. Please do not merge, just comment. 

