### PR TITLE
fix(Testnet, Backport): Revert adding blocks_non_empty to /status endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [2.0.0-rc.1.4] - 2025-03-13
+
+### Fixed
+
+- revert backward-incompatible changes to the `/status` endpoint (#5320)
+
 ## [2.0.0-rc.1.3] - 2025-03-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "executor_custom_data_model"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "iroha_data_model",
  "iroha_executor_data_model",
@@ -2917,7 +2917,7 @@ checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "iroha"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "assert_matches",
  "assertables",
@@ -2965,7 +2965,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_cli"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "clap",
  "clap-markdown",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_codec"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "clap",
  "colored",
@@ -3007,7 +3007,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_config"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "assertables",
  "cfg-if",
@@ -3035,7 +3035,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_config_base"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "derive_more",
  "drop_bomb",
@@ -3055,7 +3055,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_config_base_derive"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "darling",
  "expect-test",
@@ -3071,7 +3071,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_core"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "async-trait",
  "criterion",
@@ -3113,7 +3113,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_crypto"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "aead",
  "amcl",
@@ -3155,7 +3155,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_data_model"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "base64 0.22.1",
  "criterion",
@@ -3182,7 +3182,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_data_model_derive"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "darling",
  "derive_more",
@@ -3201,7 +3201,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_derive"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "darling",
  "impls",
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_executor"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "iroha_executor_data_model",
  "iroha_executor_derive",
@@ -3230,7 +3230,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_executor_data_model"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "derive_more",
  "iroha_data_model",
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_executor_data_model_derive"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "iroha_executor_data_model",
  "manyhow",
@@ -3253,7 +3253,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_executor_derive"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "darling",
  "iroha_macro_utils",
@@ -3265,7 +3265,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_ffi"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "derive_more",
  "getset",
@@ -3275,7 +3275,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_ffi_derive"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "darling",
  "getset",
@@ -3292,7 +3292,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_futures"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "iroha_config",
  "iroha_futures_derive",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_futures_derive"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "iroha_macro_utils",
  "manyhow",
@@ -3319,7 +3319,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_genesis"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "derive_more",
  "eyre",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_kagami"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "clap",
  "color-eyre",
@@ -3355,7 +3355,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_logger"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "color-eyre",
  "console-subscriber",
@@ -3374,14 +3374,14 @@ dependencies = [
 
 [[package]]
 name = "iroha_macro"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "iroha_derive",
 ]
 
 [[package]]
 name = "iroha_macro_utils"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "darling",
  "drop_bomb",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_numeric"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -3409,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_p2p"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_primitives"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -3453,7 +3453,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_primitives_derive"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "iroha_numeric",
  "iroha_primitives",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_schema"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "impls",
  "iroha_schema_derive",
@@ -3476,7 +3476,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_schema_derive"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "darling",
  "iroha_macro_utils",
@@ -3490,7 +3490,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_schema_gen"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "iroha_crypto",
  "iroha_data_model",
@@ -3502,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_smart_contract"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -3517,7 +3517,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_smart_contract_derive"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "iroha_macro_utils",
  "manyhow",
@@ -3528,7 +3528,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_smart_contract_utils"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_swarm"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "clap",
  "color-eyre",
@@ -3562,7 +3562,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_telemetry"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3588,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_telemetry_derive"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "iroha_macro_utils",
  "manyhow",
@@ -3600,7 +3600,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_test_network"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "backoff",
  "color-eyre",
@@ -3633,7 +3633,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_test_samples"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "iroha_crypto",
  "iroha_data_model",
@@ -3642,7 +3642,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_torii"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "async-trait",
  "axum 0.7.5",
@@ -3677,14 +3677,14 @@ dependencies = [
 
 [[package]]
 name = "iroha_torii_const"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "iroha_primitives",
 ]
 
 [[package]]
 name = "iroha_trigger"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "iroha_smart_contract",
  "iroha_smart_contract_utils",
@@ -3693,7 +3693,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_trigger_derive"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "darling",
  "iroha_macro_utils",
@@ -3705,7 +3705,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_version"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "iroha_data_model",
  "iroha_logger",
@@ -3719,7 +3719,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_version_derive"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "darling",
  "iroha_macro",
@@ -3736,7 +3736,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_wasm_builder"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "clap",
  "color-eyre",
@@ -3751,7 +3751,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_wasm_codec"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "iroha_wasm_codec_derive",
  "parity-scale-codec",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_wasm_codec_derive"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "iroha_macro_utils",
  "manyhow",
@@ -3772,7 +3772,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_wasm_test_runner"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "anyhow",
  "wasmtime",
@@ -3780,7 +3780,7 @@ dependencies = [
 
 [[package]]
 name = "irohad"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "assertables",
  "clap",
@@ -3932,7 +3932,7 @@ dependencies = [
 
 [[package]]
 name = "kura_inspector"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "clap",
  "iroha_core",
@@ -4181,7 +4181,7 @@ dependencies = [
 
 [[package]]
 name = "mint_rose_trigger_data_model"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 dependencies = [
  "iroha_data_model",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace.package]
 edition = "2021"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 # TODO: teams are being deprecated update the authors URL
 authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
 
@@ -14,40 +14,40 @@ keywords = ["blockchain", "crypto", "iroha", "ledger"]
 categories = ["cryptography::cryptocurrencies"]
 
 [workspace.dependencies]
-iroha_core = { version = "=2.0.0-rc.1.3 ", path = "crates/iroha_core" }
+iroha_core = { version = "=2.0.0-rc.1.4 ", path = "crates/iroha_core" }
 
-iroha_torii = { version = "=2.0.0-rc.1.3", path = "crates/iroha_torii" }
-iroha_torii_const = { version = "=2.0.0-rc.1.3", path = "crates/iroha_torii_const" }
+iroha_torii = { version = "=2.0.0-rc.1.4", path = "crates/iroha_torii" }
+iroha_torii_const = { version = "=2.0.0-rc.1.4", path = "crates/iroha_torii_const" }
 
-iroha = { version = "=2.0.0-rc.1.3", path = "crates/iroha" }
+iroha = { version = "=2.0.0-rc.1.4", path = "crates/iroha" }
 
-iroha_macro_utils = { version = "=2.0.0-rc.1.3", path = "crates/iroha_macro_utils" }
-iroha_telemetry = { version = "=2.0.0-rc.1.3", path = "crates/iroha_telemetry" }
-iroha_p2p = { version = "=2.0.0-rc.1.3", path = "crates/iroha_p2p" }
-iroha_primitives = { version = "=2.0.0-rc.1.3", path = "crates/iroha_primitives", default-features = false }
-iroha_config = { version = "=2.0.0-rc.1.3", path = "crates/iroha_config" }
-iroha_config_base = { version = "=2.0.0-rc.1.3", path = "crates/iroha_config_base" }
-iroha_schema_gen = { version = "=2.0.0-rc.1.3", path = "crates/iroha_schema_gen" }
-iroha_schema = { version = "=2.0.0-rc.1.3", path = "crates/iroha_schema", default-features = false }
-iroha_logger = { version = "=2.0.0-rc.1.3", path = "crates/iroha_logger" }
-iroha_crypto = { version = "=2.0.0-rc.1.3", path = "crates/iroha_crypto", default-features = false }
-iroha_macro = { version = "=2.0.0-rc.1.3", path = "crates/iroha_macro", default-features = false }
-iroha_futures = { version = "=2.0.0-rc.1.3", path = "crates/iroha_futures" }
-iroha_genesis = { version = "=2.0.0-rc.1.3", path = "crates/iroha_genesis" }
-iroha_ffi = { version = "=2.0.0-rc.1.3", path = "crates/iroha_ffi" }
-iroha_version = { version = "=2.0.0-rc.1.3", path = "crates/iroha_version", default-features = false }
-iroha_wasm_codec = { version = "=2.0.0-rc.1.3", path = "crates/iroha_wasm_codec" }
-iroha_wasm_builder = { version = "=2.0.0-rc.1.3", path = "crates/iroha_wasm_builder" }
+iroha_macro_utils = { version = "=2.0.0-rc.1.4", path = "crates/iroha_macro_utils" }
+iroha_telemetry = { version = "=2.0.0-rc.1.4", path = "crates/iroha_telemetry" }
+iroha_p2p = { version = "=2.0.0-rc.1.4", path = "crates/iroha_p2p" }
+iroha_primitives = { version = "=2.0.0-rc.1.4", path = "crates/iroha_primitives", default-features = false }
+iroha_config = { version = "=2.0.0-rc.1.4", path = "crates/iroha_config" }
+iroha_config_base = { version = "=2.0.0-rc.1.4", path = "crates/iroha_config_base" }
+iroha_schema_gen = { version = "=2.0.0-rc.1.4", path = "crates/iroha_schema_gen" }
+iroha_schema = { version = "=2.0.0-rc.1.4", path = "crates/iroha_schema", default-features = false }
+iroha_logger = { version = "=2.0.0-rc.1.4", path = "crates/iroha_logger" }
+iroha_crypto = { version = "=2.0.0-rc.1.4", path = "crates/iroha_crypto", default-features = false }
+iroha_macro = { version = "=2.0.0-rc.1.4", path = "crates/iroha_macro", default-features = false }
+iroha_futures = { version = "=2.0.0-rc.1.4", path = "crates/iroha_futures" }
+iroha_genesis = { version = "=2.0.0-rc.1.4", path = "crates/iroha_genesis" }
+iroha_ffi = { version = "=2.0.0-rc.1.4", path = "crates/iroha_ffi" }
+iroha_version = { version = "=2.0.0-rc.1.4", path = "crates/iroha_version", default-features = false }
+iroha_wasm_codec = { version = "=2.0.0-rc.1.4", path = "crates/iroha_wasm_codec" }
+iroha_wasm_builder = { version = "=2.0.0-rc.1.4", path = "crates/iroha_wasm_builder" }
 
-iroha_smart_contract = { version = "=2.0.0-rc.1.3", path = "crates/iroha_smart_contract" }
-iroha_smart_contract_utils = { version = "=2.0.0-rc.1.3", path = "crates/iroha_smart_contract_utils" }
-iroha_executor = { version = "=2.0.0-rc.1.3", path = "crates/iroha_executor" }
+iroha_smart_contract = { version = "=2.0.0-rc.1.4", path = "crates/iroha_smart_contract" }
+iroha_smart_contract_utils = { version = "=2.0.0-rc.1.4", path = "crates/iroha_smart_contract_utils" }
+iroha_executor = { version = "=2.0.0-rc.1.4", path = "crates/iroha_executor" }
 
-iroha_data_model = { version = "=2.0.0-rc.1.3", path = "crates/iroha_data_model", default-features = false }
-iroha_executor_data_model = { version = "=2.0.0-rc.1.3", path = "crates/iroha_executor_data_model" }
+iroha_data_model = { version = "=2.0.0-rc.1.4", path = "crates/iroha_data_model", default-features = false }
+iroha_executor_data_model = { version = "=2.0.0-rc.1.4", path = "crates/iroha_executor_data_model" }
 
-iroha_test_network = { version = "=2.0.0-rc.1.3", path = "crates/iroha_test_network" }
-iroha_test_samples = { version = "=2.0.0-rc.1.3", path = "crates/iroha_test_samples" }
+iroha_test_network = { version = "=2.0.0-rc.1.4", path = "crates/iroha_test_network" }
+iroha_test_samples = { version = "=2.0.0-rc.1.4", path = "crates/iroha_test_samples" }
 
 proc-macro2 = "1.0.86"
 syn = { version = "2.0.72", default-features = false }

--- a/crates/iroha/tests/extra_functional/connected_peers.rs
+++ b/crates/iroha/tests/extra_functional/connected_peers.rs
@@ -74,7 +74,7 @@ async fn connected_peers_with_f(faults: usize) -> Result<()> {
 
     let status = removed_peer.status().await?;
     // Peer might have been disconnected before getting the block
-    assert_matches!(status.blocks_non_empty, 1 | 2);
+    assert_matches!(status.blocks, 1 | 2);
     assert_eq!(status.peers, 0);
 
     // Re-register the peer: committed with f = `faults` - 1 then `status.peers` increments
@@ -112,7 +112,7 @@ async fn assert_peers_status(
                 peer.peer_id()
             );
             assert_eq!(
-                status.blocks_non_empty,
+                status.blocks,
                 expected_blocks,
                 "expected blocks for {}",
                 peer.peer_id()

--- a/crates/iroha/tests/status_response.rs
+++ b/crates/iroha/tests/status_response.rs
@@ -7,7 +7,6 @@ use tokio::task::spawn_blocking;
 fn status_eq_excluding_uptime_and_queue(lhs: &Status, rhs: &Status) -> bool {
     lhs.peers == rhs.peers
         && lhs.blocks == rhs.blocks
-        && lhs.blocks_non_empty == rhs.blocks_non_empty
         && lhs.txs_approved == rhs.txs_approved
         && lhs.txs_rejected == rhs.txs_rejected
         && lhs.view_changes == rhs.view_changes
@@ -28,7 +27,7 @@ async fn check(client: &client::Client, blocks: u64) -> Result<()> {
         &status_json,
         &status_scale
     ));
-    assert_eq!(status_json.blocks_non_empty, blocks);
+    assert_eq!(status_json.blocks, blocks);
 
     Ok(())
 }

--- a/crates/iroha_telemetry/src/metrics.rs
+++ b/crates/iroha_telemetry/src/metrics.rs
@@ -54,9 +54,6 @@ pub struct Status {
     /// Number of committed blocks (blockchain height)
     #[codec(compact)]
     pub blocks: u64,
-    /// Number of committed non-empty blocks
-    #[codec(compact)]
-    pub blocks_non_empty: u64,
     /// Number of approved transactions
     #[codec(compact)]
     pub txs_approved: u64,
@@ -79,7 +76,6 @@ impl<T: Deref<Target = Metrics>> From<&T> for Status {
         Self {
             peers: val.connected_peers.get(),
             blocks: val.block_height.get(),
-            blocks_non_empty: val.block_height_non_empty.get(),
             txs_approved: val.txs.with_label_values(&["accepted"]).get(),
             txs_rejected: val.txs.with_label_values(&["rejected"]).get(),
             uptime: Uptime(Duration::from_millis(val.uptime_since_genesis_ms.get())),
@@ -262,7 +258,6 @@ mod test {
         Status {
             peers: 4,
             blocks: 5,
-            blocks_non_empty: 3,
             txs_approved: 31,
             txs_rejected: 3,
             uptime: Uptime(Duration::new(5, 937_000_000)),

--- a/crates/iroha_test_network/src/lib.rs
+++ b/crates/iroha_test_network/src/lib.rs
@@ -655,7 +655,6 @@ impl NetworkPeer {
             let client = self.client();
             let events_tx = self.events.clone();
             let block_height_tx = self.block_height.clone();
-            let block_height_non_empty_tx = self.block_height_non_empty.clone();
             let barrier = barrier.clone();
             tasks.spawn(async move {
                 let status_client = client.clone();
@@ -679,7 +678,6 @@ impl NetworkPeer {
                 .expect("there is no max elapsed time");
                 let _ = events_tx.send(PeerLifecycleEvent::ServerStarted);
                 let _ = block_height_tx.send_replace(Some(status.blocks));
-                let _ = block_height_non_empty_tx.send_replace(Some(status.blocks_non_empty));
                 eprintln!("{log_prefix} server started, {status:?}");
 
                 let mut events = client
@@ -707,9 +705,6 @@ impl NetworkPeer {
                             eprintln!("{log_prefix} BlockStatus::Applied height={height}, is_empty={is_empty}");
                             let _ = events_tx.send(PeerLifecycleEvent::BlockApplied { height });
                             block_height_tx.send_modify(|x| *x = Some(height));
-
-                            let status = client.get_status().expect("Can't get status");
-                            block_height_non_empty_tx.send_modify(|x| *x = Some(status.blocks_non_empty));
                         }
                     }
                 }

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace.package]
 edition = "2021"
-version = "2.0.0-rc.1.3"
+version = "2.0.0-rc.1.4"
 # TODO: teams are being deprecated update the authors URL
 authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
 
@@ -24,13 +24,13 @@ opt-level = "z"     # Optimize for size vs speed with "s"/"z"(removes vectorizat
 codegen-units = 1   # Further reduces binary size but increases compilation time
 
 [workspace.dependencies]
-iroha_smart_contract = { version = "=2.0.0-rc.1.3", path = "../crates/iroha_smart_contract", features = ["debug"] }
-iroha_trigger = { version = "=2.0.0-rc.1.3", path = "../crates/iroha_trigger", features = ["debug"] }
-iroha_executor = { version = "=2.0.0-rc.1.3", path = "../crates/iroha_executor", features = ["debug"] }
-iroha_schema = { version = "=2.0.0-rc.1.3", path = "../crates/iroha_schema" }
+iroha_smart_contract = { version = "=2.0.0-rc.1.4", path = "../crates/iroha_smart_contract", features = ["debug"] }
+iroha_trigger = { version = "=2.0.0-rc.1.4", path = "../crates/iroha_trigger", features = ["debug"] }
+iroha_executor = { version = "=2.0.0-rc.1.4", path = "../crates/iroha_executor", features = ["debug"] }
+iroha_schema = { version = "=2.0.0-rc.1.4", path = "../crates/iroha_schema" }
 
-iroha_data_model = { version = "=2.0.0-rc.1.3", path = "../crates/iroha_data_model", default-features = false }
-iroha_executor_data_model = { version = "=2.0.0-rc.1.3", path = "../crates/iroha_executor_data_model" }
+iroha_data_model = { version = "=2.0.0-rc.1.4", path = "../crates/iroha_data_model", default-features = false }
+iroha_executor_data_model = { version = "=2.0.0-rc.1.4", path = "../crates/iroha_executor_data_model" }
 mint_rose_trigger_data_model = { path = "../data_model/samples/mint_rose_trigger_data_model" }
 executor_custom_data_model = { path = "../data_model/samples/executor_custom_data_model" }
 

--- a/wasm/samples/mint_rose_trigger/Cargo.toml
+++ b/wasm/samples/mint_rose_trigger/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 crate-type = ['cdylib']
 
 [dependencies]
-mint_rose_trigger_data_model = { version = "=2.0.0-rc.1.3", path = "../../../data_model/samples/mint_rose_trigger_data_model" }
+mint_rose_trigger_data_model = { version = "=2.0.0-rc.1.4", path = "../../../data_model/samples/mint_rose_trigger_data_model" }
 iroha_trigger.workspace = true
 
 panic-halt.workspace = true


### PR DESCRIPTION
Fixes #5349

(note that CI tests should fail without `blocks_non_empty`)