### PR TITLE
Fix the random bounces in `create-docker` workflow.

### DIFF
--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -9,7 +9,8 @@ env:
 
 jobs:
   test-docker:
-    runs-on: [ self-hosted, Linux ] #ubuntu-latest
+    runs-on: [self-hosted, Linux]
+    container: rust:1.56-buster
     # runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -154,7 +155,8 @@ jobs:
 
 
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux]
+    container: rust:1.56-buster
     needs: test-docker
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
### Description of the Change

Changes the push workflow to run on a self-hosted container

### Issue

Some docker workflows have been failing on GitHub-hosted containers. 

### Benefits

They should now always work. 

### Possible Drawbacks

More CI usage and heavier load on the CI runners hosted on AWS. 
