### PR TITLE
ci: enable doc tests

### DIFF
--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -113,8 +113,18 @@ jobs:
           mold --run cargo llvm-cov nextest
           --all-features
           --branch --no-report
+      - name: Doc test with no default features
+        run: >
+          mold --run cargo llvm-cov --doc
+          --no-default-features
+          --branch --no-report
+      - name: Doc test with all features
+        run: >
+          mold --run cargo llvm-cov --doc
+          --all-features
+          --branch --no-report
       - name: Generate lcov report
-        run: cargo llvm-cov report --lcov --output-path lcov.info
+        run: cargo llvm-cov report --doctests --lcov --output-path lcov.info
       - name: Upload lcov report
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -113,11 +113,6 @@ jobs:
           mold --run cargo llvm-cov nextest
           --all-features
           --branch --no-report
-      - name: Doc test with no default features
-        run: >
-          mold --run cargo llvm-cov --doc
-          --no-default-features
-          --branch --no-report
       - name: Doc test with all features
         run: >
           mold --run cargo llvm-cov --doc


### PR DESCRIPTION
## Context

Doc tests are disabled by default [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov?tab=readme-ov-file#known-limitations)

### Solution

Enable it

### Checklist

- [x] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] All review comments have been resolved.
- [x] All CI checks pass.
