### PR TITLE
refactor: Use `SystemTime` for timestamps

### DIFF
--- a/client/tests/integration/tx_history.rs
+++ b/client/tests/integration/tx_history.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr as _, thread};
+use std::{str::FromStr as _, thread, time::SystemTime};
 
 use eyre::Result;
 use iroha::{
@@ -60,7 +60,7 @@ fn client_has_rejected_and_acepted_txs_should_return_tx_history() -> Result<()> 
         .execute_all()?;
     assert_eq!(transactions.len(), 50);
 
-    let mut prev_creation_time = core::time::Duration::from_millis(0);
+    let mut prev_creation_time = SystemTime::UNIX_EPOCH;
     transactions
         .iter()
         .map(AsRef::as_ref)

--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -114,13 +114,13 @@ impl MetricsReporter {
 
         #[allow(clippy::cast_possible_truncation)]
         if let Some(timestamp) = state_view.genesis_timestamp() {
-            let curr_time = SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap();
+            let curr_time = SystemTime::now();
 
             // this will overflow in 584942417years.
             self.metrics.uptime_since_genesis_ms.set(
-                (curr_time - timestamp)
+                curr_time
+                    .duration_since(timestamp)
+                    .expect("Failed to get the current system time")
                     .as_millis()
                     .try_into()
                     .expect("Timestamp should fit into u64"),

--- a/core/src/queue.rs
+++ b/core/src/queue.rs
@@ -1,6 +1,6 @@
 //! Module with queue actor
 use core::time::Duration;
-use std::{num::NonZeroUsize, ops::Deref, sync::Arc};
+use std::{num::NonZeroUsize, ops::Deref, sync::Arc, time::SystemTime};
 
 use crossbeam_queue::ArrayQueue;
 use dashmap::{mapref::entry::Entry, DashMap};
@@ -133,8 +133,8 @@ impl Queue {
             |tx_time_to_live| core::cmp::min(self.tx_time_to_live, tx_time_to_live),
         );
 
-        let curr_time = self.time_source.get_unix_time();
-        curr_time.saturating_sub(tx_creation_time) > time_limit
+        let curr_time = SystemTime::UNIX_EPOCH + self.time_source.get_unix_time();
+        curr_time > tx_creation_time + time_limit
     }
 
     /// Returns all pending transactions.

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -1,6 +1,6 @@
 //! This module provides the [`State`] — an in-memory representation of the current blockchain state.
 use std::{
-    collections::BTreeSet, marker::PhantomData, num::NonZeroUsize, sync::Arc, time::Duration,
+    collections::BTreeSet, marker::PhantomData, num::NonZeroUsize, sync::Arc, time::SystemTime,
 };
 
 use eyre::Result;
@@ -1285,7 +1285,7 @@ pub trait StateReadOnly {
     /// Returns [`Some`] milliseconds since the genesis block was
     /// committed, or [`None`] if it wasn't.
     #[inline]
-    fn genesis_timestamp(&self) -> Option<Duration> {
+    fn genesis_timestamp(&self) -> Option<SystemTime> {
         if self.block_hashes().is_empty() {
             None
         } else {

--- a/core/src/tx.rs
+++ b/core/src/tx.rs
@@ -79,10 +79,8 @@ impl AcceptedTransaction {
             }));
         }
 
-        let now = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap();
-        if tx.creation_time().saturating_sub(now) > max_clock_drift {
+        let now = SystemTime::now();
+        if tx.creation_time() > now + max_clock_drift {
             return Err(AcceptTransactionFail::TransactionInTheFuture);
         }
 

--- a/data_model/benches/time_event_filter.rs
+++ b/data_model/benches/time_event_filter.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs)]
 
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use iroha_data_model::prelude::*;
@@ -12,14 +12,15 @@ fn schedule_from_zero_with_little_period(criterion: &mut Criterion) {
 
     const TIMESTAMP: u64 = 1_647_443_386;
 
-    let since = Duration::from_secs(TIMESTAMP);
+    let since = SystemTime::UNIX_EPOCH + Duration::from_secs(TIMESTAMP);
     let length = Duration::from_secs(1);
     let interval = TimeInterval::new(since, length);
     let event = TimeEvent {
         prev_interval: None,
         interval,
     };
-    let schedule = TimeSchedule::starting_at(Duration::ZERO).with_period(Duration::from_millis(1));
+    let schedule =
+        TimeSchedule::starting_at(SystemTime::UNIX_EPOCH).with_period(Duration::from_millis(1));
     let filter = TimeEventFilter::new(ExecutionTime::Schedule(schedule));
 
     criterion.bench_function("count_matches_from_zero", |b| {

--- a/data_model/src/block.rs
+++ b/data_model/src/block.rs
@@ -7,6 +7,8 @@
 #[cfg(not(feature = "std"))]
 use alloc::{boxed::Box, format, string::String, vec::Vec};
 use core::{fmt::Display, time::Duration};
+#[cfg(feature = "std")]
+use std::time::SystemTime;
 
 use derive_more::Display;
 use iroha_crypto::{HashOf, MerkleTree, SignatureOf};
@@ -133,8 +135,9 @@ impl BlockHeader {
     }
 
     /// Creation timestamp
-    pub const fn creation_time(&self) -> Duration {
-        Duration::from_millis(self.creation_time_ms)
+    #[cfg(feature = "std")]
+    pub fn creation_time(&self) -> SystemTime {
+        SystemTime::UNIX_EPOCH + Duration::from_millis(self.creation_time_ms)
     }
 
     /// Consensus estimation


### PR DESCRIPTION
## Context

Fixes #4729

### Solution

Use  `std::time::SystemTime` for time stamps instead of `std::time::Duration`.
* Note that `SystemTime` requires `std`, so it will not be available inside WASM.
* Alternatively `chrono::DateTime` might be used, but it will be more complex (in particular we will have to handle leap seconds), so I am not sure that it is worth it

### Migration Guide (optional)

### Review notes (optional)

### Checklist

- [ ] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.
