### PR TITLE
fix: test environments inherit and modify local `genesis.json`

### DIFF
--- a/crates/iroha_genesis/src/lib.rs
+++ b/crates/iroha_genesis/src/lib.rs
@@ -433,7 +433,7 @@ impl TryFrom<WasmPath> for WasmSmartContract {
 impl WasmPath {
     /// Resolve `self` to `here/self`,
     /// assuming `self` is an unresolved relative path to `here`.
-    /// Must be applied once.
+    /// In case `self` is absolute, it replaces `here` i.e. this method mutates nothing.
     fn resolve(&mut self, here: impl AsRef<Path>) {
         self.0 = here.as_ref().join(&self.0)
     }

--- a/crates/iroha_swarm/src/lib.rs
+++ b/crates/iroha_swarm/src/lib.rs
@@ -196,14 +196,20 @@ mod tests {
                 - 1337:1337
                 - 8080:8080
                 volumes:
+                - ./genesis.json:/config/genesis.json:ro
                 - ./client.toml:/config/client.toml:ro
                 init: true
                 command: |-
                   /bin/bash -c "
-                      kagami genesis generate --executor ../config/executor.wasm --wasm-dir ../config/libs --genesis-public-key $$GENESIS_PUBLIC_KEY > /tmp/genesis.default.json
+                      EXECUTOR_RELATIVE_PATH=$(jq -r '.executor' /config/genesis.json) && \\
+                      EXECUTOR_ABSOLUTE_PATH=$(realpath \"/config/$$EXECUTOR_RELATIVE_PATH\") && \\
+                      WASM_DIR_RELATIVE_PATH=$(jq -r '.wasm_dir' /config/genesis.json) && \\
+                      WASM_DIR_ABSOLUTE_PATH=$(realpath \"/config/$$WASM_DIR_RELATIVE_PATH\") && \\
                       jq \\
+                          --arg executor \"$$EXECUTOR_ABSOLUTE_PATH\" \\
+                          --arg wasm_dir \"$$WASM_DIR_ABSOLUTE_PATH\" \\
                           --argjson topology \"$$TOPOLOGY\" \\
-                          '.topology = $$topology' /tmp/genesis.default.json \\
+                          '.executor = $$executor | .wasm_dir = $$wasm_dir | .topology = $$topology' /config/genesis.json \\
                           >/tmp/genesis.json && \\
                       kagami genesis sign /tmp/genesis.json \\
                           --public-key $$GENESIS_PUBLIC_KEY \\
@@ -246,14 +252,20 @@ mod tests {
                 - 1337:1337
                 - 8080:8080
                 volumes:
+                - ./genesis.json:/config/genesis.json:ro
                 - ./client.toml:/config/client.toml:ro
                 init: true
                 command: |-
                   /bin/bash -c "
-                      kagami genesis generate --executor ../config/executor.wasm --wasm-dir ../config/libs --genesis-public-key $$GENESIS_PUBLIC_KEY > /tmp/genesis.default.json
+                      EXECUTOR_RELATIVE_PATH=$(jq -r '.executor' /config/genesis.json) && \\
+                      EXECUTOR_ABSOLUTE_PATH=$(realpath \"/config/$$EXECUTOR_RELATIVE_PATH\") && \\
+                      WASM_DIR_RELATIVE_PATH=$(jq -r '.wasm_dir' /config/genesis.json) && \\
+                      WASM_DIR_ABSOLUTE_PATH=$(realpath \"/config/$$WASM_DIR_RELATIVE_PATH\") && \\
                       jq \\
+                          --arg executor \"$$EXECUTOR_ABSOLUTE_PATH\" \\
+                          --arg wasm_dir \"$$WASM_DIR_ABSOLUTE_PATH\" \\
                           --argjson topology \"$$TOPOLOGY\" \\
-                          '.topology = $$topology' /tmp/genesis.default.json \\
+                          '.executor = $$executor | .wasm_dir = $$wasm_dir | .topology = $$topology' /config/genesis.json \\
                           >/tmp/genesis.json && \\
                       kagami genesis sign /tmp/genesis.json \\
                           --public-key $$GENESIS_PUBLIC_KEY \\
@@ -296,14 +308,20 @@ mod tests {
                 - 1337:1337
                 - 8080:8080
                 volumes:
+                - ./genesis.json:/config/genesis.json:ro
                 - ./client.toml:/config/client.toml:ro
                 init: true
                 command: |-
                   /bin/bash -c "
-                      kagami genesis generate --executor ../config/executor.wasm --wasm-dir ../config/libs --genesis-public-key $$GENESIS_PUBLIC_KEY > /tmp/genesis.default.json
+                      EXECUTOR_RELATIVE_PATH=$(jq -r '.executor' /config/genesis.json) && \\
+                      EXECUTOR_ABSOLUTE_PATH=$(realpath \"/config/$$EXECUTOR_RELATIVE_PATH\") && \\
+                      WASM_DIR_RELATIVE_PATH=$(jq -r '.wasm_dir' /config/genesis.json) && \\
+                      WASM_DIR_ABSOLUTE_PATH=$(realpath \"/config/$$WASM_DIR_RELATIVE_PATH\") && \\
                       jq \\
+                          --arg executor \"$$EXECUTOR_ABSOLUTE_PATH\" \\
+                          --arg wasm_dir \"$$WASM_DIR_ABSOLUTE_PATH\" \\
                           --argjson topology \"$$TOPOLOGY\" \\
-                          '.topology = $$topology' /tmp/genesis.default.json \\
+                          '.executor = $$executor | .wasm_dir = $$wasm_dir | .topology = $$topology' /config/genesis.json \\
                           >/tmp/genesis.json && \\
                       kagami genesis sign /tmp/genesis.json \\
                           --public-key $$GENESIS_PUBLIC_KEY \\
@@ -329,6 +347,7 @@ mod tests {
                 - 1338:1338
                 - 8081:8081
                 volumes:
+                - ./genesis.json:/config/genesis.json:ro
                 - ./client.toml:/config/client.toml:ro
                 init: true
               irohad2:
@@ -348,6 +367,7 @@ mod tests {
                 - 1339:1339
                 - 8082:8082
                 volumes:
+                - ./genesis.json:/config/genesis.json:ro
                 - ./client.toml:/config/client.toml:ro
                 init: true
               irohad3:
@@ -367,6 +387,7 @@ mod tests {
                 - 1340:1340
                 - 8083:8083
                 volumes:
+                - ./genesis.json:/config/genesis.json:ro
                 - ./client.toml:/config/client.toml:ro
                 init: true
         "##]).assert_eq(&build_as_string(
@@ -398,6 +419,7 @@ mod tests {
                 - 1337:1337
                 - 8080:8080
                 volumes:
+                - ./genesis.json:/config/genesis.json:ro
                 - ./client.toml:/config/client.toml:ro
                 init: true
                 healthcheck:
@@ -408,10 +430,15 @@ mod tests {
                   start_period: 4s
                 command: |-
                   /bin/bash -c "
-                      kagami genesis generate --executor ../config/executor.wasm --wasm-dir ../config/libs --genesis-public-key $$GENESIS_PUBLIC_KEY > /tmp/genesis.default.json
+                      EXECUTOR_RELATIVE_PATH=$(jq -r '.executor' /config/genesis.json) && \\
+                      EXECUTOR_ABSOLUTE_PATH=$(realpath \"/config/$$EXECUTOR_RELATIVE_PATH\") && \\
+                      WASM_DIR_RELATIVE_PATH=$(jq -r '.wasm_dir' /config/genesis.json) && \\
+                      WASM_DIR_ABSOLUTE_PATH=$(realpath \"/config/$$WASM_DIR_RELATIVE_PATH\") && \\
                       jq \\
+                          --arg executor \"$$EXECUTOR_ABSOLUTE_PATH\" \\
+                          --arg wasm_dir \"$$WASM_DIR_ABSOLUTE_PATH\" \\
                           --argjson topology \"$$TOPOLOGY\" \\
-                          '.topology = $$topology' /tmp/genesis.default.json \\
+                          '.executor = $$executor | .wasm_dir = $$wasm_dir | .topology = $$topology' /config/genesis.json \\
                           >/tmp/genesis.json && \\
                       kagami genesis sign /tmp/genesis.json \\
                           --public-key $$GENESIS_PUBLIC_KEY \\
@@ -451,6 +478,7 @@ mod tests {
                 - 1337:1337
                 - 8080:8080
                 volumes:
+                - ./genesis.json:/config/genesis.json:ro
                 - ./client.toml:/config/client.toml:ro
                 init: true
                 healthcheck:
@@ -461,10 +489,15 @@ mod tests {
                   start_period: 4s
                 command: |-
                   /bin/bash -c "
-                      kagami genesis generate --executor ../config/executor.wasm --wasm-dir ../config/libs --genesis-public-key $$GENESIS_PUBLIC_KEY > /tmp/genesis.default.json
+                      EXECUTOR_RELATIVE_PATH=$(jq -r '.executor' /config/genesis.json) && \\
+                      EXECUTOR_ABSOLUTE_PATH=$(realpath \"/config/$$EXECUTOR_RELATIVE_PATH\") && \\
+                      WASM_DIR_RELATIVE_PATH=$(jq -r '.wasm_dir' /config/genesis.json) && \\
+                      WASM_DIR_ABSOLUTE_PATH=$(realpath \"/config/$$WASM_DIR_RELATIVE_PATH\") && \\
                       jq \\
+                          --arg executor \"$$EXECUTOR_ABSOLUTE_PATH\" \\
+                          --arg wasm_dir \"$$WASM_DIR_ABSOLUTE_PATH\" \\
                           --argjson topology \"$$TOPOLOGY\" \\
-                          '.topology = $$topology' /tmp/genesis.default.json \\
+                          '.executor = $$executor | .wasm_dir = $$wasm_dir | .topology = $$topology' /config/genesis.json \\
                           >/tmp/genesis.json && \\
                       kagami genesis sign /tmp/genesis.json \\
                           --public-key $$GENESIS_PUBLIC_KEY \\
@@ -488,6 +521,7 @@ mod tests {
                 - 1338:1338
                 - 8081:8081
                 volumes:
+                - ./genesis.json:/config/genesis.json:ro
                 - ./client.toml:/config/client.toml:ro
                 init: true
                 healthcheck:
@@ -511,6 +545,7 @@ mod tests {
                 - 1339:1339
                 - 8082:8082
                 volumes:
+                - ./genesis.json:/config/genesis.json:ro
                 - ./client.toml:/config/client.toml:ro
                 init: true
                 healthcheck:
@@ -534,6 +569,7 @@ mod tests {
                 - 1340:1340
                 - 8083:8083
                 volumes:
+                - ./genesis.json:/config/genesis.json:ro
                 - ./client.toml:/config/client.toml:ro
                 init: true
                 healthcheck:

--- a/crates/iroha_swarm/src/schema.rs
+++ b/crates/iroha_swarm/src/schema.rs
@@ -243,12 +243,14 @@ impl std::fmt::Display for ContainerFile<'_> {
     }
 }
 
+const GENESIS_FILE: Filename = Filename("genesis.json");
 const CONFIG_FILE: Filename = Filename("client.toml");
 const GENESIS_SIGNED_SCALE: Filename = Filename("genesis.signed.scale");
 
 const CONTAINER_CONFIG_DIR: ContainerPath = ContainerPath("/config/");
 const CONTAINER_TMP_DIR: ContainerPath = ContainerPath("/tmp/");
 
+const CONTAINER_GENESIS_CONFIG: ContainerFile = ContainerFile(CONTAINER_CONFIG_DIR, GENESIS_FILE);
 const CONTAINER_CLIENT_CONFIG: ContainerFile = ContainerFile(CONTAINER_CONFIG_DIR, CONFIG_FILE);
 const CONTAINER_SIGNED_GENESIS: ContainerFile =
     ContainerFile(CONTAINER_TMP_DIR, GENESIS_SIGNED_SCALE);
@@ -261,7 +263,7 @@ struct ReadOnly;
 struct PathMapping<'a>(HostFile<'a>, ContainerFile<'a>, ReadOnly);
 
 /// Mapping between host and container paths.
-type Volumes<'a> = [PathMapping<'a>; 1];
+type Volumes<'a> = [PathMapping<'a>; 2];
 
 /// Healthcheck parameters.
 #[derive(Debug)]
@@ -326,10 +328,15 @@ where
 struct SignAndSubmitGenesis;
 
 const SIGN_AND_SUBMIT_GENESIS: &str = r#"/bin/bash -c "
-    kagami genesis generate --executor ../config/executor.wasm --wasm-dir ../config/libs --genesis-public-key $$GENESIS_PUBLIC_KEY > /tmp/genesis.default.json
+    EXECUTOR_RELATIVE_PATH=$(jq -r '.executor' /config/genesis.json) && \\
+    EXECUTOR_ABSOLUTE_PATH=$(realpath \"/config/$$EXECUTOR_RELATIVE_PATH\") && \\
+    WASM_DIR_RELATIVE_PATH=$(jq -r '.wasm_dir' /config/genesis.json) && \\
+    WASM_DIR_ABSOLUTE_PATH=$(realpath \"/config/$$WASM_DIR_RELATIVE_PATH\") && \\
     jq \\
+        --arg executor \"$$EXECUTOR_ABSOLUTE_PATH\" \\
+        --arg wasm_dir \"$$WASM_DIR_ABSOLUTE_PATH\" \\
         --argjson topology \"$$TOPOLOGY\" \\
-        '.topology = $$topology' /tmp/genesis.default.json \\
+        '.executor = $$executor | .wasm_dir = $$wasm_dir | .topology = $$topology' /config/genesis.json \\
         >/tmp/genesis.json && \\
     kagami genesis sign /tmp/genesis.json \\
         --public-key $$GENESIS_PUBLIC_KEY \\
@@ -528,11 +535,18 @@ impl<'a> DockerCompose<'a> {
         }: &'a PeerSettings,
     ) -> Self {
         let image = ImageId(name);
-        let volumes = [PathMapping(
-            HostFile(config_dir, CONFIG_FILE),
-            CONTAINER_CLIENT_CONFIG,
-            ReadOnly,
-        )];
+        let volumes = [
+            PathMapping(
+                HostFile(config_dir, GENESIS_FILE),
+                CONTAINER_GENESIS_CONFIG,
+                ReadOnly,
+            ),
+            PathMapping(
+                HostFile(config_dir, CONFIG_FILE),
+                CONTAINER_CLIENT_CONFIG,
+                ReadOnly,
+            ),
+        ];
         Self {
             services: build_dir.as_ref().map_or_else(
                 || {

--- a/defaults/docker-compose.local.yml
+++ b/defaults/docker-compose.local.yml
@@ -22,6 +22,7 @@ services:
     - 1337:1337
     - 8080:8080
     volumes:
+    - ./genesis.json:/config/genesis.json:ro
     - ./client.toml:/config/client.toml:ro
     init: true
     healthcheck:
@@ -32,10 +33,15 @@ services:
       start_period: 4s
     command: |-
       /bin/bash -c "
-          kagami genesis generate --executor ../config/executor.wasm --wasm-dir ../config/libs --genesis-public-key $$GENESIS_PUBLIC_KEY > /tmp/genesis.default.json
+          EXECUTOR_RELATIVE_PATH=$(jq -r '.executor' /config/genesis.json) && \\
+          EXECUTOR_ABSOLUTE_PATH=$(realpath \"/config/$$EXECUTOR_RELATIVE_PATH\") && \\
+          WASM_DIR_RELATIVE_PATH=$(jq -r '.wasm_dir' /config/genesis.json) && \\
+          WASM_DIR_ABSOLUTE_PATH=$(realpath \"/config/$$WASM_DIR_RELATIVE_PATH\") && \\
           jq \\
+              --arg executor \"$$EXECUTOR_ABSOLUTE_PATH\" \\
+              --arg wasm_dir \"$$WASM_DIR_ABSOLUTE_PATH\" \\
               --argjson topology \"$$TOPOLOGY\" \\
-              '.topology = $$topology' /tmp/genesis.default.json \\
+              '.executor = $$executor | .wasm_dir = $$wasm_dir | .topology = $$topology' /config/genesis.json \\
               >/tmp/genesis.json && \\
           kagami genesis sign /tmp/genesis.json \\
               --public-key $$GENESIS_PUBLIC_KEY \\
@@ -61,6 +67,7 @@ services:
     - 1338:1338
     - 8081:8081
     volumes:
+    - ./genesis.json:/config/genesis.json:ro
     - ./client.toml:/config/client.toml:ro
     init: true
     healthcheck:
@@ -86,6 +93,7 @@ services:
     - 1339:1339
     - 8082:8082
     volumes:
+    - ./genesis.json:/config/genesis.json:ro
     - ./client.toml:/config/client.toml:ro
     init: true
     healthcheck:
@@ -111,6 +119,7 @@ services:
     - 1340:1340
     - 8083:8083
     volumes:
+    - ./genesis.json:/config/genesis.json:ro
     - ./client.toml:/config/client.toml:ro
     init: true
     healthcheck:

--- a/defaults/docker-compose.single.yml
+++ b/defaults/docker-compose.single.yml
@@ -21,6 +21,7 @@ services:
     - 1337:1337
     - 8080:8080
     volumes:
+    - ./genesis.json:/config/genesis.json:ro
     - ./client.toml:/config/client.toml:ro
     init: true
     healthcheck:
@@ -31,10 +32,15 @@ services:
       start_period: 4s
     command: |-
       /bin/bash -c "
-          kagami genesis generate --executor ../config/executor.wasm --wasm-dir ../config/libs --genesis-public-key $$GENESIS_PUBLIC_KEY > /tmp/genesis.default.json
+          EXECUTOR_RELATIVE_PATH=$(jq -r '.executor' /config/genesis.json) && \\
+          EXECUTOR_ABSOLUTE_PATH=$(realpath \"/config/$$EXECUTOR_RELATIVE_PATH\") && \\
+          WASM_DIR_RELATIVE_PATH=$(jq -r '.wasm_dir' /config/genesis.json) && \\
+          WASM_DIR_ABSOLUTE_PATH=$(realpath \"/config/$$WASM_DIR_RELATIVE_PATH\") && \\
           jq \\
+              --arg executor \"$$EXECUTOR_ABSOLUTE_PATH\" \\
+              --arg wasm_dir \"$$WASM_DIR_ABSOLUTE_PATH\" \\
               --argjson topology \"$$TOPOLOGY\" \\
-              '.topology = $$topology' /tmp/genesis.default.json \\
+              '.executor = $$executor | .wasm_dir = $$wasm_dir | .topology = $$topology' /config/genesis.json \\
               >/tmp/genesis.json && \\
           kagami genesis sign /tmp/genesis.json \\
               --public-key $$GENESIS_PUBLIC_KEY \\

--- a/defaults/docker-compose.yml
+++ b/defaults/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     - 1337:1337
     - 8080:8080
     volumes:
+    - ./genesis.json:/config/genesis.json:ro
     - ./client.toml:/config/client.toml:ro
     init: true
     healthcheck:
@@ -30,10 +31,15 @@ services:
       start_period: 4s
     command: |-
       /bin/bash -c "
-          kagami genesis generate --executor ../config/executor.wasm --wasm-dir ../config/libs --genesis-public-key $$GENESIS_PUBLIC_KEY > /tmp/genesis.default.json
+          EXECUTOR_RELATIVE_PATH=$(jq -r '.executor' /config/genesis.json) && \\
+          EXECUTOR_ABSOLUTE_PATH=$(realpath \"/config/$$EXECUTOR_RELATIVE_PATH\") && \\
+          WASM_DIR_RELATIVE_PATH=$(jq -r '.wasm_dir' /config/genesis.json) && \\
+          WASM_DIR_ABSOLUTE_PATH=$(realpath \"/config/$$WASM_DIR_RELATIVE_PATH\") && \\
           jq \\
+              --arg executor \"$$EXECUTOR_ABSOLUTE_PATH\" \\
+              --arg wasm_dir \"$$WASM_DIR_ABSOLUTE_PATH\" \\
               --argjson topology \"$$TOPOLOGY\" \\
-              '.topology = $$topology' /tmp/genesis.default.json \\
+              '.executor = $$executor | .wasm_dir = $$wasm_dir | .topology = $$topology' /config/genesis.json \\
               >/tmp/genesis.json && \\
           kagami genesis sign /tmp/genesis.json \\
               --public-key $$GENESIS_PUBLIC_KEY \\
@@ -56,6 +62,7 @@ services:
     - 1338:1338
     - 8081:8081
     volumes:
+    - ./genesis.json:/config/genesis.json:ro
     - ./client.toml:/config/client.toml:ro
     init: true
     healthcheck:
@@ -78,6 +85,7 @@ services:
     - 1339:1339
     - 8082:8082
     volumes:
+    - ./genesis.json:/config/genesis.json:ro
     - ./client.toml:/config/client.toml:ro
     init: true
     healthcheck:
@@ -100,6 +108,7 @@ services:
     - 1340:1340
     - 8083:8083
     volumes:
+    - ./genesis.json:/config/genesis.json:ro
     - ./client.toml:/config/client.toml:ro
     init: true
     healthcheck:

--- a/scripts/build_wasm.sh
+++ b/scripts/build_wasm.sh
@@ -2,8 +2,8 @@
 set -e;
 
 DEFAULTS_DIR="defaults"
-CRATES_DIR="wasm"
-TARGET_DIR="wasm/target/prebuilt"
+CARGO_DIR="wasm"
+TARGET_DIR="$CARGO_DIR/target/prebuilt"
 
 build() {
     case $1 in
@@ -18,7 +18,7 @@ build() {
             ;;
         "samples")
             NAMES=($(
-                cargo metadata --no-deps --manifest-path "$CRATES_DIR/Cargo.toml" --format-version=1 |
+                cargo metadata --no-deps --manifest-path "$CARGO_DIR/Cargo.toml" --format-version=1 |
                 jq '.packages | map(select(.targets[].kind | contains(["cdylib"]))) | map(.manifest_path | split("/")) | map(select(.[-3] == "samples")) | map(.[-2]) | .[]' -r
             ))
     esac
@@ -26,7 +26,7 @@ build() {
     mkdir -p "$TARGET_DIR/$1"
     for name in ${NAMES[@]}; do
         out_file="$TARGET_DIR/$1/$name.wasm"
-        cargo run --bin iroha_wasm_builder -- build "$CRATES_DIR/$1/$name" --optimize --out-file "$out_file"
+        cargo run --bin iroha_wasm_builder -- build "$CARGO_DIR/$1/$name" --optimize --out-file "$out_file"
     done
     echo "info: WASM $1 build complete"
     echo "artifacts written to $TARGET_DIR/$1/"


### PR DESCRIPTION
## Context

#5027 made test environments generate `genesis.json` by themselves, which took away the means to reflect local `genesis.json` changes to the test environments

### Solution

Partially revert #5027 for `docker compose` and `test_env.py` to inherit and modify local `genesis.json`

---

### Review notes

- `executor` `wasm_dir` paths are resolved at the modified `genesis.json`. They aren't affected by the second resolution in `RawGenesisTransaction::from_path` during `kagami genesis sign`

### Checklist

- [x] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] All review comments have been resolved.
- [x] All CI checks pass.
