### PR TITLE
fix: Fix running tests for individual crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ dashmap = "5.5.3"
 rustc-hash = "1.1.0"
 
 serde = { version = "1.0.204", default-features = false }
-serde_json = { version = "1.0.121", default-features = false }
+serde_json = { version = "1.0.121", default-features = false, features = ["alloc"] }
 serde_with = { version = "3.9.0", default-features = false }
 parity-scale-codec = { version = "3.6.12", default-features = false }
 json5 = "0.4.1"

--- a/crates/iroha/tests/queries/mod.rs
+++ b/crates/iroha/tests/queries/mod.rs
@@ -41,9 +41,9 @@ fn find_blocks_reversed() -> eyre::Result<()> {
 
     let blocks = client.query(FindBlocks).execute_all()?;
     assert_eq!(blocks.len(), 2);
-    assert_eq!(blocks[1].header().prev_block_hash, None);
+    assert_eq!(blocks[1].header().prev_block_hash(), None);
     assert_eq!(
-        blocks[0].header().prev_block_hash,
+        blocks[0].header().prev_block_hash(),
         Some(blocks[1].header().hash())
     );
 

--- a/crates/iroha_cli/src/main.rs
+++ b/crates/iroha_cli/src/main.rs
@@ -1260,7 +1260,7 @@ mod multisig {
                 .parse()
                 .unwrap();
             let args = MultisigAccountArgs {
-                account: account.signatory.clone(),
+                account: account.signatory().clone(),
                 signatories: signatories.into_iter().zip(weights).collect(),
                 quorum,
                 transaction_ttl_ms: transaction_ttl
@@ -1377,7 +1377,7 @@ mod multisig {
 
         for role_id in multisig_roles {
             let super_account: AccountId = role_id
-                .name
+                .name()
                 .as_ref()
                 .strip_prefix("multisig_signatory_")
                 .unwrap()
@@ -1388,7 +1388,7 @@ mod multisig {
             trace_back_from(super_account, client, context)?;
 
             let transactions_registry_id: TriggerId = role_id
-                .name
+                .name()
                 .as_ref()
                 .replace("signatory", "transactions")
                 .parse()

--- a/crates/iroha_config/Cargo.toml
+++ b/crates/iroha_config/Cargo.toml
@@ -13,8 +13,8 @@ workspace = true
 [dependencies]
 iroha_config_base = { workspace = true }
 iroha_data_model = { workspace = true }
-iroha_primitives = { workspace = true }
-iroha_crypto = { workspace = true }
+iroha_primitives = { workspace = true, features = ["std"] }
+iroha_crypto = { workspace = true, features = ["std"] }
 
 error-stack = { workspace = true }
 tracing = { workspace = true }
@@ -23,7 +23,7 @@ url = { workspace = true, features = ["serde"] }
 
 serde = { workspace = true, features = ["derive"] }
 serde_with = { workspace = true }
-strum = { workspace = true, features = ["derive"] }
+strum = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true }
 json5 = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/iroha_numeric/Cargo.toml
+++ b/crates/iroha_numeric/Cargo.toml
@@ -40,4 +40,4 @@ displaydoc = { workspace = true }
 rust_decimal = { version = "1.35", default-features = false, features = ["serde", "serde-with-str"] }
 
 [dev-dependencies]
-serde_json = { workspace = true, features = ["alloc"] }
+serde_json = { workspace = true }

--- a/crates/iroha_primitives/Cargo.toml
+++ b/crates/iroha_primitives/Cargo.toml
@@ -47,5 +47,4 @@ serde_json = { workspace = true }
 
 
 [dev-dependencies]
-serde_json = { workspace = true, features = ["alloc"] }
 trybuild = { workspace = true }

--- a/crates/iroha_schema/Cargo.toml
+++ b/crates/iroha_schema/Cargo.toml
@@ -17,5 +17,5 @@ serde = { workspace = true, features = ["derive", "alloc"] }
 
 [dev-dependencies]
 parity-scale-codec = { workspace = true, default-features = false, features = ["derive", "full"] }
-serde_json = { workspace = true, features = ["alloc"] }
+serde_json = { workspace = true }
 impls = { workspace = true }

--- a/crates/iroha_version/Cargo.toml
+++ b/crates/iroha_version/Cargo.toml
@@ -28,7 +28,7 @@ iroha_version_derive = { path = "../iroha_version_derive", default-features = fa
 iroha_macro = { workspace = true }
 
 parity-scale-codec = { workspace = true, optional = true, features = ["derive"] }
-serde_json = { workspace = true, optional = true, features = ["alloc"] }
+serde_json = { workspace = true, optional = true }
 serde = { workspace = true, optional = true, features = ["derive"] }
 thiserror = { workspace = true, optional = true }
 

--- a/crates/iroha_version_derive/Cargo.toml
+++ b/crates/iroha_version_derive/Cargo.toml
@@ -25,7 +25,7 @@ iroha_version = { workspace = true, features = ["scale", "json"] }
 iroha_macro = { workspace = true }
 
 parity-scale-codec = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true, features = ["alloc"] }
+serde_json = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 
 trybuild = { workspace = true }

--- a/crates/iroha_wasm_codec/Cargo.toml
+++ b/crates/iroha_wasm_codec/Cargo.toml
@@ -14,4 +14,4 @@ iroha_wasm_codec_derive = { path = "../iroha_wasm_codec_derive" }
 
 thiserror = { workspace = true }
 wasmtime = { workspace = true }
-parity-scale-codec = { workspace = true, features = ["derive"] }
+parity-scale-codec = { workspace = true, features = ["derive", "std"] }


### PR DESCRIPTION
Currently some crates can't be tested individually, e.g.:
```
cargo test --package iroha_swarm
```
=>
```
   Compiling iroha_config v2.0.0-rc.1.0 (/home/dima/soramitsu/fresh/iroha/crates/iroha_config)
error[E0277]: `strum::ParseError` doesn't implement `std::fmt::Display`
  --> crates/iroha_config/src/kura.rs:17:5
```

This PR fixes it. I used the following commands to test it:

<details>

```
cargo test --no-run --package iroha &&
cargo test --no-run --package iroha_cli &&
cargo test --no-run --package iroha_codec &&
cargo test --no-run --package iroha_config &&
cargo test --no-run --package iroha_config_base &&
cargo test --no-run --package iroha_config_base_derive &&
cargo test --no-run --package iroha_core &&
cargo test --no-run --package iroha_crypto &&
cargo test --no-run --package iroha_data_model &&
cargo test --no-run --package iroha_data_model_derive &&
cargo test --no-run --package iroha_derive &&
cargo test --no-run --package iroha_executor &&
cargo test --no-run --package iroha_executor_data_model &&
cargo test --no-run --package iroha_executor_data_model_derive &&
cargo test --no-run --package iroha_executor_derive &&
cargo test --no-run --package iroha_ffi &&
cargo test --no-run --package iroha_ffi_derive &&
cargo test --no-run --package iroha_futures &&
cargo test --no-run --package iroha_futures_derive &&
cargo test --no-run --package iroha_genesis &&
cargo test --no-run --package iroha_kagami &&
cargo test --no-run --package iroha_logger &&
cargo test --no-run --package iroha_macro &&
cargo test --no-run --package iroha_macro_utils &&
cargo test --no-run --package iroha_multisig_data_model &&
cargo test --no-run --package iroha_numeric &&
cargo test --no-run --package iroha_p2p &&
cargo test --no-run --package iroha_primitives &&
cargo test --no-run --package iroha_primitives_derive &&
cargo test --no-run --package iroha_schema &&
cargo test --no-run --package iroha_schema_derive &&
cargo test --no-run --package iroha_schema_gen &&
cargo test --no-run --package iroha_smart_contract &&
cargo test --no-run --package iroha_smart_contract_derive &&
cargo test --no-run --package iroha_smart_contract_utils &&
cargo test --no-run --package iroha_swarm &&
cargo test --no-run --package iroha_telemetry &&
cargo test --no-run --package iroha_telemetry_derive &&
cargo test --no-run --package iroha_test_network &&
cargo test --no-run --package iroha_test_samples &&
cargo test --no-run --package iroha_torii &&
cargo test --no-run --package iroha_torii_const &&
cargo test --no-run --package iroha_trigger &&
cargo test --no-run --package iroha_trigger_derive &&
cargo test --no-run --package iroha_version &&
cargo test --no-run --package iroha_version_derive &&
cargo test --no-run --package iroha_wasm_builder &&
cargo test --no-run --package iroha_wasm_codec &&
cargo test --no-run --package iroha_wasm_codec_derive &&
cargo test --no-run --package iroha_wasm_test_runner &&
cargo test --no-run --package irohad &&
cargo test --no-run --package kura_inspector
```

</details>

---

Running tests for individual crate is useful when running tests from the IDE, or when using `env UPDATE_EXPECT=1`