### PR TITLE
[refactor] #2323: Enhance kura init error message

### DIFF
--- a/core/src/kura.rs
+++ b/core/src/kura.rs
@@ -178,7 +178,7 @@ impl<W: WorldTrait, IO: DiskIO> Actor for KuraWithIO<W, IO> {
                     .await;
             }
             Err(error) => {
-                error!(%error, "Initialization of kura failed");
+                error!(%error, "Kura initialization failed. Try removing the peer's `blocks` directory and restarting the peer. You can also try rebuilding the peer altogether.");
                 panic!("Kura initialization failed");
             }
         }


### PR DESCRIPTION
Signed-off-by: Ilia Churin <churin.ilya@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
A slightly altered error message for cases when `kura` initialization goes wrong.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Issue

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
Resolves #2323.
<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits
Suggests a makeshift solution to Iroha users.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
The message could actually be somewhat misleading. If there is a network being run by `docker compose` and only one of the peers has faulty data, simply restarting it wouldn't help as it will keep crashing over and over. Maybe I'm missing out on some technique, but so far the only viable solution for me was rebuilding the network, so I made sure the message reflects that.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
