### PR TITLE
fix: Make SecretString public

### DIFF
--- a/crates/iroha/src/lib.rs
+++ b/crates/iroha/src/lib.rs
@@ -5,7 +5,7 @@ pub mod config;
 pub mod http;
 mod http_default;
 pub mod query;
-mod secrecy;
+pub mod secrecy;
 
 pub use iroha_crypto as crypto;
 pub use iroha_data_model as data_model;

--- a/crates/iroha/src/secrecy.rs
+++ b/crates/iroha/src/secrecy.rs
@@ -1,12 +1,15 @@
+//! Types for representing securely printable secrets.
 use std::fmt;
 
 use derive_more::Constructor;
 use serde::{Deserialize, Serialize, Serializer};
 
+/// SecretString epresents a sensitive secret string.
 #[derive(Clone, Deserialize, Constructor)]
 pub struct SecretString(String);
 
 impl SecretString {
+    /// Returns underlying secret string
     pub fn expose_secret(&self) -> &str {
         &self.0
     }

--- a/crates/iroha/src/secrecy.rs
+++ b/crates/iroha/src/secrecy.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use derive_more::Constructor;
 use serde::{Deserialize, Serialize, Serializer};
 
-/// SecretString epresents a sensitive secret string.
+/// String sensitive to printing and serialization
 #[derive(Clone, Deserialize, Constructor)]
 pub struct SecretString(String);
 


### PR DESCRIPTION
Basic auth is defined as
```
pub struct BasicAuth {
    pub web_login: WebLogin,
    pub password: SecretString,
}
```

Since the constructor of `SecretString` is not public, a client can't construct a config without using `load()`. It is currently required by Python lib.

This PR makes `SecretString` public.