### PR TITLE
[fix] #1990: Enable peer startup via env vars in the absence of `config.json`

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -77,7 +77,17 @@ cargo run --bin kagami -- crypto --json
 
 For the Iroha peer binary to run, a configuration file must be provided. Iroha will not run with defaults if the configuration file is not available.
 
-The Iroha binary looks for either a file `config.json` in the current directory, or for a JSON file `IROHA2_CONFIG_PATH`. If the latter environment variable is defined, but not a valid configuration file, the Iroha peer binary will exit and do nothing.
+The Iroha binary looks for either a `config.json` file in the current directory, or for a JSON file `IROHA2_CONFIG_PATH`. If the configuration file is not valid, the Iroha peer binary exits and does nothing. If neither of these files is provided, all the fields from the default `config.json` should be specified as environment variables. Note that environment variables override the variables in their respective fields provided via `config.json`.
+
+The environment variables replacing `config.json` should be passed as JSON strings, meaning that any inner quotes should be properly escaped in the command line as shown in the rather unwieldy example below.
+
+<details>
+
+``` bash
+IROHA_TORII="{\"P2P_ADDR\": \"127.0.0.1:1339\", \"API_URL\": \"127.0.0.1:8080\"}" IROHA_SUMERAGI="{\"TRUSTED_PEERS\": [{\"address\": \"127.0.0.1:1337\",\"public_key\": \"ed01201c61faf8fe94e253b93114240394f79a607b7fa55f9e5a41ebec74b88055768b\"},{\"address\": \"127.0.0.1:1338\",\"public_key\": \"ed0120cc25624d62896d3a0bfd8940f928dc2abf27cc57cefeb442aa96d9081aae58a1\"},{\"address\": \"127.0.0.1:1339\",\"public_key\": \"ed0120faca9e8aa83225cb4d16d67f27dd4f93fc30ffa11adc1f5c88fd5495ecc91020\"},{\"address\": \"127.0.0.1:1340\",\"public_key\": \"ed01208e351a70b6a603ed285d666b8d689b680865913ba03ce29fb7d13a166c4e7f1f\"}]}" IROHA_KURA="{\"INIT_MODE\": \"strict\",\"BLOCK_STORE_PATH\": \"./blocks\"}" IROHA_BLOCK_SYNC="{\"GOSSIP_PERIOD_MS\": 10000,\"BATCH_SIZE\": 2}" IROHA_PUBLIC_KEY="ed01201c61faf8fe94e253b93114240394f79a607b7fa55f9e5a41ebec74b88055768b" IROHA_PRIVATE_KEY="{\"digest_function\": \"ed25519\",\"payload\": \"282ed9f3cf92811c3818dbc4ae594ed59dc1a2f78e4241e31924e101d6b1fb831c61faf8fe94e253b93114240394f79a607b7fa55f9e5a41ebec74b88055768b\"}" IROHA_GENESIS="{\"ACCOUNT_PUBLIC_KEY\": \"ed01204cffd0ee429b1bdd36b3910ec570852b8bb63f18750341772fb46bc856c5caaf\",\"ACCOUNT_PRIVATE_KEY\": {\"digest_function\": \"ed25519\",\"payload\": \"d748e18ce60cb30dea3e73c9019b7af45a8d465e3d71bcc9a5ef99a008205e534cffd0ee429b1bdd36b3910ec570852b8bb63f18750341772fb46bc856c5caaf\"}}" ./iroha 
+```
+
+</details>
 
 The  [configuration options reference](../docs/source/references/config.md) provides detailed explanations of each configuration variable. All variables defined in `config.json` can be overridden with environment variables. **We don't recommend using environment variables for configuration outside docker-compose and Kubernetes deployments**. Please change the values in the configuration file instead, so that we can better debug the problems that you might be having.
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -107,7 +107,10 @@ where
         query_validator: IsQueryAllowedBoxed<K::World>,
     ) -> Result<Self> {
         let broker = Broker::new();
-        let mut config = Configuration::from_path(&args.config_path)?;
+        let mut config = match Configuration::from_path(&args.config_path) {
+            Ok(config) => config,
+            Err(_) => Configuration::default(),
+        };
         config.load_environment()?;
 
         let genesis = G::from_configuration(
@@ -143,7 +146,9 @@ where
         broker: Broker,
     ) -> Result<Self> {
         if !config.disable_panic_terminal_colors {
-            color_eyre::install()?;
+            if let Err(e) = color_eyre::install() {
+                iroha_logger::error!("Tried to install eyre_hook twice: {:?}", e);
+            }
         }
         let telemetry = iroha_logger::init(&config.logger)?;
         iroha_logger::info!("Hyperledgerいろは2にようこそ！");

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,6 +2,7 @@
 
 use std::str::FromStr;
 
+use eyre::WrapErr as _;
 use iroha::Arguments;
 use iroha_core::prelude::AllowAll;
 use iroha_permissions_validators::public_blockchain::default_permissions;
@@ -27,6 +28,24 @@ async fn main() -> Result<(), color_eyre::Report> {
 
     if let Ok(config_path) = std::env::var("IROHA2_CONFIG_PATH") {
         args.config_path = std::path::PathBuf::from_str(&config_path)?;
+    }
+    if !args.config_path.exists() {
+        // Require all the fields defined in default `config.json`
+        // to be specified as env vars with their respective prefixes
+        let required_var_names = [
+            "IROHA_TORII",
+            "IROHA_SUMERAGI",
+            "IROHA_KURA",
+            "IROHA_BLOCK_SYNC",
+            "IROHA_PUBLIC_KEY",
+            "IROHA_PRIVATE_KEY",
+            "IROHA_GENESIS",
+        ];
+        for var_name in required_var_names {
+            std::env::var(var_name).wrap_err(format!(
+                "Failed to retrieve required environment variable: {var_name}"
+            ))?;
+        }
     }
 
     if let Ok(genesis_path) = std::env::var("IROHA2_GENESIS_PATH") {
@@ -58,4 +77,17 @@ fn print_help() {
     println!("    IROHA2_CONFIG_PATH is the location of your `config.json`");
     println!("    IROHA2_GENESIS_PATH is the location of `genesis.json`");
     println!("If either of these is not provided, Iroha checks the current directory.");
+    println!(
+        "Additionally, in case of absence of both IROHA2_CONFIG_PATH and `config.json`
+in the current directory, all the variables from `config.json` should be set via the environment
+as follows:"
+    );
+    println!("    IROHA_TORII is the torii gateway config");
+    println!("    IROHA_SUMERAGI is the consensus config");
+    println!("    IROHA_KURA is block storage config");
+    println!("    IROHA_BLOCK_SYNC is block synchronization config");
+    println!("    IROHA_PUBLIC_KEY is the peer's public key");
+    println!("    IROHA_PRIVATE_KEY is the peer's private key");
+    println!("    IROHA_GENESIS is the genesis block config");
+    println!("Examples of these variables can be found in the default `configs/peer/config.json`.")
 }


### PR DESCRIPTION
Signed-off-by: Ilia Churin <ilia.ch@netogami.net>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->
In the case when the minimal cli client (`iroha`) was provided with no `config.json` either in the same directory or as an environment variable, do not stop the execution, but instead require that all the variables from the default json be provided as environment variables too, and load them onto default configuration.

### Issue

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->
Resolves #1990.

### Benefits
Presumably easier and more flexible setup of peer through cli.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
As the fix chooses to fall back on default impl for config, it has the same problems that were discussed in #2101 and  #2118. The question is which variables should be allowed to be set via environment, and which subset of them should be required when using default, if we're going to stick with it at all. As of now, the default configuration is generated with `Default` and all the variables from the `configs/peer/config.json` are required to proceed if no file was found.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

<!-- ### Usage Examples or Tests *[optional]* -->

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

<!-- ### Alternate Designs *[optional]* -->

<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
