### PR TITLE
ci: fix poetry usage

### DIFF
--- a/.github/workflows/iroha2-dev-pr-static.yml
+++ b/.github/workflows/iroha2-dev-pr-static.yml
@@ -41,7 +41,7 @@ jobs:
         working-directory: pytests/${{ matrix.suite }}
         run: |
           poetry lock --no-update
-          poetry install
+          poetry install --no-root
       - name: Check code formatting with Black in pytests/${{ matrix.suite }}
         working-directory: pytests/${{ matrix.suite }}
         run: |

--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -227,7 +227,7 @@ jobs:
         run: docker compose -f ${{ env.DEFAULTS_DIR }}/docker-compose.yml up --wait || exit 1
       - name: Install Torii pytest dependencies
         working-directory: pytests/iroha_torii_tests
-        run: ${{ env.POETRY_PATH }} install
+        run: ${{ env.POETRY_PATH }} install --no-root
       - name: Run Torii pytests
         working-directory: pytests/iroha_torii_tests
         run: ${{ env.POETRY_PATH }} run pytest
@@ -240,7 +240,7 @@ jobs:
           chmod +x ${{ env.TEST_DIR }}/${{ env.IROHA_BIN }}
       - name: Install client pytest dependencies
         working-directory: pytests/iroha_cli_tests
-        run: ${{ env.POETRY_PATH }} install
+        run: ${{ env.POETRY_PATH }} install --no-root
       - name: Run client pytests
         uses: nick-fields/retry@v3
         env:

--- a/crates/iroha_core/src/smartcontracts/wasm/cache.rs
+++ b/crates/iroha_core/src/smartcontracts/wasm/cache.rs
@@ -12,7 +12,7 @@ use crate::{
 
 /// Executor related things (linker initialization, module instantiation, memory free)
 /// takes significant amount of time in case of single peer transactions handling.
-/// (https://github.com/hyperledger/iroha/issues/3716#issuecomment-2348417005).
+/// (https://github.com/hyperledger-iroha/iroha/issues/3716#issuecomment-2348417005).
 /// So this cache is used to share `Store` and `Instance` for different transaction validation.
 #[derive(Default)]
 pub struct WasmCache<'world, 'block, 'state> {

--- a/lychee.toml
+++ b/lychee.toml
@@ -12,6 +12,6 @@ exclude_path = [
 exclude = [
     "^http[s]?://127.0.0.1",
     "^http[s]?://localhost",
-    "^http[s]?://iroha"
+    "^http[s]?://iroha",
     "^https://github.com/hyperledger-iroha/iroha"
 ]

--- a/lychee.toml
+++ b/lychee.toml
@@ -12,6 +12,5 @@ exclude_path = [
 exclude = [
     "^http[s]?://127.0.0.1",
     "^http[s]?://localhost",
-    "^http[s]?://iroha",
-    "^https://github.com/hyperledger-iroha/iroha"
+    "^http[s]?://iroha"
 ]

--- a/lychee.toml
+++ b/lychee.toml
@@ -13,4 +13,5 @@ exclude = [
     "^http[s]?://127.0.0.1",
     "^http[s]?://localhost",
     "^http[s]?://iroha"
+    "^https://github.com/hyperledger-iroha/iroha"
 ]

--- a/pytests/iroha_cli_tests/README.md
+++ b/pytests/iroha_cli_tests/README.md
@@ -134,7 +134,7 @@ To get started with Poetry, follow these steps:
 3. Install the dependencies and set up a virtual environment using Poetry:
 
    ```bash
-   poetry install
+   poetry install --no-root
    ```
 
 4. Activate the virtual environment:

--- a/pytests/iroha_torii_tests/README.md
+++ b/pytests/iroha_torii_tests/README.md
@@ -16,7 +16,7 @@ These instructions will get you a copy of the project up and running on your loc
 First, use Poetry to install the dependencies:
 
 ```bash
-poetry install
+poetry install --no-root
 ```
 
 This command will create a virtual environment and install all the necessary dependencies.


### PR DESCRIPTION
Since the latest poetry update, some warnings have been treated as errors, causing CI to fail.
[Example](https://github.com/hyperledger-iroha/iroha/actions/runs/12828450212/job/35773040722?pr=5282)