### PR TITLE
feat!: Finalize non-empty blocks by allowing empty blocks after them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [2.0.0-rc.1.3] - 2025-03-07
+
+### Added
+
+- finalize non-empty blocks by allowing empty blocks after them (#5320)
+
 ## [2.0.0-rc.1.2] - 2025-02-25
 
 ### Fixed

--- a/crates/iroha/tests/extra_functional/connected_peers.rs
+++ b/crates/iroha/tests/extra_functional/connected_peers.rs
@@ -86,7 +86,7 @@ async fn connected_peers_with_f(faults: usize) -> Result<()> {
 
     let status = removed_peer.status().await?;
     // Peer might have been disconnected before getting the block
-    assert_matches!(status.blocks, 1 | 2);
+    assert_matches!(status.blocks_non_empty, 1 | 2);
     assert_eq!(status.peers, 0);
 
     // Re-register the peer: committed with f = `faults` - 1 then `status.peers` increments
@@ -124,7 +124,7 @@ async fn assert_peers_status(
                 peer.peer_id()
             );
             assert_eq!(
-                status.blocks,
+                status.blocks_non_empty,
                 expected_blocks,
                 "expected blocks for {}",
                 peer.peer_id()

--- a/crates/iroha/tests/queries/mod.rs
+++ b/crates/iroha/tests/queries/mod.rs
@@ -38,15 +38,24 @@ fn find_blocks_reversed() -> eyre::Result<()> {
     let (network, _rt) = NetworkBuilder::new().start_blocking()?;
     let client = network.client();
 
+    // Waiting for empty block to be committed
+    std::thread::sleep(network.pipeline_time());
+
     client.submit_blocking(Register::domain(Domain::new("domain1".parse()?)))?;
 
+    // Waiting for empty block to be committed
+    std::thread::sleep(network.pipeline_time());
+
     let blocks = client.query(FindBlocks).execute_all()?;
-    assert_eq!(blocks.len(), 2);
-    assert_eq!(blocks[1].header().prev_block_hash(), None);
-    assert_eq!(
-        blocks[0].header().prev_block_hash(),
-        Some(blocks[1].header().hash())
-    );
+    assert_eq!(blocks.len(), 4);
+    assert_eq!(blocks[blocks.len() - 1].header().prev_block_hash(), None);
+    for i in 0..blocks.len() - 1 {
+        assert_eq!(
+            blocks[i].header().prev_block_hash(),
+            Some(blocks[i + 1].header().hash())
+        );
+    }
+    assert!(blocks[0].is_empty());
 
     Ok(())
 }

--- a/crates/iroha/tests/status_response.rs
+++ b/crates/iroha/tests/status_response.rs
@@ -7,6 +7,7 @@ use tokio::task::spawn_blocking;
 fn status_eq_excluding_uptime_and_queue(lhs: &Status, rhs: &Status) -> bool {
     lhs.peers == rhs.peers
         && lhs.blocks == rhs.blocks
+        && lhs.blocks_non_empty == rhs.blocks_non_empty
         && lhs.txs_approved == rhs.txs_approved
         && lhs.txs_rejected == rhs.txs_rejected
         && lhs.view_changes == rhs.view_changes
@@ -27,7 +28,7 @@ async fn check(client: &client::Client, blocks: u64) -> Result<()> {
         &status_json,
         &status_scale
     ));
-    assert_eq!(status_json.blocks, blocks);
+    assert_eq!(status_json.blocks_non_empty, blocks);
 
     Ok(())
 }

--- a/crates/iroha/tests/triggers/by_call_trigger.rs
+++ b/crates/iroha/tests/triggers/by_call_trigger.rs
@@ -99,8 +99,11 @@ fn infinite_recursion_should_produce_one_call_per_block() -> Result<()> {
 
     test_client.submit_blocking(call_trigger)?;
 
+    // Waiting for empty block to be committed
+    thread::sleep(network.pipeline_time());
+
     let new_value = get_asset_value(&test_client, asset_id);
-    assert_eq!(new_value, prev_value.checked_add(Numeric::ONE).unwrap());
+    assert_eq!(new_value, prev_value.checked_add(numeric!(2)).unwrap());
 
     Ok(())
 }
@@ -153,11 +156,14 @@ fn trigger_failure_should_not_cancel_other_triggers_execution() -> Result<()> {
     // Executing bad trigger
     test_client.submit_blocking(ExecuteTrigger::new(bad_trigger_id))?;
 
+    // Waiting for empty block to be committed
+    thread::sleep(network.pipeline_time());
+
     // Checking results
     let new_asset_value = get_asset_value(&test_client, asset_id);
     assert_eq!(
         new_asset_value,
-        prev_asset_value.checked_add(Numeric::ONE).unwrap()
+        prev_asset_value.checked_add(numeric!(2)).unwrap()
     );
     Ok(())
 }

--- a/crates/iroha/tests/triggers/time_trigger.rs
+++ b/crates/iroha/tests/triggers/time_trigger.rs
@@ -102,8 +102,6 @@ fn pre_commit_trigger_should_be_executed() -> Result<()> {
     let account_id = ALICE_ID.clone();
     let asset_id = AssetId::new(asset_definition_id, account_id.clone());
 
-    let mut prev_value = get_asset_value(&test_client, asset_id.clone());
-
     // Start listening BEFORE submitting any transaction not to miss any block committed event
     let event_listener = get_block_committed_event_listener(&test_client)?;
 
@@ -119,11 +117,11 @@ fn pre_commit_trigger_should_be_executed() -> Result<()> {
     ));
     test_client.submit(register_trigger)?;
 
-    for _ in event_listener.take(CHECKS_COUNT) {
-        let new_value = get_asset_value(&test_client, asset_id.clone());
-        assert_eq!(new_value, prev_value.checked_add(Numeric::ONE).unwrap());
-        prev_value = new_value;
+    // Waiting for empty block to be committed
+    std::thread::sleep(network.pipeline_time());
 
+    let mut prev_value = get_asset_value(&test_client, asset_id.clone());
+    for _ in event_listener.take(CHECKS_COUNT) {
         // ISI just to create a new block
         let sample_isi = SetKeyValue::account(
             account_id.clone(),
@@ -131,6 +129,13 @@ fn pre_commit_trigger_should_be_executed() -> Result<()> {
             "value".parse::<Json>()?,
         );
         test_client.submit(sample_isi)?;
+
+        // Waiting for empty block to be committed
+        std::thread::sleep(network.pipeline_time());
+
+        let new_value = get_asset_value(&test_client, asset_id.clone());
+        assert_eq!(new_value, prev_value.checked_add(numeric!(2)).unwrap());
+        prev_value = new_value;
     }
 
     Ok(())

--- a/crates/iroha_core/src/metrics.rs
+++ b/crates/iroha_core/src/metrics.rs
@@ -77,7 +77,8 @@ impl MetricsReporter {
                 };
                 block_index += 1;
                 let block_txs_rejected = block.errors().count() as u64;
-                let block_txs_approved = block.transactions().count() as u64 - block_txs_rejected;
+                let block_txs_all = block.transactions().count() as u64;
+                let block_txs_approved = block_txs_all - block_txs_rejected;
 
                 self.metrics
                     .txs
@@ -92,6 +93,9 @@ impl MetricsReporter {
                     .with_label_values(&["total"])
                     .inc_by(block_txs_approved + block_txs_rejected);
                 self.metrics.block_height.inc();
+                if block_txs_all != 0 {
+                    self.metrics.block_height_non_empty.inc();
+                }
             }
             *lastest_block_height = block_index;
         }

--- a/crates/iroha_data_model/src/events/pipeline.rs
+++ b/crates/iroha_data_model/src/events/pipeline.rs
@@ -351,12 +351,12 @@ mod tests {
 
     impl BlockHeader {
         fn dummy(height: NonZeroU64) -> Self {
+            let transactions_hash =
+                HashOf::from_untyped_unchecked(Hash::prehashed([1_u8; Hash::LENGTH]));
             Self {
                 height,
                 prev_block_hash: None,
-                transactions_hash: HashOf::from_untyped_unchecked(Hash::prehashed(
-                    [1_u8; Hash::LENGTH],
-                )),
+                transactions_hash: Some(transactions_hash),
                 creation_time_ms: 0,
                 view_change_index: 0,
             }

--- a/crates/iroha_data_model/src/query/dsl/predicates.rs
+++ b/crates/iroha_data_model/src/query/dsl/predicates.rs
@@ -302,7 +302,10 @@ impl_predicate_atom! {
         Equals(expected: HashOf<BlockHeader>) [eq] => input == expected,
     }
     BlockHeaderPredicateAtom(_input: BlockHeader) [BlockHeaderPrototype] {}
-    SignedBlockPredicateAtom(_input: SignedBlock) [SignedBlockPrototype] {}
+    SignedBlockPredicateAtom(input: SignedBlock) [SignedBlockPrototype] {
+        /// Checks if the block is empty (has no transactions)
+        IsEmpty [is_empty] => input.is_empty(),
+    }
     TransactionHashPredicateAtom(input: HashOf<SignedTransaction>) [TransactionHashPrototype] {
         /// Checks if the input is equal to the expected value.
         Equals(expected: HashOf<SignedTransaction>) [eq] => input == expected,

--- a/crates/iroha_schema_gen/src/lib.rs
+++ b/crates/iroha_schema_gen/src/lib.rs
@@ -360,6 +360,7 @@ types!(
     Option<DomainId>,
     Option<ForwardCursor>,
     Option<HashOf<BlockHeader>>,
+    Option<HashOf<MerkleTree<SignedTransaction>>>,
     Option<HashOf<SignedTransaction>>,
     Option<IpfsPath>,
     Option<Name>,

--- a/crates/iroha_test_network/src/lib.rs
+++ b/crates/iroha_test_network/src/lib.rs
@@ -42,7 +42,7 @@ use tokio::{
     io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
     process::Child,
     runtime::{self, Runtime},
-    sync::{broadcast, oneshot, watch, Mutex},
+    sync::{broadcast, oneshot, watch, Barrier, Mutex},
     task::{spawn_blocking, JoinSet},
     time::timeout,
 };
@@ -210,7 +210,7 @@ impl Network {
         self.peers.iter().map(|x| x.id.clone()).collect()
     }
 
-    /// Resolves when all _running_ peers have at least N blocks
+    /// Resolves when all _running_ peers have at least N non-empty blocks
     /// # Errors
     /// If this doesn't happen within a timeout.
     pub async fn ensure_blocks(&self, height: u64) -> Result<&Self> {
@@ -466,6 +466,7 @@ pub struct NetworkPeer {
     is_running: Arc<AtomicBool>,
     events: broadcast::Sender<PeerLifecycleEvent>,
     block_height: watch::Sender<Option<u64>>,
+    block_height_non_empty: watch::Sender<Option<u64>>,
     // dropping these the last
     port_p2p: Arc<AllocatedPort>,
     port_api: Arc<AllocatedPort>,
@@ -493,6 +494,7 @@ impl NetworkPeer {
 
         let (events, _rx) = broadcast::channel(32);
         let (block_height, _rx) = watch::channel(None);
+        let (block_height_non_empty, _rx) = watch::channel(None);
 
         let result = Self {
             id,
@@ -503,6 +505,7 @@ impl NetworkPeer {
             is_running: Default::default(),
             events,
             block_height,
+            block_height_non_empty,
             port_p2p: Arc::new(port_p2p),
             port_api: Arc::new(port_api),
         };
@@ -524,9 +527,10 @@ impl NetworkPeer {
     ///
     /// Passed configuration must contain network topology in the `trusted_peers` parameter.
     ///
-    /// This function doesn't wait for peer server to start working, or for it to commit genesis block.
-    /// Iroha could as well terminate immediately with an error, and it is not tracked by this function.
-    /// Use [`Self::events`]/[`Self::once`] to monitor peer's lifecycle.
+    /// This function waits for peer server to start working,
+    /// in particular it waits for `/status` response and connects to event stream.
+    /// However it doesn't wait for genesis block to be commited.
+    /// See [`Self::events`]/[`Self::once`]/[`Self::once_block`] to monitor peer's lifecycle.
     ///
     /// # Panics
     /// If peer was not started.
@@ -637,6 +641,7 @@ impl NetworkPeer {
             is_running: self.is_running.clone(),
             events: self.events.clone(),
             block_height: self.block_height.clone(),
+            block_height_non_empty: self.block_height_non_empty.clone(),
         };
         tasks.spawn(async move {
             if let Err(err) = peer_exit.monitor(shutdown_rx).await {
@@ -645,11 +650,15 @@ impl NetworkPeer {
             }
         });
 
+        let barrier = Arc::new(Barrier::new(2));
+
         {
             let log_prefix = log_prefix.clone();
             let client = self.client();
             let events_tx = self.events.clone();
             let block_height_tx = self.block_height.clone();
+            let block_height_non_empty_tx = self.block_height_non_empty.clone();
+            let barrier = barrier.clone();
             tasks.spawn(async move {
                 let status_client = client.clone();
                 let status = backoff::future::retry(
@@ -671,7 +680,8 @@ impl NetworkPeer {
                 .await
                 .expect("there is no max elapsed time");
                 let _ = events_tx.send(PeerLifecycleEvent::ServerStarted);
-                let _ = block_height_tx.send(Some(status.blocks));
+                let _ = block_height_tx.send_replace(Some(status.blocks));
+                let _ = block_height_non_empty_tx.send_replace(Some(status.blocks_non_empty));
                 eprintln!("{log_prefix} server started, {status:?}");
 
                 let mut events = client
@@ -682,19 +692,34 @@ impl NetworkPeer {
                         panic!("cannot proceed")
                     });
 
+                // We need to connect to event stream before [start] function returns.
+                // Otherwise there can be such situation:
+                // * [start] function returns
+                // * test code submits some transactions and peer applied some blocks
+                // * we do not yet connect to event stream,
+                //   so `height` and `height_non_empty` will not be updated
+                // * test code uses `ensure_blocks` function which relies on `height_non_empty`
+                barrier.wait().await;
+
                 while let Some(Ok(event)) = events.next().await {
                     if let EventBox::Pipeline(PipelineEventBox::Block(block)) = event {
                         if *block.status() == BlockStatus::Applied {
                             let height = block.header().height().get();
-                            eprintln!("{log_prefix} BlockStatus::Applied height={height}",);
+                            let is_empty = block.header().transactions_hash().is_none();
+                            eprintln!("{log_prefix} BlockStatus::Applied height={height}, is_empty={is_empty}");
                             let _ = events_tx.send(PeerLifecycleEvent::BlockApplied { height });
                             block_height_tx.send_modify(|x| *x = Some(height));
+
+                            let status = client.get_status().expect("Can't get status");
+                            block_height_non_empty_tx.send_modify(|x| *x = Some(status.blocks_non_empty));
                         }
                     }
                 }
                 eprintln!("{log_prefix} events stream is closed");
             });
         }
+
+        barrier.wait().await;
 
         *run_guard = Some(PeerRun {
             tasks,
@@ -757,11 +782,11 @@ impl NetworkPeer {
         }
     }
 
-    /// Wait until peer's block height reaches N.
+    /// Wait until peer's count of non-empty blocks reaches N.
     ///
-    /// Resolves immediately if peer is already running _and_ its current block height is greater or equal to N.
+    /// Resolves immediately if peer is already running _and_ has at least N non-empty blocks committed.
     pub async fn once_block(&self, n: u64) {
-        let mut recv = self.block_height.subscribe();
+        let mut recv = self.block_height_non_empty.subscribe();
 
         if recv.borrow().map(|x| x >= n).unwrap_or(false) {
             return;
@@ -826,10 +851,6 @@ impl NetworkPeer {
             .await
             .expect("should not panic")
     }
-
-    pub fn blocks(&self) -> watch::Receiver<Option<u64>> {
-        self.block_height.subscribe()
-    }
 }
 
 /// Compare by ID
@@ -864,6 +885,7 @@ struct PeerExit {
     is_running: Arc<AtomicBool>,
     events: broadcast::Sender<PeerLifecycleEvent>,
     block_height: watch::Sender<Option<u64>>,
+    block_height_non_empty: watch::Sender<Option<u64>>,
 }
 
 impl PeerExit {
@@ -877,6 +899,7 @@ impl PeerExit {
         let _ = self.events.send(PeerLifecycleEvent::Terminated { status });
         self.is_running.store(false, Ordering::Relaxed);
         self.block_height.send_modify(|x| *x = None);
+        self.block_height_non_empty.send_modify(|x| *x = None);
 
         Ok(())
     }

--- a/docs/source/references/schema.json
+++ b/docs/source/references/schema.json
@@ -794,7 +794,7 @@
       },
       {
         "name": "transactions_hash",
-        "type": "HashOf<MerkleTree<SignedTransaction>>"
+        "type": "Option<HashOf<MerkleTree<SignedTransaction>>>"
       },
       {
         "name": "creation_time_ms",
@@ -3415,6 +3415,9 @@
   "Option<HashOf<BlockHeader>>": {
     "Option": "HashOf<BlockHeader>"
   },
+  "Option<HashOf<MerkleTree<SignedTransaction>>>": {
+    "Option": "HashOf<MerkleTree<SignedTransaction>>"
+  },
   "Option<HashOf<SignedTransaction>>": {
     "Option": "HashOf<SignedTransaction>"
   },
@@ -4991,7 +4994,12 @@
     ]
   },
   "SignedBlockPredicateAtom": {
-    "Enum": []
+    "Enum": [
+      {
+        "tag": "IsEmpty",
+        "discriminant": 0
+      }
+    ]
   },
   "SignedBlockProjection<PredicateMarker>": {
     "Enum": [


### PR DESCRIPTION
## Context

Fixes #5317

### Solution

If there are no transactions after a timeout period, and the previous block has transactions, then an empty block will be created. Note that there can't be two sequential empty blocks.

### Migration Guide

An empty block will be added after a non-empty one if there are no transactions, therefore e.g. pre-commit trigger might get executed more times than you expected.

Also note about `/status` endpoint response fields:
* `blocks` - existing field (no change), note that it will include empty blocks
* `blocks_non_empty` - new field, count of non-empty blocks

### Checklist

- [ ] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.
- [ ] All CI checks pass.
