### PR TITLE
Added `buildx` as suggested by the failing pipeline.

### DIFF
--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -158,6 +158,11 @@ jobs:
     needs: test-docker
     steps:
       - uses: actions/checkout@v2
+      - name: set up buildx
+        uses: docker/setup-buildx-action@v1
+        id: buildx
+        with:
+          install: true
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION


### Description of the Change
Should fix issues with the CI push workflow. 

### Issue

Docker build requires `buildx`

### Benefits
Can push Docker builds

### Possible Drawbacks
haven't tested it yet. 

