### PR TITLE
ci: Add webhook trigger for iroha-java tests upload to Allure

### DIFF
--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -92,6 +92,15 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/hyperledger-iroha/iroha-python/dispatches \
             -d '{"event_type":"dispatch-event"}'
+      - name: Trigger java SDK tests
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.REPO_ACCESS_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/hyperledger-iroha/iroha-java/dispatches \
+            -d '{"event_type":"allure-upload-trigger"}'
 
   telemetry:
     # FIXME #2646


### PR DESCRIPTION
## Context
We need to trigger java-sdk tests to upload these results to Allure.

### Solution
Add the corresponding webhook trigger.

### Checklist

- [ ] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.
- [ ] All CI checks pass.