### PR TITLE
ci: Add unzip package to ci-image

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -9,7 +9,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 
 ENV PATH=$POETRY_HOME/bin:$PATH
 
-RUN pacman -Syu rustup mold musl rust-musl openssl libgit2 jq \
+RUN pacman -Syu rustup mold musl rust-musl openssl libgit2 jq unzip \
     git docker docker-buildx docker-compose \
     python python-pip --noconfirm --disable-download-timeout && \
     curl -sSL https://install.python-poetry.org | python3 -


### PR DESCRIPTION
## Context
Unzip package is missed for `Sonarqube` action.

### Solution

Add unzip package to ci-image. Need to recompile `ci-image` after that.

### Checklist

- [ ] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.
- [ ] All CI checks pass.