### PR TITLE
fix: Protect `BasicAuth::password` from being printed

### DIFF
--- a/crates/iroha/src/client.rs
+++ b/crates/iroha/src/client.rs
@@ -165,7 +165,11 @@ impl Client {
         mut headers: HashMap<String, String>,
     ) -> Self {
         if let Some(basic_auth) = basic_auth {
-            let credentials = format!("{}:{}", basic_auth.web_login, basic_auth.password);
+            let credentials = format!(
+                "{}:{}",
+                basic_auth.web_login,
+                basic_auth.password.expose_secret()
+            );
             let engine = base64::engine::general_purpose::STANDARD;
             let encoded = base64::engine::Engine::encode(&engine, credentials);
             headers.insert(String::from("Authorization"), format!("Basic {encoded}"));
@@ -974,11 +978,13 @@ mod blocks_api {
 
 #[cfg(test)]
 mod tests {
-    use iroha_primitives::small::SmallStr;
     use iroha_test_samples::gen_account_in;
 
     use super::*;
-    use crate::config::{BasicAuth, Config};
+    use crate::{
+        config::{BasicAuth, Config},
+        secrecy::SecretString,
+    };
 
     const LOGIN: &str = "mad_hatter";
     const PASSWORD: &str = "ilovetea";
@@ -1035,7 +1041,7 @@ mod tests {
         let client = Client::new(Config {
             basic_auth: Some(BasicAuth {
                 web_login: LOGIN.parse().expect("Failed to create valid `WebLogin`"),
-                password: SmallStr::from_str(PASSWORD),
+                password: SecretString::new(PASSWORD.to_owned()),
             }),
             ..config_factory()
         });

--- a/crates/iroha/src/config.rs
+++ b/crates/iroha/src/config.rs
@@ -21,6 +21,8 @@ mod user;
 
 pub use user::Root as UserConfig;
 
+use crate::secrecy::SecretString;
+
 #[allow(missing_docs)]
 pub const DEFAULT_TRANSACTION_TIME_TO_LIVE: Duration = Duration::from_secs(100);
 #[allow(missing_docs)]
@@ -49,12 +51,12 @@ impl FromStr for WebLogin {
 }
 
 /// Basic Authentication credentials
-#[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct BasicAuth {
     /// Login for Basic Authentication
     pub web_login: WebLogin,
     /// Password for Basic Authentication
-    pub password: SmallStr,
+    pub password: SecretString,
 }
 
 /// Complete client configuration

--- a/crates/iroha/src/lib.rs
+++ b/crates/iroha/src/lib.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod http;
 mod http_default;
 pub mod query;
+mod secrecy;
 
 pub use iroha_crypto as crypto;
 pub use iroha_data_model as data_model;

--- a/crates/iroha/src/secrecy.rs
+++ b/crates/iroha/src/secrecy.rs
@@ -1,0 +1,27 @@
+use std::fmt;
+
+use derive_more::Constructor;
+use serde::{Deserialize, Serialize, Serializer};
+
+#[derive(Clone, Deserialize, Constructor)]
+pub struct SecretString(String);
+
+impl SecretString {
+    pub fn expose_secret(&self) -> &str {
+        &self.0
+    }
+}
+
+const REDACTED: &'static str = "[REDACTED]";
+
+impl Serialize for SecretString {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        REDACTED.serialize(serializer)
+    }
+}
+
+impl fmt::Debug for SecretString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        REDACTED.fmt(f)
+    }
+}


### PR DESCRIPTION
## Context

Fixes #5182

### Checklist

- [ ] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.
- [ ] All CI checks pass.
