### PR TITLE
fix(core): reconnect disconnected peer

### DIFF
--- a/crates/iroha_core/src/peers_gossiper.rs
+++ b/crates/iroha_core/src/peers_gossiper.rs
@@ -11,7 +11,7 @@ use std::{
 use iroha_config::parameters::actual::TrustedPeers;
 use iroha_data_model::peer::{Peer, PeerId};
 use iroha_futures::supervisor::{Child, OnShutdown, ShutdownSignal};
-use iroha_p2p::{Broadcast, UpdatePeers, UpdateTopology, UpdateOnlinePeers};
+use iroha_p2p::{Broadcast, UpdateOnlinePeers, UpdatePeers, UpdateTopology};
 use iroha_primitives::{addr::SocketAddr, unique_vec::UniqueVec};
 use iroha_version::{Decode, Encode};
 use parity_scale_codec::{Error, Input};
@@ -152,13 +152,17 @@ impl PeersGossiper {
         if online_peers.len() == 0 {
             iroha_logger::debug!("Peer is disconnected from the network");
 
-            let peers: Vec<_> = self.initial_peers.iter()
-            .map(|(id, address)| Peer::new(address.clone(), id.clone()))
-            .chain(self.gossip_peers.iter()
-                .map(|(id, addresses)| Peer::new(choose_address_majority_rule(addresses), id.clone())))
-            .collect();
-        
-            self.network.update_online_peers_addresses(UpdateOnlinePeers(peers));
+            let peers: Vec<_> = self
+                .initial_peers
+                .iter()
+                .map(|(id, address)| Peer::new(address.clone(), id.clone()))
+                .chain(self.gossip_peers.iter().map(|(id, addresses)| {
+                    Peer::new(choose_address_majority_rule(addresses), id.clone())
+                }))
+                .collect();
+
+            self.network
+                .update_online_peers_addresses(UpdateOnlinePeers(peers));
         }
     }
 

--- a/crates/iroha_p2p/src/network.rs
+++ b/crates/iroha_p2p/src/network.rs
@@ -28,8 +28,8 @@ use crate::{
         message::*,
         Connection, ConnectionId,
     },
-    unbounded_with_len, Broadcast, Error, NetworkMessage, OnlinePeers, Post, UpdatePeers,
-    UpdateTopology, UpdateOnlinePeers
+    unbounded_with_len, Broadcast, Error, NetworkMessage, OnlinePeers, Post, UpdateOnlinePeers,
+    UpdatePeers, UpdateTopology,
 };
 
 /// [`NetworkBase`] actor handle.
@@ -373,8 +373,8 @@ impl<T: Pload, K: Kex, E: Enc> NetworkBase<T, K, E> {
         self.update_topology()
     }
 
-    // Updates the list of online peers with new addresses.  
-    // Useful when a peer needs to initiate its integration into the network.  
+    // Updates the list of online peers with new addresses.
+    // Useful when a peer needs to initiate its integration into the network.
     fn update_online_peers_addresses(&mut self, UpdateOnlinePeers(peers): UpdateOnlinePeers) {
         debug!(?peers, "Add new online peers addresses");
         for peer in &peers {


### PR DESCRIPTION
# Summary
This PR addresses scenarios like those described in #5286, where peers may not appear in online peer lists, causing them to passively wait for incoming connections (become isolated).

# Changes
- During the gossip process, if a peer disconnects, it will now actively update the online peer list with previously connected peers and those in `TRUSTED_PEERS`. On the other hand, on the restart, peers will reference the `TRUSTED_PEERS` list.

Checks are added during peer gossip, so there are certain delays in online peer updates. This shouldn't cause problems with too many requests.