### PR TITLE
[feature] #2097: Store asset-registering transactions

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -309,7 +309,13 @@ impl Iroha {
             std::path::Path::new(&config.kura.block_store_path),
             config.kura.debug_output_new_blocks,
         )?;
-        let wsv = WorldStateView::from_configuration(config.wsv, world, Arc::clone(&kura));
+        let queue = Arc::new(Queue::from_configuration(&config.queue));
+        let wsv = WorldStateView::from_configuration(
+            config.wsv,
+            world,
+            Arc::clone(&queue),
+            Arc::clone(&kura),
+        );
 
         let transaction_validator = TransactionValidator::new(config.sumeragi.transaction_limits);
 
@@ -326,7 +332,6 @@ impl Iroha {
 
         let notify_shutdown = Arc::new(Notify::new());
 
-        let queue = Arc::new(Queue::from_configuration(&config.queue));
         if Self::start_telemetry(telemetry, &config).await? {
             iroha_logger::info!("Telemetry started")
         } else {

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1489,6 +1489,13 @@ pub mod asset {
     pub fn by_id(asset_id: impl Into<EvaluatesTo<<Asset as Identifiable>::Id>>) -> FindAssetById {
         FindAssetById::new(asset_id)
     }
+
+    /// Construct a query to get an asset definition registering transaction by its id
+    pub fn register_tx_by_definition_id(
+        asset_definition_id: impl Into<EvaluatesTo<<AssetDefinition as Identifiable>::Id>>,
+    ) -> FindAssetRegisteringTransaction {
+        FindAssetRegisteringTransaction::new(asset_definition_id)
+    }
 }
 
 pub mod block {

--- a/client/tests/integration/queries/asset_register_tx.rs
+++ b/client/tests/integration/queries/asset_register_tx.rs
@@ -1,0 +1,47 @@
+#![allow(clippy::restriction)]
+
+use std::thread;
+
+use eyre::Result;
+use iroha_client::client::asset;
+use iroha_crypto::KeyPair;
+use iroha_data_model::prelude::*;
+use test_network::*;
+
+use crate::integration::Configuration;
+
+#[test]
+fn find_asset_register_tx_returns_the_right_hash() -> Result<()> {
+    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_690).start_with_runtime();
+    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    let pipeline_time = Configuration::pipeline_time();
+    thread::sleep(pipeline_time * 2);
+
+    let domain_id: DomainId = "domain".parse()?;
+    let create_domain = RegisterBox::new(Domain::new(domain_id.clone()));
+    test_client.submit_blocking(create_domain)?;
+
+    let account_id: AccountId = "account@domain".parse()?;
+    let (public_key, _) = KeyPair::generate()?.into();
+    let account = Account::new(account_id, [public_key]);
+    let create_account = RegisterBox::new(account);
+    test_client.submit_blocking(create_account)?;
+
+    let asset_definition_id_1 = AssetDefinitionId::new("xor".parse()?, domain_id.clone());
+    let create_asset = RegisterBox::new(AssetDefinition::quantity(asset_definition_id_1.clone()));
+    let asset_reg_tx_hash_1 = test_client.submit_blocking(create_asset)?;
+
+    let asset_definition_id_2 = AssetDefinitionId::new("val".parse()?, domain_id);
+    let create_asset = RegisterBox::new(AssetDefinition::quantity(asset_definition_id_2.clone()));
+    let asset_reg_tx_hash_2 = test_client.submit_blocking(create_asset)?;
+
+    let query_result_1 =
+        test_client.request(asset::register_tx_by_definition_id(asset_definition_id_1))?;
+    let query_result_2 =
+        test_client.request(asset::register_tx_by_definition_id(asset_definition_id_2))?;
+
+    assert_eq!(query_result_1, asset_reg_tx_hash_1.into());
+    assert_eq!(query_result_2, asset_reg_tx_hash_2.into());
+
+    Ok(())
+}

--- a/client/tests/integration/queries/mod.rs
+++ b/client/tests/integration/queries/mod.rs
@@ -1,3 +1,4 @@
 mod account;
 mod asset;
+mod asset_register_tx;
 mod role;

--- a/core/benches/kura.rs
+++ b/core/benches/kura.rs
@@ -4,7 +4,9 @@ use std::{str::FromStr as _, sync::Arc};
 
 use byte_unit::Byte;
 use criterion::{criterion_group, criterion_main, Criterion};
-use iroha_core::{block::*, kura::BlockStore, prelude::*, tx::TransactionValidator, wsv::World};
+use iroha_core::{
+    block::*, kura::BlockStore, prelude::*, queue::Queue, tx::TransactionValidator, wsv::World,
+};
 use iroha_crypto::KeyPair;
 use iroha_data_model::{block::VersionedCommittedBlock, prelude::*};
 use iroha_version::scale::EncodeVersioned;
@@ -46,7 +48,11 @@ async fn measure_block_size_for_n_validators(n_validators: u32) {
         .chain_first()
         .validate(
             &TransactionValidator::new(transaction_limits),
-            &Arc::new(WorldStateView::new(World::new(), kura)),
+            &Arc::new(WorldStateView::new(
+                World::new(),
+                &Queue::default_queue_for_testing(),
+                kura,
+            )),
         );
     let mut block = block
         .sign(KeyPair::generate().expect("Failed to generate KeyPair"))

--- a/core/benches/validation.rs
+++ b/core/benches/validation.rs
@@ -4,8 +4,8 @@ use std::{collections::BTreeSet, str::FromStr as _, sync::Arc};
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use iroha_core::{
-    block::*, prelude::*, sumeragi::network_topology::Topology, tx::TransactionValidator,
-    wsv::World,
+    block::*, prelude::*, queue::Queue, sumeragi::network_topology::Topology,
+    tx::TransactionValidator, wsv::World,
 };
 use iroha_data_model::prelude::*;
 
@@ -72,6 +72,7 @@ fn build_test_and_transient_wsv(keys: KeyPair) -> WorldStateView {
             assert!(domain.add_account(account).is_none());
             World::with([domain], BTreeSet::new())
         },
+        &Queue::default_queue_for_testing(),
         kura,
     )
 }
@@ -208,6 +209,7 @@ fn validate_blocks(criterion: &mut Criterion) {
                 &transaction_validator,
                 &Arc::new(WorldStateView::new(
                     World::with([domain.clone()], BTreeSet::new()),
+                    &Queue::default_queue_for_testing(),
                     kura.clone(),
                 )),
             )

--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -919,7 +919,7 @@ mod tests {
     use iroha_data_model::prelude::*;
 
     use super::*;
-    use crate::kura::Kura;
+    use crate::{kura::Kura, queue::Queue};
 
     #[test]
     pub fn committed_and_valid_block_hashes_are_equal() {
@@ -940,7 +940,8 @@ mod tests {
         assert!(domain.add_account(account).is_none());
         let world = World::with([domain], Vec::new());
         let kura = Kura::blank_kura_for_testing();
-        let wsv = WorldStateView::new(world, kura);
+        let queue = Queue::default_queue_for_testing();
+        let wsv = WorldStateView::new(world, &queue, kura);
 
         // Creating an instruction
         let asset_definition_id = AssetDefinitionId::from_str("xor#wonderland").expect("Valid");

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod wsv;
 use core::time::Duration;
 
 use dashmap::{DashMap, DashSet};
+use iroha_crypto::HashOf;
 use iroha_data_model::prelude::*;
 use parity_scale_codec::{Decode, Encode};
 use tokio::sync::broadcast;
@@ -47,6 +48,11 @@ pub type PermissionTokensMap = DashMap<<Account as Identifiable>::Id, Permission
 /// API to work with a collections of [`PermissionTokenDefinitionId`] : [`PermissionTokenDefinition`] mappings.
 pub type PermissionTokenDefinitionsMap =
     DashMap<<PermissionTokenDefinition as Identifiable>::Id, PermissionTokenDefinition>;
+
+/// API to work with collection of key([`AssetDefinitionId`])-value([`HashOf<VersionedSignedTransaction>`])
+/// pairs.
+pub type AssetRegisterTxsMap =
+    DashMap<<AssetDefinition as Identifiable>::Id, HashOf<VersionedSignedTransaction>>;
 
 /// Type of `Sender<Event>` which should be used for channels of `Event` messages.
 pub type EventsSender = broadcast::Sender<Event>;

--- a/core/src/smartcontracts/isi/account.rs
+++ b/core/src/smartcontracts/isi/account.rs
@@ -456,15 +456,13 @@ pub mod query {
     use iroha_data_model::query::error::QueryExecutionFailure as Error;
 
     use super::{super::Evaluate, *};
+    use crate::evaluate_with_error_msg;
 
     impl ValidQuery for FindRolesByAccountId {
         #[metrics(+"find_roles_by_account_id")]
         fn execute(&self, wsv: &WorldStateView) -> Result<Self::Output, Error> {
-            let account_id = self
-                .id
-                .evaluate(wsv, &Context::new())
-                .wrap_err("Failed to evaluate account id")
-                .map_err(|e| Error::Evaluate(e.to_string()))?;
+            let account_id =
+                evaluate_with_error_msg!(self.id, wsv, "Failed to evaluate account id");
             iroha_logger::trace!(%account_id, roles=?wsv.world.roles);
             let roles = wsv.map_account(&account_id, |account| {
                 account.roles.iter().cloned().collect::<Vec<_>>()
@@ -476,11 +474,8 @@ pub mod query {
     impl ValidQuery for FindPermissionTokensByAccountId {
         #[metrics(+"find_permission_tokens_by_account_id")]
         fn execute(&self, wsv: &WorldStateView) -> Result<Self::Output, Error> {
-            let account_id = self
-                .id
-                .evaluate(wsv, &Context::new())
-                .wrap_err("Failed to evaluate account id")
-                .map_err(|e| Error::Evaluate(e.to_string()))?;
+            let account_id =
+                evaluate_with_error_msg!(self.id, wsv, "Failed to evaluate account id");
             iroha_logger::trace!(%account_id, accounts=?wsv.world.domains);
             let tokens = wsv.map_account(&account_id, |account| {
                 wsv.account_permission_tokens(account)
@@ -505,11 +500,7 @@ pub mod query {
     impl ValidQuery for FindAccountById {
         #[metrics(+"find_account_by_id")]
         fn execute(&self, wsv: &WorldStateView) -> Result<Self::Output, Error> {
-            let id = self
-                .id
-                .evaluate(wsv, &Context::default())
-                .wrap_err("Failed to get id")
-                .map_err(|e| Error::Evaluate(e.to_string()))?;
+            let id = evaluate_with_error_msg!(self.id, wsv, "Failed to get id");
             iroha_logger::trace!(%id);
             wsv.map_account(&id, Clone::clone).map_err(Into::into)
         }
@@ -518,11 +509,7 @@ pub mod query {
     impl ValidQuery for FindAccountsByName {
         #[metrics(+"find_account_by_name")]
         fn execute(&self, wsv: &WorldStateView) -> Result<Self::Output, Error> {
-            let name = self
-                .name
-                .evaluate(wsv, &Context::default())
-                .wrap_err("Failed to get account name")
-                .map_err(|e| Error::Evaluate(e.to_string()))?;
+            let name = evaluate_with_error_msg!(self.name, wsv, "Failed to get account name");
             iroha_logger::trace!(%name);
             let mut vec = Vec::new();
             for domain in wsv.domains().iter() {
@@ -539,11 +526,7 @@ pub mod query {
     impl ValidQuery for FindAccountsByDomainId {
         #[metrics(+"find_accounts_by_domain_id")]
         fn execute(&self, wsv: &WorldStateView) -> Result<Self::Output, Error> {
-            let id = self
-                .domain_id
-                .evaluate(wsv, &Context::default())
-                .wrap_err("Failed to get domain id")
-                .map_err(|e| Error::Evaluate(e.to_string()))?;
+            let id = evaluate_with_error_msg!(self.domain_id, wsv, "Failed to get domain id");
             iroha_logger::trace!(%id);
             Ok(wsv.domain(&id)?.accounts.values().cloned().collect())
         }
@@ -552,16 +535,8 @@ pub mod query {
     impl ValidQuery for FindAccountKeyValueByIdAndKey {
         #[metrics(+"find_account_key_value_by_id_and_key")]
         fn execute(&self, wsv: &WorldStateView) -> Result<Self::Output, Error> {
-            let id = self
-                .id
-                .evaluate(wsv, &Context::default())
-                .wrap_err("Failed to get account id")
-                .map_err(|e| Error::Evaluate(e.to_string()))?;
-            let key = self
-                .key
-                .evaluate(wsv, &Context::default())
-                .wrap_err("Failed to get key")
-                .map_err(|e| Error::Evaluate(e.to_string()))?;
+            let id = evaluate_with_error_msg!(self.id, wsv, "Failed to get account id");
+            let key = evaluate_with_error_msg!(self.key, wsv, "Failed to get key");
             iroha_logger::trace!(%id, %key);
             wsv.map_account(&id, |account| account.metadata.get(&key).map(Clone::clone))?
                 .ok_or_else(|| FindError::MetadataKey(key).into())
@@ -571,11 +546,8 @@ pub mod query {
     impl ValidQuery for FindAccountsWithAsset {
         #[metrics(+"find_accounts_with_asset")]
         fn execute(&self, wsv: &WorldStateView) -> Result<Self::Output, Error> {
-            let asset_definition_id = self
-                .asset_definition_id
-                .evaluate(wsv, &Context::default())
-                .wrap_err("Failed to get asset id")
-                .map_err(|e| Error::Evaluate(e.to_string()))?;
+            let asset_definition_id =
+                evaluate_with_error_msg!(self.asset_definition_id, wsv, "Failed to get asset id");
             iroha_logger::trace!(%asset_definition_id);
 
             let domain_id = &asset_definition_id.domain_id;

--- a/core/src/smartcontracts/isi/asset.rs
+++ b/core/src/smartcontracts/isi/asset.rs
@@ -436,6 +436,7 @@ pub mod query {
     };
 
     use super::*;
+    use crate::evaluate_with_error_msg;
 
     impl ValidQuery for FindAllAssets {
         #[metrics(+"find_all_assets")]
@@ -468,11 +469,7 @@ pub mod query {
     impl ValidQuery for FindAssetById {
         #[metrics(+"find_asset_by_id")]
         fn execute(&self, wsv: &WorldStateView) -> Result<Self::Output, Error> {
-            let id = self
-                .id
-                .evaluate(wsv, &Context::default())
-                .wrap_err("Failed to get asset id")
-                .map_err(|e| Error::Evaluate(e.to_string()))?;
+            let id = evaluate_with_error_msg!(self.id, wsv, "Failed to get asset id");
             iroha_logger::trace!(%id);
             wsv.asset(&id).map_err(|asset_err| {
                 if let Err(definition_err) = wsv.asset_definition_entry(&id.definition_id) {
@@ -487,11 +484,7 @@ pub mod query {
     impl ValidQuery for FindAssetDefinitionById {
         #[metrics(+"find_asset_defintion_by_id")]
         fn execute(&self, wsv: &WorldStateView) -> Result<Self::Output, Error> {
-            let id = self
-                .id
-                .evaluate(wsv, &Context::default())
-                .wrap_err("Failed to get asset definition id")
-                .map_err(|e| Error::Evaluate(e.to_string()))?;
+            let id = evaluate_with_error_msg!(self.id, wsv, "Failed to get asset definition id");
 
             let entry = wsv.asset_definition_entry(&id).map_err(Error::from)?;
 
@@ -502,11 +495,7 @@ pub mod query {
     impl ValidQuery for FindAssetsByName {
         #[metrics(+"find_assets_by_name")]
         fn execute(&self, wsv: &WorldStateView) -> Result<Self::Output, Error> {
-            let name = self
-                .name
-                .evaluate(wsv, &Context::default())
-                .wrap_err("Failed to get asset name")
-                .map_err(|e| Error::Evaluate(e.to_string()))?;
+            let name = evaluate_with_error_msg!(self.name, wsv, "Failed to get asset name");
             iroha_logger::trace!(%name);
             let mut vec = Vec::new();
             for domain in wsv.domains().iter() {
@@ -525,11 +514,7 @@ pub mod query {
     impl ValidQuery for FindAssetsByAccountId {
         #[metrics(+"find_assets_by_account_id")]
         fn execute(&self, wsv: &WorldStateView) -> Result<Self::Output, Error> {
-            let id = self
-                .account_id
-                .evaluate(wsv, &Context::default())
-                .wrap_err("Failed to get account id")
-                .map_err(|e| Error::Evaluate(e.to_string()))?;
+            let id = evaluate_with_error_msg!(self.account_id, wsv, "Failed to get account id");
             iroha_logger::trace!(%id);
             wsv.account_assets(&id).map_err(Into::into)
         }
@@ -538,11 +523,11 @@ pub mod query {
     impl ValidQuery for FindAssetsByAssetDefinitionId {
         #[metrics(+"find_assets_by_asset_definition_id")]
         fn execute(&self, wsv: &WorldStateView) -> Result<Self::Output, Error> {
-            let id = self
-                .asset_definition_id
-                .evaluate(wsv, &Context::default())
-                .wrap_err("Failed to get asset definition id")
-                .map_err(|e| Error::Evaluate(e.to_string()))?;
+            let id = evaluate_with_error_msg!(
+                self.asset_definition_id,
+                wsv,
+                "Failed to get asset definition id"
+            );
             iroha_logger::trace!(%id);
             let mut vec = Vec::new();
             for domain in wsv.domains().iter() {
@@ -561,11 +546,7 @@ pub mod query {
     impl ValidQuery for FindAssetsByDomainId {
         #[metrics(+"find_assets_by_domain_id")]
         fn execute(&self, wsv: &WorldStateView) -> Result<Self::Output, Error> {
-            let id = self
-                .domain_id
-                .evaluate(wsv, &Context::default())
-                .wrap_err("Failed to get domain id")
-                .map_err(|e| Error::Evaluate(e.to_string()))?;
+            let id = evaluate_with_error_msg!(self.domain_id, wsv, "Failed to get domain id");
             iroha_logger::trace!(%id);
             let mut vec = Vec::new();
             for account in wsv.domain(&id)?.accounts.values() {
@@ -580,16 +561,13 @@ pub mod query {
     impl ValidQuery for FindAssetsByDomainIdAndAssetDefinitionId {
         #[metrics(+"find_assets_by_domain_id_and_asset_definition_id")]
         fn execute(&self, wsv: &WorldStateView) -> Result<Self::Output, Error> {
-            let domain_id = self
-                .domain_id
-                .evaluate(wsv, &Context::default())
-                .wrap_err("Failed to get domain id")
-                .map_err(|e| Error::Evaluate(e.to_string()))?;
-            let asset_definition_id = self
-                .asset_definition_id
-                .evaluate(wsv, &Context::default())
-                .wrap_err("Failed to get asset definition id")
-                .map_err(|e| Error::Evaluate(e.to_string()))?;
+            let domain_id =
+                evaluate_with_error_msg!(self.domain_id, wsv, "Failed to get domain id");
+            let asset_definition_id = evaluate_with_error_msg!(
+                self.asset_definition_id,
+                wsv,
+                "Failed to get asset definition id"
+            );
             let domain = wsv.domain(&domain_id)?;
             let _definition = domain
                 .asset_definitions
@@ -613,11 +591,7 @@ pub mod query {
     impl ValidQuery for FindAssetQuantityById {
         #[metrics(+"find_asset_quantity_by_id")]
         fn execute(&self, wsv: &WorldStateView) -> Result<Self::Output, Error> {
-            let id = self
-                .id
-                .evaluate(wsv, &Context::default())
-                .wrap_err("Failed to get asset id")
-                .map_err(|e| Error::Evaluate(e.to_string()))?;
+            let id = evaluate_with_error_msg!(self.id, wsv, "Failed to get asset id");
             iroha_logger::trace!(%id);
             let value = wsv
                 .asset(&id)
@@ -638,11 +612,7 @@ pub mod query {
     impl ValidQuery for FindTotalAssetQuantityByAssetDefinitionId {
         #[metrics(+"find_total_asset_quantity_by_asset_definition_id")]
         fn execute(&self, wsv: &WorldStateView) -> Result<Self::Output, Error> {
-            let id = self
-                .id
-                .evaluate(wsv, &Context::default())
-                .wrap_err("Failed to get asset definition id")
-                .map_err(|e| Error::Evaluate(e.to_string()))?;
+            let id = evaluate_with_error_msg!(self.id, wsv, "Failed to get asset definition id");
             iroha_logger::trace!(%id);
             let asset_value = wsv.asset_total_amount(&id)?;
             Ok(asset_value)
@@ -652,16 +622,8 @@ pub mod query {
     impl ValidQuery for FindAssetKeyValueByIdAndKey {
         #[metrics(+"find_asset_key_value_by_id_and_key")]
         fn execute(&self, wsv: &WorldStateView) -> Result<Self::Output, Error> {
-            let id = self
-                .id
-                .evaluate(wsv, &Context::default())
-                .wrap_err("Failed to get asset id")
-                .map_err(|e| Error::Evaluate(e.to_string()))?;
-            let key = self
-                .key
-                .evaluate(wsv, &Context::default())
-                .wrap_err("Failed to get key")
-                .map_err(|e| Error::Evaluate(e.to_string()))?;
+            let id = evaluate_with_error_msg!(self.id, wsv, "Failed to get asset id");
+            let key = evaluate_with_error_msg!(self.key, wsv, "Failed to get key");
             let asset = wsv.asset(&id).map_err(|asset_err| {
                 if let Err(definition_err) = wsv.asset_definition_entry(&id.definition_id) {
                     Error::Find(Box::new(definition_err))
@@ -685,19 +647,29 @@ pub mod query {
     impl ValidQuery for IsAssetDefinitionOwner {
         #[metrics("is_asset_definition_owner")]
         fn execute(&self, wsv: &WorldStateView) -> Result<Self::Output, Error> {
-            let asset_definition_id = self
-                .asset_definition_id
-                .evaluate(wsv, &Context::default())
-                .wrap_err("Failed to get asset definition id")
-                .map_err(|e| Error::Evaluate(e.to_string()))?;
-            let account_id = self
-                .account_id
-                .evaluate(wsv, &Context::default())
-                .wrap_err("Failed to get account id")
-                .map_err(|e| Error::Evaluate(e.to_string()))?;
+            let asset_definition_id = evaluate_with_error_msg!(
+                self.asset_definition_id,
+                wsv,
+                "Failed to get asset definition id"
+            );
+            let account_id =
+                evaluate_with_error_msg!(self.account_id, wsv, "Failed to get account id");
 
             let entry = wsv.asset_definition_entry(&asset_definition_id)?;
             Ok(entry.owned_by() == &account_id)
+        }
+    }
+
+    impl ValidQuery for FindAssetRegisteringTransaction {
+        #[metrics(+"find_asset_registering_transaction")]
+        fn execute(&self, wsv: &WorldStateView) -> Result<Self::Output, Error> {
+            let asset_definition_id =
+                evaluate_with_error_msg!(self.id, wsv, "Failed to get asset definition id");
+            iroha_logger::trace!(%asset_definition_id);
+            let tx_hash = wsv
+                .asset_register_tx(&asset_definition_id)
+                .ok_or_else(|| FindError::AssetDefinition(asset_definition_id))?;
+            Ok(tx_hash)
         }
     }
 }

--- a/core/src/smartcontracts/isi/expression.rs
+++ b/core/src/smartcontracts/isi/expression.rs
@@ -506,7 +506,7 @@ mod tests {
     use parity_scale_codec::{DecodeAll, Encode};
 
     use super::*;
-    use crate::{kura::Kura, wsv::World};
+    use crate::{kura::Kura, queue::Queue, wsv::World};
 
     /// Example taken from [whitepaper](https://github.com/hyperledger/iroha/blob/iroha2-dev/docs/source/iroha_2_whitepaper.md#261-multisignature-transactions)
     #[test]
@@ -575,7 +575,8 @@ mod tests {
         )
         .build();
         let kura = Kura::blank_kura_for_testing();
-        let wsv = WorldStateView::new(World::new(), kura);
+        let queue = Queue::default_queue_for_testing();
+        let wsv = WorldStateView::new(World::new(), &queue, kura);
         assert_eq!(
             expression.evaluate(&wsv, &Context::new())?,
             Value::Bool(true)
@@ -636,6 +637,7 @@ mod tests {
     #[test]
     fn where_expression() -> Result<()> {
         let kura = Kura::blank_kura_for_testing();
+        let queue = Queue::default_queue_for_testing();
         assert_eq!(
             WhereBuilder::evaluate(EvaluatesTo::new_unchecked(
                 ContextValue::new(Name::from_str("test_value").expect("Can't fail.")).into()
@@ -645,7 +647,10 @@ mod tests {
                 EvaluatesTo::new_evaluates_to_value(Add::new(2_u32, 3_u32).into())
             )
             .build()
-            .evaluate(&WorldStateView::new(World::new(), kura), &Context::new())?,
+            .evaluate(
+                &WorldStateView::new(World::new(), &queue, kura),
+                &Context::new()
+            )?,
             5_u32.to_value()
         );
         Ok(())
@@ -672,8 +677,12 @@ mod tests {
             .build()
             .into();
         let kura = Kura::blank_kura_for_testing();
+        let queue = Queue::default_queue_for_testing();
         assert_eq!(
-            outer_expression.evaluate(&WorldStateView::new(World::new(), kura), &Context::new())?,
+            outer_expression.evaluate(
+                &WorldStateView::new(World::new(), &queue, kura),
+                &Context::new()
+            )?,
             6_u32.to_value()
         );
         Ok(())
@@ -699,7 +708,8 @@ mod tests {
     #[test]
     fn if_condition_branches_correctly() -> Result<()> {
         let kura = Kura::blank_kura_for_testing();
-        let wsv = WorldStateView::new(World::new(), kura);
+        let queue = Queue::default_queue_for_testing();
+        let wsv = WorldStateView::new(World::new(), &queue, kura);
         assert_eq!(
             IfExpression::new(true, 1_u32, 2_u32).evaluate(&wsv, &Context::new())?,
             1_u32.to_value()
@@ -720,7 +730,8 @@ mod tests {
             I::Value: Debug,
         {
             let kura = Kura::blank_kura_for_testing();
-            let wsv = WorldStateView::new(World::default(), kura);
+            let queue = Queue::default_queue_for_testing();
+            let wsv = WorldStateView::new(World::default(), &queue, kura);
             let result: Result<_, _> = inst.evaluate(&wsv, &Context::new());
             let _err = result.expect_err(err_msg);
         }
@@ -775,7 +786,8 @@ mod tests {
     #[test]
     fn operations_are_correctly_calculated() -> Result<()> {
         let kura = Kura::blank_kura_for_testing();
-        let wsv = WorldStateView::new(World::new(), kura);
+        let queue = Queue::default_queue_for_testing();
+        let wsv = WorldStateView::new(World::new(), &queue, kura);
         assert_eq!(
             Add::new(1_u32, 2_u32).evaluate(&wsv, &Context::new())?,
             3_u32.to_value()
@@ -857,7 +869,8 @@ mod tests {
         let deserialized_expression: ExpressionBox =
             serde_json::from_str(&serialized_expression).expect("Failed to de-serialize.");
         let kura = Kura::blank_kura_for_testing();
-        let wsv = WorldStateView::new(World::new(), kura);
+        let queue = Queue::default_queue_for_testing();
+        let wsv = WorldStateView::new(World::new(), &queue, kura);
         assert_eq!(
             expression
                 .evaluate(&wsv, &Context::new())
@@ -876,7 +889,8 @@ mod tests {
             ExpressionBox::decode_all(&mut serialized_expression.as_slice())
                 .expect("Failed to decode.");
         let kura = Kura::blank_kura_for_testing();
-        let wsv = WorldStateView::new(World::new(), kura);
+        let queue = Queue::default_queue_for_testing();
+        let wsv = WorldStateView::new(World::new(), &queue, kura);
         assert_eq!(
             expression
                 .evaluate(&wsv, &Context::new())

--- a/core/src/smartcontracts/isi/tx.rs
+++ b/core/src/smartcontracts/isi/tx.rs
@@ -3,15 +3,16 @@
 use eyre::{Result, WrapErr};
 use iroha_data_model::{
     prelude::*,
-    query::error::{FindError, QueryExecutionFailure},
+    query::error::{FindError, QueryExecutionFailure as Error},
 };
 use iroha_telemetry::metrics;
 
 use super::*;
+use crate::evaluate_with_error_msg;
 
 impl ValidQuery for FindAllTransactions {
     #[metrics(+"find_all_transactions")]
-    fn execute(&self, wsv: &WorldStateView) -> Result<Self::Output, QueryExecutionFailure> {
+    fn execute(&self, wsv: &WorldStateView) -> Result<Self::Output, Error> {
         let mut txs = wsv.transaction_values();
         txs.reverse();
         Ok(txs)
@@ -20,12 +21,8 @@ impl ValidQuery for FindAllTransactions {
 
 impl ValidQuery for FindTransactionsByAccountId {
     #[metrics(+"find_transactions_by_account_id")]
-    fn execute(&self, wsv: &WorldStateView) -> Result<Self::Output, QueryExecutionFailure> {
-        let id = self
-            .account_id
-            .evaluate(wsv, &Context::default())
-            .wrap_err("Failed to get account id")
-            .map_err(|e| QueryExecutionFailure::Evaluate(e.to_string()))?;
+    fn execute(&self, wsv: &WorldStateView) -> Result<Self::Output, Error> {
+        let id = evaluate_with_error_msg!(self.account_id, wsv, "Failed to get account id");
         iroha_logger::trace!(%id);
         Ok(wsv.transactions_values_by_account_id(&id))
     }
@@ -33,12 +30,8 @@ impl ValidQuery for FindTransactionsByAccountId {
 
 impl ValidQuery for FindTransactionByHash {
     #[metrics(+"find_transaction_by_hash")]
-    fn execute(&self, wsv: &WorldStateView) -> Result<Self::Output, QueryExecutionFailure> {
-        let hash = self
-            .hash
-            .evaluate(wsv, &Context::default())
-            .wrap_err("Failed to get hash")
-            .map_err(|e| QueryExecutionFailure::Evaluate(e.to_string()))?;
+    fn execute(&self, wsv: &WorldStateView) -> Result<Self::Output, Error> {
+        let hash = evaluate_with_error_msg!(self.hash, wsv, "Failed to get hash");
         iroha_logger::trace!(%hash);
         let hash = hash.typed();
         if !wsv.has_transaction(&hash) {

--- a/core/src/smartcontracts/wasm.rs
+++ b/core/src/smartcontracts/wasm.rs
@@ -864,7 +864,7 @@ mod tests {
     use iroha_crypto::KeyPair;
 
     use super::*;
-    use crate::{kura::Kura, PeersIds, World};
+    use crate::{kura::Kura, queue::Queue, PeersIds, World};
 
     fn world_with_test_account(account_id: AccountId) -> World {
         let domain_id = account_id.domain_id.clone();
@@ -919,7 +919,8 @@ mod tests {
     fn execute_instruction_exported() -> Result<(), Error> {
         let account_id = AccountId::from_str("alice@wonderland").expect("Valid");
         let kura = Kura::blank_kura_for_testing();
-        let wsv = WorldStateView::new(world_with_test_account(account_id.clone()), kura);
+        let queue = Queue::default_queue_for_testing();
+        let wsv = WorldStateView::new(world_with_test_account(account_id.clone()), &queue, kura);
 
         let isi_hex = {
             let new_account_id = AccountId::from_str("mad_hatter@wonderland").expect("Valid");
@@ -957,7 +958,8 @@ mod tests {
     fn execute_query_exported() -> Result<(), Error> {
         let account_id = AccountId::from_str("alice@wonderland").expect("Valid");
         let kura = Kura::blank_kura_for_testing();
-        let wsv = WorldStateView::new(world_with_test_account(account_id.clone()), kura);
+        let queue = Queue::default_queue_for_testing();
+        let wsv = WorldStateView::new(world_with_test_account(account_id.clone()), &queue, kura);
         let query_hex = encode_hex(QueryBox::from(FindAccountById::new(account_id.clone())));
 
         let wat = format!(
@@ -994,8 +996,9 @@ mod tests {
     fn instruction_limit_reached() -> Result<(), Error> {
         let account_id = AccountId::from_str("alice@wonderland").expect("Valid");
         let kura = Kura::blank_kura_for_testing();
+        let queue = Queue::default_queue_for_testing();
 
-        let wsv = WorldStateView::new(world_with_test_account(account_id.clone()), kura);
+        let wsv = WorldStateView::new(world_with_test_account(account_id.clone()), &queue, kura);
 
         let isi_hex = {
             let new_account_id = AccountId::from_str("mad_hatter@wonderland").expect("Valid");
@@ -1042,7 +1045,8 @@ mod tests {
     fn instructions_not_allowed() -> Result<(), Error> {
         let account_id = AccountId::from_str("alice@wonderland").expect("Valid");
         let kura = Kura::blank_kura_for_testing();
-        let wsv = WorldStateView::new(world_with_test_account(account_id.clone()), kura);
+        let queue = Queue::default_queue_for_testing();
+        let wsv = WorldStateView::new(world_with_test_account(account_id.clone()), &queue, kura);
 
         let isi_hex = {
             let new_account_id = AccountId::from_str("mad_hatter@wonderland").expect("Valid");
@@ -1089,7 +1093,8 @@ mod tests {
     fn queries_not_allowed() -> Result<(), Error> {
         let account_id = AccountId::from_str("alice@wonderland").expect("Valid");
         let kura = Kura::blank_kura_for_testing();
-        let wsv = WorldStateView::new(world_with_test_account(account_id.clone()), kura);
+        let queue = Queue::default_queue_for_testing();
+        let wsv = WorldStateView::new(world_with_test_account(account_id.clone()), &queue, kura);
         let query_hex = encode_hex(QueryBox::from(FindAccountById::new(account_id.clone())));
 
         let wat = format!(

--- a/data_model/src/query.rs
+++ b/data_model/src/query.rs
@@ -84,6 +84,8 @@ model! {
         FindAssetKeyValueByIdAndKey(FindAssetKeyValueByIdAndKey),
         /// [`FindAssetKeyValueByIdAndKey`] variant.
         FindAssetDefinitionKeyValueByIdAndKey(FindAssetDefinitionKeyValueByIdAndKey),
+        /// [`FindAssetRegisteringTransaction`] variant.
+        FindAssetRegisteringTransaction(FindAssetRegisteringTransaction),
         /// [`FindAllDomains`] variant.
         FindAllDomains(FindAllDomains),
         /// [`FindDomainById`] variant.
@@ -732,6 +734,24 @@ pub mod asset {
         type Output = bool;
     }
 
+    query! {
+        /// [`FindAssetRegisteringTransaction`] Iroha Query gets [`AssetDefinitionId`] as input and finds
+        /// [`Hash`] of the transaction that registered this asset.
+        #[derive(Display)]
+        #[display(fmt = "Find asset registering transaction of `{id}` asset")]
+        // SAFETY: `FindAssetRegisteringTransaction` has no trap representation in `EvaluatesTo<AssetDefinitionId>`
+        #[ffi_type(unsafe {robust})]
+        #[repr(transparent)]
+        pub struct FindAssetRegisteringTransaction {
+            /// `Id` of an [`AssetDefinition`] .
+            pub id: EvaluatesTo<AssetDefinitionId>,
+        }
+    }
+
+    impl Query for FindAssetRegisteringTransaction {
+        type Output = iroha_crypto::Hash;
+    }
+
     impl FindAssetById {
         /// Construct [`FindAssetById`].
         pub fn new(id: impl Into<EvaluatesTo<AssetId>>) -> Self {
@@ -843,13 +863,23 @@ pub mod asset {
         }
     }
 
+    impl FindAssetRegisteringTransaction {
+        /// Construct [`FindAssetRegisteringTransaction`].
+        pub fn new(asset_definition_id: impl Into<EvaluatesTo<AssetDefinitionId>>) -> Self {
+            Self {
+                id: asset_definition_id.into(),
+            }
+        }
+    }
+
     /// The prelude re-exports most commonly used traits, structs and macros from this crate.
     pub mod prelude {
         pub use super::{
             FindAllAssets, FindAllAssetsDefinitions, FindAssetById, FindAssetDefinitionById,
             FindAssetDefinitionKeyValueByIdAndKey, FindAssetKeyValueByIdAndKey,
-            FindAssetQuantityById, FindAssetsByAccountId, FindAssetsByAssetDefinitionId,
-            FindAssetsByDomainId, FindAssetsByDomainIdAndAssetDefinitionId, FindAssetsByName,
+            FindAssetQuantityById, FindAssetRegisteringTransaction, FindAssetsByAccountId,
+            FindAssetsByAssetDefinitionId, FindAssetsByDomainId,
+            FindAssetsByDomainIdAndAssetDefinitionId, FindAssetsByName,
             FindTotalAssetQuantityByAssetDefinitionId, IsAssetDefinitionOwner,
         };
     }

--- a/docs/source/references/schema.json
+++ b/docs/source/references/schema.json
@@ -4175,113 +4175,118 @@
           "ty": "iroha_data_model::query::asset::FindAssetDefinitionKeyValueByIdAndKey"
         },
         {
-          "name": "FindAllDomains",
+          "name": "FindAssetRegisteringTransaction",
           "discriminant": 20,
+          "ty": "iroha_data_model::query::asset::FindAssetRegisteringTransaction"
+        },
+        {
+          "name": "FindAllDomains",
+          "discriminant": 21,
           "ty": "iroha_data_model::query::domain::FindAllDomains"
         },
         {
           "name": "FindDomainById",
-          "discriminant": 21,
+          "discriminant": 22,
           "ty": "iroha_data_model::query::domain::FindDomainById"
         },
         {
           "name": "FindDomainKeyValueByIdAndKey",
-          "discriminant": 22,
+          "discriminant": 23,
           "ty": "iroha_data_model::query::domain::FindDomainKeyValueByIdAndKey"
         },
         {
           "name": "FindAllPeers",
-          "discriminant": 23,
+          "discriminant": 24,
           "ty": "iroha_data_model::query::peer::FindAllPeers"
         },
         {
           "name": "FindAllBlocks",
-          "discriminant": 24,
+          "discriminant": 25,
           "ty": "iroha_data_model::query::block::FindAllBlocks"
         },
         {
           "name": "FindAllBlockHeaders",
-          "discriminant": 25,
+          "discriminant": 26,
           "ty": "iroha_data_model::query::block::FindAllBlockHeaders"
         },
         {
           "name": "FindBlockHeaderByHash",
-          "discriminant": 26,
+          "discriminant": 27,
           "ty": "iroha_data_model::query::block::FindBlockHeaderByHash"
         },
         {
           "name": "FindAllTransactions",
-          "discriminant": 27,
+          "discriminant": 28,
           "ty": "iroha_data_model::query::transaction::FindAllTransactions"
         },
         {
           "name": "FindTransactionsByAccountId",
-          "discriminant": 28,
+          "discriminant": 29,
           "ty": "iroha_data_model::query::transaction::FindTransactionsByAccountId"
         },
         {
           "name": "FindTransactionByHash",
-          "discriminant": 29,
+          "discriminant": 30,
           "ty": "iroha_data_model::query::transaction::FindTransactionByHash"
         },
         {
           "name": "FindPermissionTokensByAccountId",
-          "discriminant": 30,
+          "discriminant": 31,
           "ty": "iroha_data_model::query::permissions::FindPermissionTokensByAccountId"
         },
         {
           "name": "FindAllPermissionTokenDefinitions",
-          "discriminant": 31,
+          "discriminant": 32,
           "ty": "iroha_data_model::query::permissions::FindAllPermissionTokenDefinitions"
         },
         {
           "name": "DoesAccountHavePermissionToken",
-          "discriminant": 32,
+          "discriminant": 33,
           "ty": "iroha_data_model::query::permissions::DoesAccountHavePermissionToken"
         },
         {
           "name": "FindAllActiveTriggerIds",
-          "discriminant": 33,
+          "discriminant": 34,
           "ty": "iroha_data_model::query::trigger::FindAllActiveTriggerIds"
         },
         {
           "name": "FindTriggerById",
-          "discriminant": 34,
+          "discriminant": 35,
           "ty": "iroha_data_model::query::trigger::FindTriggerById"
         },
         {
           "name": "FindTriggerKeyValueByIdAndKey",
-          "discriminant": 35,
+          "discriminant": 36,
           "ty": "iroha_data_model::query::trigger::FindTriggerKeyValueByIdAndKey"
         },
         {
           "name": "FindTriggersByDomainId",
-          "discriminant": 36,
+          "discriminant": 37,
           "ty": "iroha_data_model::query::trigger::FindTriggersByDomainId"
         },
         {
           "name": "FindAllRoles",
-          "discriminant": 37,
+          "discriminant": 38,
           "ty": "iroha_data_model::query::role::FindAllRoles"
         },
         {
           "name": "FindAllRoleIds",
-          "discriminant": 38,
+          "discriminant": 39,
           "ty": "iroha_data_model::query::role::FindAllRoleIds"
         },
         {
           "name": "FindRoleByRoleId",
-          "discriminant": 39,
+          "discriminant": 40,
           "ty": "iroha_data_model::query::role::FindRoleByRoleId"
         },
         {
           "name": "FindRolesByAccountId",
-          "discriminant": 40,
+          "discriminant": 41,
           "ty": "iroha_data_model::query::role::FindRolesByAccountId"
         },
         {
           "name": "FindAllParameters",
-          "discriminant": 41,
+          "discriminant": 42,
           "ty": "iroha_data_model::query::peer::FindAllParameters"
         }
       ]
@@ -4410,6 +4415,16 @@
         {
           "name": "id",
           "ty": "iroha_data_model::expression::EvaluatesTo<iroha_data_model::asset::Id>"
+        }
+      ]
+    }
+  },
+  "iroha_data_model::query::asset::FindAssetRegisteringTransaction": {
+    "Struct": {
+      "declarations": [
+        {
+          "name": "id",
+          "ty": "iroha_data_model::expression::EvaluatesTo<iroha_data_model::asset::DefinitionId>"
         }
       ]
     }

--- a/tools/parity_scale_decoder/src/generate_map.rs
+++ b/tools/parity_scale_decoder/src/generate_map.rs
@@ -166,6 +166,7 @@ pub fn generate_map() -> DumpDecodedMap {
         FindAssetDefinitionKeyValueByIdAndKey,
         FindAssetKeyValueByIdAndKey,
         FindAssetQuantityById,
+        FindAssetRegisteringTransaction,
         FindAssetsByAccountId,
         FindAssetsByAssetDefinitionId,
         FindAssetsByDomainId,


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
* Augmented `Account` with a dashmap storing asset registering transactions.
* New query to get those transactions.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Issue
Closes #2097.
<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits
Ease of use and querying for SDK developers.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
* Fatter `Account` structs.
* Concerns about event implications. Now (un)registering an asset emits two events instead of one, and e.g. using `FindError::Asset` to report failing to retrieve a value from the map might be not ideal semantically. 
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Alternate Designs
Does the `AssetDefinition` need the same functionality? I.e. do we want to augment `Domain` with the same kind of map?
<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
