### PR TITLE
[fix] #2303: Fix docker-compose' peers doesn't get gracefully shut down

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - "8180:8180"
     volumes:
       - './configs/peer:/config'
+    init: true
     command: ./iroha --submit-genesis
 
   iroha1:
@@ -32,6 +33,7 @@ services:
       - "8181:8181"
     volumes:
       - './configs/peer:/config'
+    init: true
 
   iroha2:
     image: hyperledger/iroha2:dev
@@ -48,6 +50,7 @@ services:
       - "8182:8182"
     volumes:
       - './configs/peer:/config'
+    init: true
 
   iroha3:
     image: hyperledger/iroha2:dev
@@ -64,3 +67,4 @@ services:
       - "8183:8183"
     volumes:
       - './configs/peer:/config'
+    init: true


### PR DESCRIPTION
Signed-off-by: Vladimir Pesterev <pesterev@pm.me>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

[The comment](https://github.com/hyperledger/iroha/issues/2303#issuecomment-1144872465) explains why

### Issue

Resolves #2303 

### Benefits

Peer's graceful shutdown will works with `docker-compose.yml` config.

### Possible Drawbacks

Possibly `init` config affects performance.

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
