### PR TITLE
Update rust version to 1.56.0

### DIFF
--- a/.github/workflows/iroha2-dev-pr-heavy.yml
+++ b/.github/workflows/iroha2-dev-pr-heavy.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   bench:
     runs-on: [self-hosted, Linux]
-    container: rust:1.55-buster
+    container: rust:1.56-buster
     if: ${{ false }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/iroha2-dev-pr-static.yml
+++ b/.github/workflows/iroha2-dev-pr-static.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   check:
     runs-on: [self-hosted, Linux] #ubuntu-latest
-    container: rust:1.55-buster
+    container: rust:1.56-buster
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -37,9 +37,9 @@ jobs:
       - name: Install cargo-lints
         run: cargo install cargo-lints
       - name: Install nightly for rustfmt
-        run: rustup install --profile default nightly-2021-03-24
+        run: rustup install --profile default nightly-2021-10-22
       - name: Format check
-        run: cargo +nightly-2021-03-24 fmt --all -- --check
+        run: cargo +nightly-2021-10-22 fmt --all -- --check
       - name: Static analysis without features
         run: cargo lints clippy --workspace --benches --tests
       - name: Static analysis with all features enabled

--- a/.github/workflows/iroha2-dev-pr-unstable.yml
+++ b/.github/workflows/iroha2-dev-pr-unstable.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   test:
     runs-on: [self-hosted, Linux] #ubuntu-latest
-    container: rust:1.55-buster
+    container: rust:1.56-buster
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   test:
     runs-on: [self-hosted, Linux] #ubuntu-latest
-    container: rust:1.55-buster
+    container: rust:1.56-buster
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
@@ -41,7 +41,7 @@ jobs:
 
   test-consensus-with-mock:
     runs-on: [self-hosted, Linux] #ubuntu-latest
-    container: rust:1.55-buster
+    container: rust:1.56-buster
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
@@ -68,7 +68,7 @@ jobs:
 
   test-deadlock-detection:
     runs-on: [self-hosted, Linux] #ubuntu-latest
-    container: rust:1.55-buster
+    container: rust:1.56-buster
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -130,7 +130,7 @@ jobs:
   # 2  Coverage bot can have results from `iroha2-dev` to report accurate coverage changes.
   coverage:
     runs-on: [self-hosted, Linux]
-    container: rust:1.55-buster
+    container: rust:1.56-buster
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2

--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install latest rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.55
+          toolchain: 1.56
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -56,7 +56,7 @@ jobs:
 
   archive-and-publish-schema:
     runs-on: [self-hosted, Linux]
-    container: rust:1.55-buster
+    container: rust:1.56-buster
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
@@ -96,7 +96,7 @@ jobs:
 
   print-telemetry:
     runs-on: [self-hosted, Linux] #ubuntu-latest
-    container: rust:1.55-buster
+    container: rust:1.56-buster
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -206,7 +206,7 @@ jobs:
   # 2  Coverage bot can have results from `iroha2-dev` to report accurate coverage changes.
   coverage:
     runs-on: [self-hosted, Linux]
-    container: rust:1.55-buster
+    container: rust:1.56-buster
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies

--- a/.github/workflows/iroha2-pr.yml
+++ b/.github/workflows/iroha2-pr.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   long-tests:
     runs-on: [self-hosted, Linux] #ubuntu-latest
-    container: rust:1.55-buster
+    container: rust:1.56-buster
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
@@ -39,7 +39,7 @@ jobs:
       - name: Install latest rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.55
+          toolchain: 1.56
       - name: Build Client CLI
         run: cargo build --verbose
         working-directory: client_cli

--- a/.github/workflows/iroha2.yml
+++ b/.github/workflows/iroha2.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   coverage:
     runs-on: [self-hosted, Linux] #ubuntu-latest
-    container: rust:1.55-buster
+    container: rust:1.56-buster
     steps:
       - uses: actions/checkout@v2
       - name: Set nightly toolchain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,9 +204,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.61"
+version = "0.3.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
+checksum = "091bcdf2da9950f96aa522681ce805e6857f6ca8df73833d35736ab2dc78e152"
 dependencies = [
  "addr2line",
  "cc",
@@ -323,15 +323,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.7.1"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9df67f7bf9ef8498769f994239c45613ef0c5899415fb58e9add412d2c1a538"
+checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
 name = "byte-slice-cast"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0796d76a983651b4a0ddda16203032759f2fd9103d9181f7c65c06ee8872e6"
+checksum = "1d30c751592b77c499e7bce34d99d67c2c11bdc0574e9a488ddade14150a4698"
 
 [[package]]
 name = "byte-tools"
@@ -341,9 +341,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byte-unit"
-version = "4.0.12"
+version = "4.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063197e6eb4b775b64160dedde7a0986bb2836cce140e9492e9e96f28e18bcd8"
+checksum = "956ffc5b0ec7d7a6949e3f21fd63ba5af4cffdc2ba1e0b7bf62b481458c4ae7f"
 dependencies = [
  "utf8-width",
 ]
@@ -981,7 +981,6 @@ checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1003,17 +1002,6 @@ name = "futures-core"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -1199,9 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac5956d4e63858efaec57e0d6c1c2f6a41e1487f830314a324ccd7e2223a7ca0"
+checksum = "3bd566f08830dd1fa75b2a5f1d8def8336de7f08b2692a9a71efbe7188aea36f"
 
 [[package]]
 name = "hashbrown"
@@ -1211,18 +1199,18 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "headers"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b7591fb62902706ae8e7aaff416b1b0fa2c0fd0878b46dc13baa3712d8a855"
+checksum = "a4c4eb0471fcb85846d8b0690695ef354f9afb11cb03cac2e1d7c9253351afb0"
 dependencies = [
  "base64",
  "bitflags",
  "bytes",
  "headers-core",
  "http",
+ "httpdate",
  "mime",
  "sha-1",
- "time",
 ]
 
 [[package]]
@@ -1267,6 +1255,12 @@ dependencies = [
  "hex-literal-impl",
  "proc-macro-hack",
 ]
+
+[[package]]
+name = "hex-literal"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e4590e13640f19f249fe3e4eca5113bc4289f2497710378190e7f4bd96f45b"
 
 [[package]]
 name = "hex-literal-impl"
@@ -1528,7 +1522,7 @@ dependencies = [
  "eyre",
  "futures",
  "hex",
- "hex-literal",
+ "hex-literal 0.2.1",
  "iroha_actor",
  "iroha_config",
  "iroha_crypto",
@@ -1541,7 +1535,6 @@ dependencies = [
  "iroha_schema",
  "iroha_telemetry",
  "iroha_version",
- "maplit",
  "once_cell",
  "parity-scale-codec",
  "rand 0.7.3",
@@ -1564,7 +1557,7 @@ dependencies = [
  "derive_more",
  "eyre",
  "hex",
- "hex-literal",
+ "hex-literal 0.3.3",
  "iroha_schema",
  "openssl-sys",
  "parity-scale-codec",
@@ -2061,9 +2054,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.26.2"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2"
+checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
 dependencies = [
  "memchr",
 ]
@@ -2877,9 +2870,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
+checksum = "f2807892cfa58e081aa1f1111391c7a0649d4fa127a4ffbe34bcbfb35a1171a4"
 dependencies = [
  "digest 0.9.0",
  "rand_core 0.6.3",
@@ -3515,9 +3508,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"
-version = "5.1.15"
+version = "5.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "265455aab08c55a1ab13f07c8d5e25c7d46900f4484dd7cbd682e77171f93f3c"
+checksum = "7b62d4fc8fc9c81d139c8106b9f4e583e7c1eb36e320dc28d5c03aab86729495"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/actor/Cargo.toml
+++ b/actor/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iroha_actor"
 version = "0.1.0"
-authors = ["i1i1"]
-edition = "2018"
+authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -15,7 +15,7 @@ async-trait = "0.1"
 once_cell = "1"
 dashmap = "4"
 eyre = "0.6.5"
-futures = "0.3"
+futures = { version = "0.3.17", default-features = false, features = ["std", "async-await"] }
 iroha_actor_derive = { path = "derive" }
 tokio = { version = "1.6.0", features = ["sync", "time", "rt", "io-util", "rt-multi-thread"]}
 iroha_logger = { path = "../logger" }

--- a/actor/derive/Cargo.toml
+++ b/actor/derive/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iroha_actor_derive"
 version = "0.1.0"
-authors = ["i1i1"]
-edition = "2018"
+authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "iroha"
 version = "0.1.0"
 authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
-edition = "2018"
+edition = "2021"
 description = "Iroha is a straightforward distributed ledger technology (DLT), inspired by Japanese Kaizen principle — eliminate excessiveness (muri). Iroha has essential functionality for your asset, information and identity management needs, at the same time being an efficient and trustworthy crash fault-tolerant tool for your enterprise needs."
 readme = "README.md"
 homepage = "https://github.com/hyperledger/iroha/tree/iroha2-dev"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iroha_client"
 version = "0.1.0"
-authors = [ "Nikita Puzankov <humb1t@yandex.ru>", "Egor Ivkov <e.o.ivkov@gmail.com>", "Vladislav Markushin <negigic@gmail.com>", "武宮誠 <takemiya@soramitsu.co.jp>" ]
-edition = "2018"
+authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
+edition = "2021"
 description = "Iroha Client is a Rust Library which encapsulates network related logic and gives users an ability to interact with Iroha Peers like they are non-distributed application."
 readme = "README.md"
 homepage = "https://github.com/hyperledger/iroha/tree/iroha2-dev"
@@ -43,7 +43,7 @@ test_network = { path = "../core/test_network" }
 async-trait = "0.1.31"
 color-eyre = "0.5.11"
 criterion = "0.3"
-futures = "0.3.4"
+futures = { version = "0.3.17", default-features = false, features = ["std", "async-await"] }
 tempfile = "3"
 rand = "0.7.3"
 unique_port = "0.1.0"

--- a/client_cli/Cargo.toml
+++ b/client_cli/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iroha_client_cli"
 version = "0.1.0"
-authors = [ "Nikita Puzankov <humb1t@yandex.ru>", "Egor Ivkov < <e.o.ivkov@gmail.com>", "Vladislav Markushin <negigic@gmail.com>", "武宮誠 <takemiya@soramitsu.co.jp>" ]
-edition = "2018"
+authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
+edition = "2021"
 description = "Iroha CLI Client provides an ability to interact with Iroha Peers Web API without direct network usage. It's a `light` client which only converts Command Line Interface commands into Iroha Web API Network Requests."
 readme = "README.md"
 homepage = "https://github.com/hyperledger/iroha/tree/iroha2-dev"
@@ -21,10 +21,9 @@ iroha_client = { version = "=0.1.0", path = "../client" }
 iroha_data_model = { version = "=0.1.0", path = "../data_model" }
 iroha_crypto = { version = "=0.1.0", path = "../crypto" }
 
-
 color-eyre = "0.5.11"
 structopt = "0.3"
-futures = "0.3.4"
+futures = { version = "0.3.17", default-features = false, features = ["std", "async-await"] }
 dialoguer = "0.8"
 serde_json = "1.0"
 

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iroha_config"
 version = "0.1.0"
-authors = ["i1i1"]
-edition = "2018"
+authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
+edition = "2021"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/config/derive/Cargo.toml
+++ b/config/derive/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iroha_config_derive"
 version = "0.1.0"
-authors = ["i1i1"]
-edition = "2018"
+authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "iroha_core"
 version = "0.1.0"
 authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
-edition = "2018"
+edition = "2021"
 description = "Iroha is a straightforward distributed ledger technology (DLT), inspired by Japanese Kaizen principle — eliminate excessiveness (muri). Iroha has essential functionality for your asset, information and identity management needs, at the same time being an efficient and trustworthy crash fault-tolerant tool for your enterprise needs."
 readme = "README.md"
 homepage = "https://github.com/hyperledger/iroha/tree/iroha2-dev"
@@ -44,7 +44,7 @@ async-stream = "0.3.2"
 chrono = "0.4"
 dashmap = { version = "4.0" }
 eyre = "0.6.5"
-futures = { version = "0.3.4" }
+futures = { version = "0.3.17", default-features = false, features = ["std", "async-await"] }
 parity-scale-codec = { version = "2", features = ["derive"] }
 rand = "0.7.3"
 serde = { version = "1.0", features = ["derive"] }
@@ -63,7 +63,6 @@ tempfile = "3"
 criterion = "0.3"
 hex = "0.4.0"
 unique_port = "0.1.0"
-maplit = "1.0.2"
 byte-unit = "4.0.12"
 once_cell = "1"
 

--- a/core/docs/Cargo.toml
+++ b/core/docs/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iroha_docs"
 version = "0.1.0"
-authors = ["i1i1"]
-edition = "2018"
+authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/core/src/smartcontracts/isi/mod.rs
+++ b/core/src/smartcontracts/isi/mod.rs
@@ -96,8 +96,8 @@ pub struct AssetTypeError {
 }
 
 impl Display for AssetTypeError {
+    #[allow(clippy::use_debug)]
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        #[allow(clippy::use_debug)]
         write!(
             f,
             "Asset type error: expected asset of type {:?}, but got {:?}",

--- a/core/src/sumeragi/view_change.rs
+++ b/core/src/sumeragi/view_change.rs
@@ -268,7 +268,7 @@ mod tests {
         .sign(key_pair_2.clone())?;
         let peer_1 = PeerId::new("127.0.0.1:1001", &key_pair_1.public_key);
         let peer_2 = PeerId::new("127.0.0.1:1002", &key_pair_2.public_key);
-        let peers = maplit::hashset![peer_1, peer_2];
+        let peers = [peer_1, peer_2].into();
         assert!(proof.verify(&peers, 1));
         Ok(())
     }
@@ -285,7 +285,7 @@ mod tests {
         )?;
         let peer_1 = PeerId::new("127.0.0.1:1001", &key_pair_1.public_key);
         let peer_2 = PeerId::new("127.0.0.1:1002", &key_pair_2.public_key);
-        let peers = maplit::hashset![peer_1, peer_2];
+        let peers = [peer_1, peer_2].into();
         assert!(!proof.verify(&peers, 1));
         Ok(())
     }
@@ -304,7 +304,7 @@ mod tests {
         .sign(key_pair_3)?;
         let peer_1 = PeerId::new("127.0.0.1:1001", &key_pair_1.public_key);
         let peer_2 = PeerId::new("127.0.0.1:1002", &key_pair_2.public_key);
-        let peers = maplit::hashset![peer_1, peer_2];
+        let peers = [peer_1, peer_2].into();
         assert!(!proof.verify(&peers, 1));
         Ok(())
     }
@@ -327,7 +327,7 @@ mod tests {
             .sign(key_pair_2.clone())?;
             proof_chain.push(proof);
         }
-        let peers = maplit::hashset![peer_1, peer_2];
+        let peers = [peer_1, peer_2].into();
         assert!(proof_chain.verify_with_state(&peers, 1, &latest_block));
         Ok(())
     }
@@ -355,7 +355,7 @@ mod tests {
             .sign(key_pair_2.clone())?;
             proof_chain.push(proof);
         }
-        let peers = maplit::hashset![peer_1, peer_2];
+        let peers = [peer_1, peer_2].into();
         assert!(!proof_chain.verify_with_state(&peers, 1, &latest_block));
         Ok(())
     }

--- a/core/test_network/Cargo.toml
+++ b/core/test_network/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "test_network"
 version = "0.1.0"
-authors = ["i1i1"]
-edition = "2018"
+authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
@@ -22,7 +22,7 @@ tempfile = "3"
 unique_port = "0.1.0"
 tokio = { version = "1.6.0", features = ["rt", "rt-multi-thread", "macros"]}
 rand = "0.7.3"
-futures = "0.3"
+futures = { version = "0.3.17", default-features = false, features = ["std", "async-await"] }
 
 [dev-dependencies]
 iroha_crypto = { path = "../../crypto" }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iroha_crypto"
 version = "0.1.0"
-authors = ["Egor Ivkov <e.o.ivkov@gmail.com>"]
-edition = "2018"
+authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -19,5 +19,5 @@ serde_json = "1"
 ursa = "=0.3.7"
 
 [dev-dependencies]
-hex-literal = "0.2.1"
+hex-literal = "0.3"
 serde_json = "1.0"

--- a/crypto_cli/Cargo.toml
+++ b/crypto_cli/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iroha_crypto_cli"
 version = "0.1.0"
-authors = ["Nikita Puzankov <humb1t@yandex.ru>", "Egor Ivkov < <e.o.ivkov@gmail.com>", "Vladislav Markushin <negigic@gmail.com>", "武宮誠 <takemiya@soramitsu.co.jp>"]
-edition = "2018"
+authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/data_model/Cargo.toml
+++ b/data_model/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iroha_data_model"
 version = "0.1.0"
-authors = ["Nikita Puzankov <humb1t@yandex.ru>"]
-edition = "2018"
+authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
+edition = "2021"
 description = "Iroha uses a simple data model made up of domains, peers, accounts, assets, signatories, and permissions. This library contains basic data model structures."
 readme = "README.md"
 homepage = "https://github.com/hyperledger/iroha/tree/iroha2-dev"

--- a/data_model/src/lib.rs
+++ b/data_model/src/lib.rs
@@ -636,11 +636,10 @@ pub mod permissions {
 
     impl PermissionToken {
         /// Constructor.
-        pub fn new(name: impl Into<Name>, params: BTreeMap<Name, Value>) -> Self {
-            PermissionToken {
-                name: name.into(),
-                params,
-            }
+        pub fn new(name: impl Into<Name>, params: impl IntoIterator<Item = (Name, Value)>) -> Self {
+            let params = params.into_iter().collect();
+            let name = name.into();
+            Self { name, params }
         }
     }
 

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iroha_futures"
 version = "0.1.0"
-authors = ["i1i1"]
-edition = "2018"
+authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/futures/derive/Cargo.toml
+++ b/futures/derive/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iroha_futures_derive"
 version = "0.1.0"
-authors = ["i1i1"]
-edition = "2018"
+authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
+edition = "2021"
 
 [features]
 default = ["telemetry"]

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iroha_logger"
 version = "0.1.0"
-authors = ["Nikita Puzankov <humb1t@yandex.ru>", "Egor Ivkov <e.o.ivkov@gmail.com>", "Vladislav Markushin <negigic@gmail.com>", "武宮誠 <takemiya@soramitsu.co.jp>"]
-edition = "2018"
+authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
+edition = "2021"
 
 [dependencies]
 chrono = "0.4"

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iroha_macro"
 version = "0.1.0"
-authors = [ "Nikita Puzankov <humb1t@yandex.ru>", "Egor Ivkov < <e.o.ivkov@gmail.com>", "Vladislav Markushin <negigic@gmail.com>", "武宮誠 <takemiya@soramitsu.co.jp>" ]
-edition = "2018"
+authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
+edition = "2021"
 description = "This crate contains macroses and attributes for Iroha projects. iroha_derive contains derive macroses."
 readme = "README.md"
 homepage = "https://github.com/hyperledger/iroha/tree/iroha2-dev"

--- a/macro/derive/Cargo.toml
+++ b/macro/derive/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iroha_derive"
 version = "0.1.0"
-authors = ["Nikita Puzankov <humb1t@yandex.ru>"]
-edition = "2018"
+authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -2,7 +2,7 @@
 name = "iroha_p2p"
 version = "0.1.0"
 authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
-edition = "2018"
+edition = "2021"
 homepage = "https://github.com/hyperledger/iroha/tree/iroha2-dev"
 repository = "https://github.com/hyperledger/iroha/tree/iroha2-dev"
 license = "Apache-2.0"
@@ -23,7 +23,7 @@ eyre = "0.6.5"
 rand = "0.7.3"
 tokio = { version = "1.6.0", features = ["net",  "sync", "time", "io-util"]}
 async-stream = "0.3"
-futures = { version = "0.3" }
+futures = { version = "0.3.17", default-features = false, features = ["std", "async-await"] }
 async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 parity-scale-codec = { version = "2", features = ["derive"] }

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -567,8 +567,8 @@ pub enum State {
 }
 
 impl Display for State {
+    #[allow(clippy::use_debug)]
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        #[allow(clippy::use_debug)]
         write!(f, "{:?}", &self)
     }
 }

--- a/permissions_validators/Cargo.toml
+++ b/permissions_validators/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iroha_permissions_validators"
 version = "0.1.0"
-authors = ["Egor Ivkov <e.o.ivkov@gmail.com>"]
-edition = "2018"
+authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/permissions_validators/src/lib.rs
+++ b/permissions_validators/src/lib.rs
@@ -1895,7 +1895,6 @@ pub mod public_blockchain {
         use std::collections::{BTreeMap, BTreeSet};
 
         use iroha_core::wsv::World;
-        use maplit::{btreemap, btreeset};
 
         use super::*;
 
@@ -1935,9 +1934,10 @@ pub mod public_blockchain {
             let mut bob_account = Account::new(bob_id.clone());
             let _ = bob_account.permission_tokens.insert(PermissionToken::new(
                 transfer::CAN_TRANSFER_USER_ASSETS_TOKEN,
-                btreemap! {
-                    ASSET_ID_TOKEN_PARAM_NAME.to_string() => alice_xor_id.clone().into(),
-                },
+                [(
+                    ASSET_ID_TOKEN_PARAM_NAME.to_string(),
+                    alice_xor_id.clone().into(),
+                )],
             ));
             domain.accounts.insert(bob_id.clone(), bob_account);
             let domains = vec![("test".to_string(), domain)];
@@ -1962,9 +1962,7 @@ pub mod public_blockchain {
                 <Asset as Identifiable>::Id::from_names("xor", "test", "alice", "test");
             let permission_token_to_alice = PermissionToken::new(
                 transfer::CAN_TRANSFER_USER_ASSETS_TOKEN,
-                btreemap! {
-                    ASSET_ID_TOKEN_PARAM_NAME.to_owned() => alice_xor_id.into(),
-                },
+                [(ASSET_ID_TOKEN_PARAM_NAME.to_owned(), alice_xor_id.into())],
             );
             let wsv = WorldStateView::<World>::new(World::new());
             let grant = Instruction::Grant(GrantBox {
@@ -1983,19 +1981,22 @@ pub mod public_blockchain {
             let xor_id = <AssetDefinition as Identifiable>::Id::new("xor", "test");
             let xor_definition = new_xor_definition(&xor_id);
             let wsv = WorldStateView::<World>::new(World::with(
-                btreemap! {
-                    "test".to_string() => Domain {
-                    accounts: BTreeMap::new(),
-                    name: "test".to_string(),
-                    asset_definitions: btreemap! {
-                        xor_id.clone() =>
-                        AssetDefinitionEntry {
-                            definition: xor_definition,
-                            registered_by: alice_id.clone()
-                        }
-                    }.into_iter().collect(),
-                }},
-                btreeset! {},
+                [(
+                    "test".to_owned(),
+                    Domain {
+                        accounts: BTreeMap::new(),
+                        name: "test".to_owned(),
+                        asset_definitions: [(
+                            xor_id.clone(),
+                            AssetDefinitionEntry {
+                                definition: xor_definition,
+                                registered_by: alice_id.clone(),
+                            },
+                        )]
+                        .into(),
+                    },
+                )],
+                [],
             ));
             let unregister =
                 Instruction::Unregister(UnregisterBox::new(IdBox::AssetDefinitionId(xor_id)));
@@ -2017,19 +2018,18 @@ pub mod public_blockchain {
             let mut bob_account = Account::new(bob_id.clone());
             let _ = bob_account.permission_tokens.insert(PermissionToken::new(
                 unregister::CAN_UNREGISTER_ASSET_WITH_DEFINITION,
-                btreemap! {
-                    ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_string() => xor_id.clone().into(),
-                },
+                [(
+                    ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_string(),
+                    xor_id.clone().into(),
+                )],
             ));
             domain.accounts.insert(bob_id.clone(), bob_account);
             domain.asset_definitions.insert(
                 xor_id.clone(),
                 AssetDefinitionEntry::new(xor_definition, alice_id.clone()),
             );
-            let domains = btreemap! {
-                "test".to_owned() => domain
-            };
-            let wsv = WorldStateView::<World>::new(World::with(domains, btreeset! {}));
+            let domains = [("test".to_owned(), domain)];
+            let wsv = WorldStateView::<World>::new(World::with(domains, []));
             let instruction = Instruction::Unregister(UnregisterBox::new(xor_id));
             let validator: IsInstructionAllowedBoxed<World> =
                 unregister::OnlyAssetsCreatedByThisAccount
@@ -2047,19 +2047,19 @@ pub mod public_blockchain {
             let xor_definition = new_xor_definition(&xor_id);
             let permission_token_to_alice = PermissionToken::new(
                 unregister::CAN_UNREGISTER_ASSET_WITH_DEFINITION,
-                btreemap! {
-                    ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_owned() => xor_id.clone().into(),
-                },
+                [(
+                    ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_owned(),
+                    xor_id.clone().into(),
+                )],
             );
             let mut domain = Domain::new("test");
             domain.asset_definitions.insert(
                 xor_id,
                 AssetDefinitionEntry::new(xor_definition, alice_id.clone()),
             );
-            let domains = btreemap! {
-                "test".to_owned() => domain
-            };
-            let wsv = WorldStateView::<World>::new(World::with(domains, btreeset! {}));
+            let domains = [("test".to_owned(), domain)];
+
+            let wsv = WorldStateView::<World>::new(World::with(domains, []));
             let grant = Instruction::Grant(GrantBox {
                 object: permission_token_to_alice.into(),
                 destination_id: IdBox::AccountId(bob_id.clone()).into(),
@@ -2079,21 +2079,22 @@ pub mod public_blockchain {
             let xor_id = <AssetDefinition as Identifiable>::Id::new("xor", "test");
             let xor_definition = new_xor_definition(&xor_id);
             let wsv = WorldStateView::<World>::new(World::with(
-                btreemap! {
-                    "test".to_string() => Domain {
-                    accounts: BTreeMap::new(),
-                    name: "test".to_string(),
-                    asset_definitions: btreemap! {
-                        xor_id =>
-                        AssetDefinitionEntry {
-                            definition: xor_definition,
-                            registered_by: alice_id.clone()
-                        }
-                    }
-                    .into_iter()
-                    .collect(),
-                }},
-                btreeset! {},
+                [(
+                    "test".to_string(),
+                    Domain {
+                        accounts: BTreeMap::new(),
+                        name: "test".to_string(),
+                        asset_definitions: [(
+                            xor_id,
+                            AssetDefinitionEntry {
+                                definition: xor_definition,
+                                registered_by: alice_id.clone(),
+                            },
+                        )]
+                        .into(),
+                    },
+                )],
+                [],
             ));
             let mint = Instruction::Mint(MintBox {
                 object: Value::U32(100).into(),
@@ -2119,19 +2120,18 @@ pub mod public_blockchain {
             let mut bob_account = Account::new(bob_id.clone());
             let _ = bob_account.permission_tokens.insert(PermissionToken::new(
                 mint::CAN_MINT_USER_ASSET_DEFINITIONS_TOKEN,
-                btreemap! {
-                    ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_string() => xor_id.clone().into(),
-                },
+                [(
+                    ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_string(),
+                    xor_id.clone().into(),
+                )],
             ));
             domain.accounts.insert(bob_id.clone(), bob_account);
             domain.asset_definitions.insert(
                 xor_id,
                 AssetDefinitionEntry::new(xor_definition, alice_id.clone()),
             );
-            let domains = btreemap! {
-                "test".to_owned() => domain
-            };
-            let wsv = WorldStateView::<World>::new(World::with(domains, btreeset! {}));
+            let domains = [("test".to_owned(), domain)];
+            let wsv = WorldStateView::<World>::new(World::with(domains, []));
             let instruction = Instruction::Mint(MintBox {
                 object: Value::U32(100).into(),
                 destination_id: IdBox::AssetId(alice_xor_id).into(),
@@ -2151,18 +2151,17 @@ pub mod public_blockchain {
             let xor_definition = new_xor_definition(&xor_id);
             let permission_token_to_alice = PermissionToken::new(
                 mint::CAN_MINT_USER_ASSET_DEFINITIONS_TOKEN,
-                btreemap! {
-                    ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_owned() => xor_id.clone().into(),
-                },
+                [(
+                    ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_owned(),
+                    xor_id.clone().into(),
+                )],
             );
             let mut domain = Domain::new("test");
             domain.asset_definitions.insert(
                 xor_id,
                 AssetDefinitionEntry::new(xor_definition, alice_id.clone()),
             );
-            let domains = btreemap! {
-                "test".to_owned() => domain
-            };
+            let domains = [("test".to_owned(), domain)];
             let wsv = WorldStateView::<World>::new(World::with(domains, vec![]));
             let grant = Instruction::Grant(GrantBox {
                 object: permission_token_to_alice.into(),
@@ -2183,22 +2182,22 @@ pub mod public_blockchain {
             let xor_id = <AssetDefinition as Identifiable>::Id::new("xor", "test");
             let xor_definition = new_xor_definition(&xor_id);
             let wsv = WorldStateView::<World>::new(World::with(
-                btreemap! {
-                    "test".to_string() => Domain {
-                    accounts: BTreeMap::new(),
-                    name: "test".to_string(),
-                    asset_definitions: btreemap! {
-                        xor_id =>
-                        AssetDefinitionEntry {
-                            definition: xor_definition,
-                            registered_by: alice_id.clone()
-                        }
-                    }
-                    .into_iter()
-                    .collect(),
-                    }
-                },
-                vec![],
+                [(
+                    "test".to_string(),
+                    Domain {
+                        accounts: [].into(),
+                        name: "test".to_string(),
+                        asset_definitions: [(
+                            xor_id,
+                            AssetDefinitionEntry {
+                                definition: xor_definition,
+                                registered_by: alice_id.clone(),
+                            },
+                        )]
+                        .into(),
+                    },
+                )],
+                [],
             ));
             let burn = Instruction::Burn(BurnBox {
                 object: Value::U32(100).into(),
@@ -2224,18 +2223,17 @@ pub mod public_blockchain {
             let mut bob_account = Account::new(bob_id.clone());
             let _ = bob_account.permission_tokens.insert(PermissionToken::new(
                 burn::CAN_BURN_ASSET_WITH_DEFINITION,
-                btreemap! {
-                    ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_string() => xor_id.clone().into(),
-                },
+                [(
+                    ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_string(),
+                    xor_id.clone().into(),
+                )],
             ));
             domain.accounts.insert(bob_id.clone(), bob_account);
             domain.asset_definitions.insert(
                 xor_id,
                 AssetDefinitionEntry::new(xor_definition, alice_id.clone()),
             );
-            let domains = btreemap! {
-                "test".to_owned() => domain
-            };
+            let domains = [("test".to_owned(), domain)];
             let wsv = WorldStateView::<World>::new(World::with(domains, vec![]));
             let instruction = Instruction::Burn(BurnBox {
                 object: Value::U32(100).into(),
@@ -2256,18 +2254,17 @@ pub mod public_blockchain {
             let xor_definition = new_xor_definition(&xor_id);
             let permission_token_to_alice = PermissionToken::new(
                 burn::CAN_BURN_ASSET_WITH_DEFINITION,
-                btreemap! {
-                    ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_owned() => xor_id.clone().into(),
-                },
+                [(
+                    ASSET_DEFINITION_ID_TOKEN_PARAM_NAME.to_owned(),
+                    xor_id.clone().into(),
+                )],
             );
             let mut domain = Domain::new("test");
             domain.asset_definitions.insert(
                 xor_id,
                 AssetDefinitionEntry::new(xor_definition, alice_id.clone()),
             );
-            let domains = btreemap! {
-                "test".to_owned() => domain
-            };
+            let domains = [("test".to_owned(), domain)];
             let wsv = WorldStateView::<World>::new(World::with(domains, vec![]));
             let grant = Instruction::Grant(GrantBox {
                 object: permission_token_to_alice.into(),
@@ -2304,9 +2301,10 @@ pub mod public_blockchain {
             let mut bob_account = Account::new(bob_id.clone());
             let _ = bob_account.permission_tokens.insert(PermissionToken::new(
                 burn::CAN_BURN_USER_ASSETS_TOKEN,
-                btreemap! {
-                    ASSET_ID_TOKEN_PARAM_NAME.to_string() => alice_xor_id.clone().into(),
-                },
+                [(
+                    ASSET_ID_TOKEN_PARAM_NAME.to_string(),
+                    alice_xor_id.clone().into(),
+                )],
             ));
             domain.accounts.insert(bob_id.clone(), bob_account);
             let domains = vec![("test".to_string(), domain)];
@@ -2330,9 +2328,7 @@ pub mod public_blockchain {
                 <Asset as Identifiable>::Id::from_names("xor", "test", "alice", "test");
             let permission_token_to_alice = PermissionToken::new(
                 burn::CAN_BURN_USER_ASSETS_TOKEN,
-                btreemap! {
-                    ASSET_ID_TOKEN_PARAM_NAME.to_owned() => alice_xor_id.into(),
-                },
+                [(ASSET_ID_TOKEN_PARAM_NAME.to_owned(), alice_xor_id.into())],
             );
             let wsv = WorldStateView::<World>::new(World::new());
             let grant = Instruction::Grant(GrantBox {
@@ -2425,22 +2421,22 @@ pub mod public_blockchain {
             let xor_id = <AssetDefinition as Identifiable>::Id::new("xor", "test");
             let xor_definition = new_xor_definition(&xor_id);
             let wsv = WorldStateView::<World>::new(World::with(
-                btreemap! {
-                    "test".to_string() => Domain {
-                    accounts: BTreeMap::new(),
-                    name: "test".to_string(),
-                    asset_definitions: btreemap! {
-                        xor_id.clone() =>
-                        AssetDefinitionEntry {
-                            definition: xor_definition,
-                            registered_by: alice_id.clone()
-                        }
-                    }
-                    .into_iter()
-                    .collect(),
-                    }
-                },
-                vec![],
+                [(
+                    "test".to_string(),
+                    Domain {
+                        accounts: BTreeMap::new(),
+                        name: "test".to_string(),
+                        asset_definitions: [(
+                            xor_id.clone(),
+                            AssetDefinitionEntry {
+                                definition: xor_definition,
+                                registered_by: alice_id.clone(),
+                            },
+                        )]
+                        .into(),
+                    },
+                )],
+                [],
             ));
             let set = Instruction::SetKeyValue(SetKeyValueBox::new(
                 IdBox::AssetDefinitionId(xor_id),
@@ -2462,22 +2458,22 @@ pub mod public_blockchain {
             let xor_id = <AssetDefinition as Identifiable>::Id::new("xor", "test");
             let xor_definition = new_xor_definition(&xor_id);
             let wsv = WorldStateView::<World>::new(World::with(
-                btreemap! {
-                    "test".to_string() => Domain {
-                    accounts: BTreeMap::new(),
-                    name: "test".to_string(),
-                    asset_definitions: btreemap! {
-                        xor_id.clone() =>
-                        AssetDefinitionEntry {
-                            definition: xor_definition,
-                            registered_by: alice_id.clone()
-                        }
-                    }
-                    .into_iter()
-                    .collect(),
-                    }
-                },
-                vec![],
+                [(
+                    "test".to_string(),
+                    Domain {
+                        accounts: BTreeMap::new(),
+                        name: "test".to_string(),
+                        asset_definitions: [(
+                            xor_id.clone(),
+                            AssetDefinitionEntry {
+                                definition: xor_definition,
+                                registered_by: alice_id.clone(),
+                            },
+                        )]
+                        .into(),
+                    },
+                )],
+                [],
             ));
             let set = Instruction::RemoveKeyValue(RemoveKeyValueBox::new(
                 IdBox::AssetDefinitionId(xor_id),

--- a/schema/Cargo.toml
+++ b/schema/Cargo.toml
@@ -2,7 +2,7 @@
 name = "iroha_schema"
 version = "0.1.0"
 authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
-edition = "2018"
+edition = "2021"
 
 [dev-dependencies]
 trybuild = { version = "1.0", features = ["diff"] }

--- a/schema/bin/Cargo.toml
+++ b/schema/bin/Cargo.toml
@@ -2,7 +2,7 @@
 name = "iroha_schema_bin"
 version = "0.1.0"
 authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
-edition = "2018"
+edition = "2021"
 
 
 [dependencies]

--- a/schema/derive/Cargo.toml
+++ b/schema/derive/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "iroha_schema_derive"
 version = "0.0.0"
-edition = "2018"
+authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
+edition = "2021"
 publish = false
 
 [lib]

--- a/substrate/Cargo.toml
+++ b/substrate/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iroha_substrate"
 version = "0.1.0"
-authors = ["Nikita Puzankov <humb1t@yandex.ru>"]
-edition = "2018"
+authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/telemetry/Cargo.toml
+++ b/telemetry/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iroha_telemetry"
 version = "0.1.0"
-authors = ["i1i1"]
-edition = "2018"
+authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
+edition = "2021"
 build = "build.rs"
 
 [features]
@@ -11,7 +11,7 @@ dev-telemetry = []
 [dependencies]
 chrono = "0.4"
 eyre = "0.6.5"
-futures = "0.3"
+futures = { version = "0.3.17", default-features = false, features = ["std", "async-await"] }
 serde_json = "1"
 streaming-stats = "0.2"
 serde = { version = "1", features = ["derive"] }

--- a/version/Cargo.toml
+++ b/version/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iroha_version"
 version = "0.1.0"
-authors = ["Egor Ivkov <e.o.ivkov@gmail.com>"]
-edition = "2018"
+authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/version/derive/Cargo.toml
+++ b/version/derive/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iroha_version_derive"
 version = "0.1.0"
-authors = ["Egor Ivkov <e.o.ivkov@gmail.com>"]
-edition = "2018"
+authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
+edition = "2021"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
Closes #1548 

### Description of the Change

This pr migrates from rust 1.55 to 1.56 and also updates rust edition from 2018 to 2021.

### Issue

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
