### PR TITLE
refactor(iroha_test_network): use pretty format for logs

### DIFF
--- a/crates/iroha_test_network/src/lib.rs
+++ b/crates/iroha_test_network/src/lib.rs
@@ -555,7 +555,7 @@ impl NetworkPeer {
                 format!("127.0.0.1:{}", self.port_p2p),
             )
             .write(["torii", "address"], format!("127.0.0.1:{}", self.port_api))
-            .write(["logger", "format"], "json");
+            .write(["logger", "format"], "pretty");
 
         let config_path = self.dir.path().join(format!("run-{run_num}-config.toml"));
         let genesis_path = self.dir.path().join(format!("run-{run_num}-genesis.scale"));
@@ -597,7 +597,8 @@ impl NetworkPeer {
                 .unwrap();
             tasks.spawn(async move {
                 let mut lines = BufReader::new(output).lines();
-                while let Ok(Some(line)) = lines.next_line().await {
+                while let Ok(Some(mut line)) = lines.next_line().await {
+                    line.push('\n');
                     file.write_all(line.as_bytes())
                         .await
                         .expect("writing logs to file shouldn't fail");


### PR DESCRIPTION
It is quite difficult to read logs of local tests in json format, so I propose to use pretty format for them. Also fixed newlines in such logs.