### PR TITLE
refactor!: Simplify serialization of `NumericSpec` in `genesis.json`

### DIFF
--- a/crates/iroha_cli/CommandLineHelp.md
+++ b/crates/iroha_cli/CommandLineHelp.md
@@ -656,13 +656,13 @@ Retrieve details of a specific asset definition
 
 Register an asset definition
 
-**Usage:** `iroha asset definition register [OPTIONS] --id <ID> --spec <SPEC>`
+**Usage:** `iroha asset definition register [OPTIONS] --id <ID>`
 
 ###### **Options:**
 
 * `-i`, `--id <ID>` — Asset definition in the format "asset#domain"
 * `-m`, `--mint-once` — Disables minting after the first instance
-* `-s`, `--spec <SPEC>` — Numeric spec of the asset
+* `-s`, `--scale <SCALE>` — Numeric scale of the asset. No value means unconstrained
 
 
 

--- a/crates/iroha_cli/src/main.rs
+++ b/crates/iroha_cli/src/main.rs
@@ -875,7 +875,7 @@ mod asset {
                         context.print_data(&entry)
                     }
                     Register(args) => {
-                        let mut entry = AssetDefinition::new(args.id, args.spec);
+                        let mut entry = AssetDefinition::new(args.id, args.scale.into());
                         if args.mint_once {
                             entry = entry.mintable_once();
                         }
@@ -912,9 +912,9 @@ mod asset {
             /// Disables minting after the first instance
             #[arg(short, long)]
             pub mint_once: bool,
-            /// Numeric spec of the asset
+            /// Numeric scale of the asset. No value means unconstrained.
             #[arg(short, long)]
-            pub spec: NumericSpec,
+            pub scale: Option<u32>,
         }
 
         #[derive(clap::Args, Debug)]

--- a/defaults/genesis.json
+++ b/defaults/genesis.json
@@ -59,7 +59,9 @@
       "Register": {
         "AssetDefinition": {
           "id": "rose#wonderland",
-          "spec": "Numeric",
+          "spec": {
+            "scale": null
+          },
           "mintable": "Infinitely",
           "logo": null,
           "metadata": {}
@@ -87,7 +89,9 @@
       "Register": {
         "AssetDefinition": {
           "id": "cabbage#garden_of_live_flowers",
-          "spec": "Numeric",
+          "spec": {
+            "scale": null
+          },
           "mintable": "Infinitely",
           "logo": null,
           "metadata": {}


### PR DESCRIPTION
## Context

Fixes #5335
https://github.com/hyperledger-iroha/iroha/pull/5308#discussion_r1968589667

### Solution

Use default JSON serialization for `NumericSpec`. 
Custom `Display` implementation is kept for ISI display formatting.

### Migration Guide

This PR should be considered as part of #5308, so see "Migration Guide" section in #5308

---

### Checklist

- [ ] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.
- [ ] All CI checks pass.
