### PR TITLE
Fix signatures in schema

### DIFF
--- a/crypto/src/signature.rs
+++ b/crypto/src/signature.rs
@@ -223,6 +223,10 @@ impl<T> Clone for SignatureOf<T> {
 }
 
 impl<T> IntoSchema for SignatureOf<T> {
+    fn type_name() -> String {
+        Signature::type_name()
+    }
+
     fn schema(metamap: &mut iroha_schema::MetaMap) {
         Signature::schema(metamap)
     }


### PR DESCRIPTION
Closes #1550 

### Description of the Change

This pr substitutes `SIgnatureOf` in the schema to just `Signature`, as they practically are the same.

### Issue

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
