### PR TITLE
Add optional nonce to distinguish transactions. Close #1493

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -17,22 +17,23 @@ is-it-maintained-open-issues = { repository = "https://github.com/hyperledger/ir
 maintenance = { status = "actively-developed" }
 
 [dependencies]
+iroha_config = { path = "../config" }
 iroha_core = { path = "../core" }
+iroha_crypto = { version = "=0.1.0", path = "../crypto" }
 iroha_data_model = { version = "=0.1.0", path = "../data_model" }
 iroha_derive = { version = "=0.1.0", path = "../macro/derive" }
 iroha_logger = { version = "=0.1.0", path = "../logger"}
-iroha_crypto = { version = "=0.1.0", path = "../crypto" }
-iroha_config = { path = "../config" }
-iroha_version = { version = "=0.1.0", path = "../version" }
 iroha_telemetry = { path = "../telemetry" }
+iroha_version = { version = "=0.1.0", path = "../version" }
 
+attohttpc = "0.16.3"
 eyre = "0.6.5"
+http = "0.2.1"
+rand = "0.7.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-attohttpc = "0.16.3"
-http = "0.2.1"
-tungstenite = { version = "0.12.0", features = ["tls-vendored"] }
 tracing = "0.1"
+tungstenite = { version = "0.12.0", features = ["tls-vendored"] }
 
 [dev-dependencies]
 iroha_core = { path = "../core", features = ["dev-telemetry", "telemetry"] }
@@ -45,7 +46,6 @@ color-eyre = "0.5.11"
 criterion = "0.3"
 futures = { version = "0.3.17", default-features = false, features = ["std", "async-await"] }
 tempfile = "3"
-rand = "0.7.3"
 unique_port = "0.1.0"
 tokio = { version = "1.6.0", features = ["rt", "rt-multi-thread"]}
 

--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -11,6 +11,7 @@ const DEFAULT_TORII_API_URL: &str = "127.0.0.1:8080";
 const DEFAULT_TRANSACTION_TIME_TO_LIVE_MS: u64 = 100_000;
 const DEFAULT_TRANSACTION_STATUS_TIMEOUT_MS: u64 = 10_000;
 const DEFAULT_MAX_INSTRUCTION_NUMBER: u64 = 2_u64.pow(12);
+const DEFAULT_ADD_TRANSACTION_NONCE: bool = false;
 
 /// `Configuration` provides an ability to define client parameters such as `TORII_URL`.
 // TODO: design macro to load config from env.
@@ -30,13 +31,15 @@ pub struct Configuration {
     pub torii_api_url: String,
     /// Proposed transaction TTL in milliseconds.
     pub transaction_time_to_live_ms: u64,
-    /// `Logger` configuration.
-    #[config(inner)]
-    pub logger_configuration: LoggerConfiguration,
     /// Transaction status wait timeout in milliseconds.
     pub transaction_status_timeout_ms: u64,
     /// Maximum number of instructions per transaction
     pub max_instruction_number: u64,
+    /// If `true` add nonce, which make different hashes for transactions which occur repeatedly and simultaneously
+    pub add_transaction_nonce: bool,
+    /// `Logger` configuration.
+    #[config(inner)]
+    pub logger_configuration: LoggerConfiguration,
 }
 
 impl Default for Configuration {
@@ -49,6 +52,7 @@ impl Default for Configuration {
             transaction_time_to_live_ms: DEFAULT_TRANSACTION_TIME_TO_LIVE_MS,
             transaction_status_timeout_ms: DEFAULT_TRANSACTION_STATUS_TIMEOUT_MS,
             max_instruction_number: DEFAULT_MAX_INSTRUCTION_NUMBER,
+            add_transaction_nonce: DEFAULT_ADD_TRANSACTION_NONCE,
             logger_configuration: LoggerConfiguration::default(),
         }
     }

--- a/client_cli/src/main.rs
+++ b/client_cli/src/main.rs
@@ -14,7 +14,7 @@ use iroha_crypto::prelude::*;
 use iroha_data_model::prelude::*;
 use structopt::StructOpt;
 
-/// Metadata wrapper, which can be captured from cli arguments (from user suplied file).
+/// Metadata wrapper, which can be captured from cli arguments (from user supplied file).
 #[derive(Debug, Clone)]
 pub struct Metadata(pub UnlimitedMetadata);
 

--- a/data_model/src/lib.rs
+++ b/data_model/src/lib.rs
@@ -2039,6 +2039,8 @@ pub mod transaction {
         pub creation_time: u64,
         /// The transaction will be dropped after this time if it is still in a `Queue`.
         pub time_to_live_ms: u64,
+        /// Random value to make different hashes for transactions which occur repeatedly and simultaneously
+        pub nonce: Option<u32>,
         /// Metadata.
         pub metadata: UnlimitedMetadata,
     }
@@ -2116,6 +2118,23 @@ pub mod transaction {
                 account_id,
                 proposed_ttl_ms,
                 UnlimitedMetadata::new(),
+                None,
+            )
+        }
+
+        /// [`Transaction`] constructor with nonce.
+        pub fn with_nonce(
+            instructions: Vec<Instruction>,
+            account_id: <Account as Identifiable>::Id,
+            proposed_ttl_ms: u64,
+            nonce: u32,
+        ) -> Transaction {
+            Transaction::with_metadata(
+                instructions,
+                account_id,
+                proposed_ttl_ms,
+                UnlimitedMetadata::new(),
+                Some(nonce),
             )
         }
 
@@ -2125,6 +2144,7 @@ pub mod transaction {
             account_id: <Account as Identifiable>::Id,
             proposed_ttl_ms: u64,
             metadata: UnlimitedMetadata,
+            nonce: Option<u32>,
         ) -> Transaction {
             #[allow(clippy::cast_possible_truncation, clippy::expect_used)]
             Transaction {
@@ -2136,6 +2156,7 @@ pub mod transaction {
                         .expect("Failed to get System Time.")
                         .as_millis() as u64,
                     time_to_live_ms: proposed_ttl_ms,
+                    nonce,
                     metadata,
                 },
                 signatures: BTreeSet::new(),


### PR DESCRIPTION
### Description of the Change
* Add `Transaction.Payload.nonce` field
* Whether add nonce or not is configurable in `client/config.json`

### Issue
Close #1493

### Benefits
Can make different hashes for transactions which occur repeatedly and simultaneously

### Possible Drawbacks
Affection to performance unmeasured