### PR TITLE
ci: Add back Coveralls coverage tool

### DIFF
--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -120,11 +120,12 @@ jobs:
         with:
           name: report-coverage
           path: lcov.info
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+      - name: Upload coverage to Coveralls
+        uses: coverallsapp/github-action@v2.3.4
         with:
-          fail_ci_if_error: true
-          files: lcov.info
+          file: lcov.info
+          format: lcov
+          github-token: ${{ github.token }}
       - name: Upload test network artifacts
         if: failure() && (steps.test_no_features.outcome == 'failure' || steps.test_all_features.outcome == 'failure')
         uses: actions/upload-artifact@v4

--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -120,6 +120,12 @@ jobs:
         with:
           name: report-coverage
           path: lcov.info
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload test network artifacts
         if: failure() && (steps.test_no_features.outcome == 'failure' || steps.test_all_features.outcome == 'failure')
         uses: actions/upload-artifact@v4

--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -125,7 +125,6 @@ jobs:
         with:
           fail_ci_if_error: true
           files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload test network artifacts
         if: failure() && (steps.test_no_features.outcome == 'failure' || steps.test_all_features.outcome == 'failure')
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Context
`llvm-cov` coverage doesn't work with SonarQube.

### Solution
Add Action to upload coverage report to `Coveralls`.


- [ ] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.
- [ ] All CI checks pass.
