### PR TITLE
feat: generic structure through execution cycle

### DIFF
--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -102,14 +102,16 @@ jobs:
         run: |
           mv ${{ env.WASM_TARGET_DIR }}/libs ${{ env.DEFAULTS_DIR }}/libs
           mv ${{ env.DEFAULTS_DIR }}/libs/default_executor.wasm ${{ env.DEFAULTS_DIR }}/executor.wasm
-      - name: Install irohad
-        run: which irohad || cargo install --path crates/irohad --locked
+      - name: Install irohad with no default features
+        run: cargo install --path crates/irohad --locked --no-default-features
       - name: Test with no default features
         id: test_no_features
         run: >
           mold --run cargo llvm-cov nextest
           --no-default-features
           --branch --no-report
+      - name: Install irohad with all features
+        run: cargo install --path crates/irohad --locked --all-features
       - name: Test with all features
         id: test_all_features
         run: >

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3069,6 +3069,7 @@ dependencies = [
  "attohttpc",
  "base64 0.22.1",
  "color-eyre",
+ "criterion",
  "derive_more",
  "displaydoc",
  "error-stack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3110,6 +3110,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "iroha_authorizer"
+version = "2.0.0-rc.1.0"
+dependencies = [
+ "iroha_tree",
+]
+
+[[package]]
 name = "iroha_cli"
 version = "2.0.0-rc.1.0"
 dependencies = [
@@ -3223,6 +3230,7 @@ dependencies = [
  "iroha_primitives",
  "iroha_telemetry",
  "iroha_test_samples",
+ "iroha_tree",
  "iroha_version",
  "iroha_wasm_codec",
  "mv",
@@ -3818,6 +3826,20 @@ name = "iroha_torii_const"
 version = "2.0.0-rc.1.0"
 dependencies = [
  "iroha_primitives",
+]
+
+[[package]]
+name = "iroha_tree"
+version = "2.0.0-rc.1.0"
+dependencies = [
+ "derive_more",
+ "hashbrown 0.15.1",
+ "iroha_data_model",
+ "iroha_executor_data_model",
+ "iroha_logger",
+ "parity-scale-codec",
+ "serde_json",
+ "serde_with",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ iroha_executor_data_model = { version = "=2.0.0-rc.1.0", path = "crates/iroha_ex
 
 iroha_test_network = { version = "=2.0.0-rc.1.0", path = "crates/iroha_test_network" }
 iroha_test_samples = { version = "=2.0.0-rc.1.0", path = "crates/iroha_test_samples" }
+iroha_tree = { version = "=2.0.0-rc.1.0", path = "crates/iroha_tree" }
+iroha_authorizer = { version = "=2.0.0-rc.1.0", path = "crates/iroha_authorizer" }
 
 proc-macro2 = "1.0.86"
 syn = { version = "2.0.72", default-features = false }

--- a/crates/iroha/Cargo.toml
+++ b/crates/iroha/Cargo.toml
@@ -47,6 +47,9 @@ tls-rustls-webpki-roots = [
     "tungstenite/rustls-tls-webpki-roots",
 ]
 
+# Abstract instructions, events, and event filters into a generic structure to simulate possible execution paths.
+prediction = []
+
 [dependencies]
 iroha_config = { workspace = true }
 iroha_config_base = { workspace = true }

--- a/crates/iroha/Cargo.toml
+++ b/crates/iroha/Cargo.toml
@@ -97,3 +97,9 @@ hex = { workspace = true }
 assertables = { workspace = true }
 trybuild = { workspace = true }
 assert_matches = "1.5.0"
+criterion = { workspace = true }
+
+[[bench]]
+name = "one_block"
+harness = false
+path = "benches/one_block.rs"

--- a/crates/iroha/benches/one_block.rs
+++ b/crates/iroha/benches/one_block.rs
@@ -1,0 +1,156 @@
+#![expect(missing_docs)]
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use iroha::{
+    client::Client,
+    data_model::{parameter::BlockParameter, prelude::*},
+};
+use iroha_test_network::*;
+use iroha_test_samples::{load_sample_wasm, ALICE_ID, BOB_ID};
+use nonzero_ext::nonzero;
+
+const N_TRANSACTIONS_PER_BLOCK: u64 = 1;
+
+fn bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("one_block");
+    group.sample_size(10);
+    group.bench_function("trigger_executable_builtin", |b| {
+        b.iter_batched(setup_builtin, routine, criterion::BatchSize::SmallInput);
+    });
+    group.bench_function("trigger_executable_wasm", |b| {
+        b.iter_batched(setup_wasm, routine, criterion::BatchSize::SmallInput);
+    });
+    group.finish();
+}
+
+fn setup_builtin() -> Input {
+    let rose: AssetDefinitionId = "rose#wonderland".parse().unwrap();
+    let rose_alice: AssetId = format!("{rose}#{}", ALICE_ID.clone()).parse().unwrap();
+    let transfer_rose_alice_bob = Transfer::asset_numeric(rose_alice.clone(), 1u32, BOB_ID.clone());
+    setup(vec![transfer_rose_alice_bob])
+}
+
+fn setup_wasm() -> Input {
+    setup(load_sample_wasm("trigger_transfer_one"))
+}
+
+/// Given a test network equipped with a trigger
+fn setup(trigger_executable: impl Into<Executable>) -> Input {
+    let rose: AssetDefinitionId = "rose#wonderland".parse().unwrap();
+    let rose_alice: AssetId = format!("{rose}#{}", ALICE_ID.clone()).parse().unwrap();
+    let rose_bob: AssetId = format!("{rose}#{}", BOB_ID.clone()).parse().unwrap();
+    let register_trigger = Register::trigger(Trigger::new(
+        "transfer_one_to_bob_on_mint_roses_at_alice"
+            .parse()
+            .unwrap(),
+        Action::new(
+            trigger_executable,
+            Repeats::Indefinitely,
+            ALICE_ID.clone(),
+            AssetEventFilter::new()
+                .for_asset(rose_alice.clone())
+                .for_events(AssetEventSet::Created),
+        ),
+    ));
+    let (network, rt) = NetworkBuilder::new()
+        .with_genesis_instruction(register_trigger)
+        .with_genesis_instruction(SetParameter::new(Parameter::Block(
+            BlockParameter::MaxTransactions(nonzero!(N_TRANSACTIONS_PER_BLOCK)),
+        )))
+        .start_blocking()
+        .unwrap();
+    let mut test_client = network.client();
+    test_client.add_transaction_nonce = true;
+    let n0_rose_alice = get_asset_value(&test_client, rose_alice.clone());
+    let n0_rose_bob = get_asset_value(&test_client, rose_bob.clone());
+    let mint_rose_alice = Mint::asset_numeric(1u32, rose_alice.clone());
+
+    Input {
+        network,
+        rt,
+        test_client,
+        rose_alice,
+        rose_bob,
+        n0_rose_alice,
+        n0_rose_bob,
+        mint_rose_alice,
+    }
+}
+
+struct Input {
+    network: Network,
+    rt: tokio::runtime::Runtime,
+    test_client: Client,
+    rose_alice: AssetId,
+    rose_bob: AssetId,
+    n0_rose_alice: Numeric,
+    n0_rose_bob: Numeric,
+    mint_rose_alice: Mint<Numeric, Asset>,
+}
+
+/// # Scenario
+///
+/// 0. Transaction: [mint a rose for Alice, mint another rose for Alice]
+/// 0. Trigger execution: asset created (some roses for Alice) -> transfer a rose from Alice to Bob
+fn routine(
+    Input {
+        network: _network,
+        rt: _rt,
+        test_client,
+        rose_alice,
+        rose_bob,
+        n0_rose_alice,
+        n0_rose_bob,
+        mint_rose_alice,
+    }: Input,
+) {
+    let mint_twice = [mint_rose_alice.clone(), mint_rose_alice];
+    #[allow(clippy::reversed_empty_ranges)]
+    for _ in 1..N_TRANSACTIONS_PER_BLOCK {
+        // Transaction nonce is enabled in setup, otherwise hashes may collide
+        test_client
+            .submit_all(mint_twice.clone())
+            .expect("transaction should be submitted");
+    }
+    test_client
+        .submit_all_blocking(mint_twice)
+        .expect("transaction should be committed");
+    // TODO peer.once_block(2)
+    assert_eq!(
+        test_client.get_status().unwrap().blocks,
+        2,
+        "Extra blocks created"
+    );
+
+    let n1_rose_alice = get_asset_value(&test_client, rose_alice);
+    let n1_rose_bob = get_asset_value(&test_client, rose_bob);
+
+    // FIXME
+    // assert_eq!(
+    //     n1_rose_alice,
+    //     n0_rose_alice.checked_add(N_TRANSACTIONS_PER_BLOCK.into()).unwrap()
+    // );
+    // assert_eq!(n1_rose_bob, n0_rose_bob.checked_add(N_TRANSACTIONS_PER_BLOCK.into()).unwrap());
+    assert_eq!(
+        n1_rose_alice,
+        n0_rose_alice
+            .checked_add(Numeric::from(2 * N_TRANSACTIONS_PER_BLOCK))
+            .unwrap()
+    );
+    assert_eq!(n1_rose_bob, n0_rose_bob);
+}
+
+fn get_asset_value(client: &Client, asset_id: AssetId) -> Numeric {
+    let Ok(asset) = client
+        .query(FindAssets::new())
+        .filter_with(|asset| asset.id.eq(asset_id))
+        .execute_single()
+    else {
+        return Numeric::ZERO;
+    };
+
+    *asset.value()
+}
+
+criterion_group!(benches, bench);
+criterion_main!(benches);

--- a/crates/iroha/tests/events/notification.rs
+++ b/crates/iroha/tests/events/notification.rs
@@ -8,6 +8,7 @@ use iroha_test_samples::ALICE_ID;
 use tokio::{task::spawn_blocking, time::timeout};
 
 #[tokio::test]
+#[cfg_attr(feature = "prediction", ignore = "depends on deprecated event types")]
 async fn trigger_completion_success_should_produce_event() -> Result<()> {
     let network = NetworkBuilder::new().start().await?;
 
@@ -48,6 +49,7 @@ async fn trigger_completion_success_should_produce_event() -> Result<()> {
 }
 
 #[tokio::test]
+#[cfg_attr(feature = "prediction", ignore = "depends on deprecated event types")]
 async fn trigger_completion_failure_should_produce_event() -> Result<()> {
     let network = NetworkBuilder::new().start().await?;
 

--- a/crates/iroha/tests/transfer_domain.rs
+++ b/crates/iroha/tests/transfer_domain.rs
@@ -289,6 +289,7 @@ fn domain_owner_nft_permissions() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(feature = "prediction", ignore = "depends on deprecated event types")]
 fn domain_owner_trigger_permissions() -> Result<()> {
     let (network, _rt) = NetworkBuilder::new().start_blocking()?;
     let test_client = network.client();

--- a/crates/iroha/tests/triggers/by_call_trigger.rs
+++ b/crates/iroha/tests/triggers/by_call_trigger.rs
@@ -4,21 +4,19 @@ use eyre::{eyre, Result, WrapErr};
 use iroha::{
     crypto::KeyPair,
     data_model::{
-        prelude::*,
         query::{builder::SingleQueryError, error::FindError, trigger::FindTriggers},
         transaction::Executable,
     },
 };
 use iroha_executor_data_model::permission::trigger::CanRegisterTrigger;
-use iroha_test_network::*;
-use iroha_test_samples::{load_sample_wasm, ALICE_ID};
 use mint_rose_trigger_data_model::MintRoseArgs;
 
-use crate::triggers::get_asset_value;
+use super::*;
 
 const TRIGGER_NAME: &str = "mint_rose";
 
 #[test]
+#[cfg_attr(feature = "prediction", ignore = "depends on deprecated event types")]
 fn call_execute_trigger() -> Result<()> {
     let (network, _rt) = NetworkBuilder::new().start_blocking()?;
     let test_client = network.client();
@@ -43,6 +41,7 @@ fn call_execute_trigger() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(feature = "prediction", ignore = "depends on deprecated event types")]
 fn execute_trigger_should_produce_event() -> Result<()> {
     let (network, _rt) = NetworkBuilder::new().start_blocking()?;
     let test_client = network.client();
@@ -79,6 +78,7 @@ fn execute_trigger_should_produce_event() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(feature = "prediction", ignore = "depends on deprecated event types")]
 fn infinite_recursion_should_produce_one_call_per_block() -> Result<()> {
     let (network, _rt) = NetworkBuilder::new().start_blocking()?;
     let test_client = network.client();
@@ -109,6 +109,7 @@ fn infinite_recursion_should_produce_one_call_per_block() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(feature = "prediction", ignore = "depends on deprecated event types")]
 fn trigger_failure_should_not_cancel_other_triggers_execution() -> Result<()> {
     let (network, _rt) = NetworkBuilder::new().start_blocking()?;
     let test_client = network.client();
@@ -169,6 +170,7 @@ fn trigger_failure_should_not_cancel_other_triggers_execution() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(feature = "prediction", ignore = "depends on deprecated event types")]
 fn trigger_should_not_be_executed_with_zero_repeats_count() -> Result<()> {
     let (network, _rt) = NetworkBuilder::new().start_blocking()?;
     let test_client = network.client();
@@ -234,6 +236,7 @@ fn trigger_should_not_be_executed_with_zero_repeats_count() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(feature = "prediction", ignore = "depends on deprecated event types")]
 fn trigger_should_be_able_to_modify_its_own_repeats_count() -> Result<()> {
     let (network, _rt) = NetworkBuilder::new().start_blocking()?;
     let test_client = network.client();
@@ -281,6 +284,7 @@ fn trigger_should_be_able_to_modify_its_own_repeats_count() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(feature = "prediction", ignore = "depends on deprecated event types")]
 fn only_account_with_permission_can_register_trigger() -> Result<()> {
     let (network, _rt) = NetworkBuilder::new().start_blocking()?;
     let test_client = network.client();
@@ -353,6 +357,7 @@ fn only_account_with_permission_can_register_trigger() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(feature = "prediction", ignore = "depends on deprecated event types")]
 fn unregister_trigger() -> Result<()> {
     let (network, _rt) = NetworkBuilder::new().start_blocking()?;
     let test_client = network.client();
@@ -412,6 +417,7 @@ fn unregister_trigger() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(feature = "prediction", ignore = "depends on deprecated event types")]
 fn trigger_in_genesis() -> Result<()> {
     let wasm = load_sample_wasm("mint_rose_trigger");
     let account_id = ALICE_ID.clone();
@@ -457,6 +463,7 @@ fn trigger_in_genesis() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(feature = "prediction", ignore = "depends on deprecated event types")]
 fn trigger_should_be_able_to_modify_other_trigger() -> Result<()> {
     let (network, _rt) = NetworkBuilder::new().start_blocking()?;
     let test_client = network.client();
@@ -517,6 +524,7 @@ fn trigger_should_be_able_to_modify_other_trigger() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(feature = "prediction", ignore = "depends on deprecated event types")]
 fn trigger_burn_repetitions() -> Result<()> {
     let (network, _rt) = NetworkBuilder::new().start_blocking()?;
     let test_client = network.client();
@@ -552,6 +560,7 @@ fn trigger_burn_repetitions() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(feature = "prediction", ignore = "depends on deprecated event types")]
 fn unregistering_one_of_two_triggers_with_identical_wasm_should_not_cause_original_wasm_loss(
 ) -> Result<()> {
     let (network, _rt) = NetworkBuilder::new().start_blocking()?;
@@ -614,6 +623,7 @@ fn build_register_trigger_isi(
 }
 
 #[test]
+#[cfg_attr(feature = "prediction", ignore = "depends on deprecated event types")]
 fn call_execute_trigger_with_args() -> Result<()> {
     let (network, _rt) = NetworkBuilder::new().start_blocking()?;
     let test_client = network.client();

--- a/crates/iroha/tests/triggers/data_trigger.rs
+++ b/crates/iroha/tests/triggers/data_trigger.rs
@@ -1,10 +1,5 @@
 use eyre::Result;
-use iroha::{
-    client,
-    data_model::{parameter::SumeragiParameter, prelude::*},
-};
-use iroha_test_network::*;
-use iroha_test_samples::{gen_account_in, ALICE_ID};
+use iroha::{client, data_model::parameter::SumeragiParameter};
 
 use super::*;
 

--- a/crates/iroha/tests/triggers/data_trigger.rs
+++ b/crates/iroha/tests/triggers/data_trigger.rs
@@ -1,10 +1,122 @@
 use eyre::Result;
-use iroha::{client, data_model::prelude::*};
+use iroha::{
+    client,
+    data_model::{parameter::SumeragiParameter, prelude::*},
+};
 use iroha_test_network::*;
 use iroha_test_samples::{gen_account_in, ALICE_ID};
 
+use super::*;
+
+/// # Scenario
+///
+/// 0. Transaction: [register Carol]
+/// 0. Trigger execution: account created (Carol) -> mint roses for Carol
+/// 0. Transaction: [burn one of Carol's roses] ... Depends on the previous trigger execution
+/// 0. Block commit
 #[test]
-fn must_execute_both_triggers() -> Result<()> {
+#[ignore = "enable in #4937"]
+fn executes_on_every_transaction() -> Result<()> {
+    let carol = gen_account_in("wonderland");
+    let rose_carol: AssetId = format!("rose##{}", carol.0).parse().unwrap();
+    let mint_roses_on_carol_creation = Trigger::new(
+        "mint_roses_on_carol_creation".parse().unwrap(),
+        Action::new(
+            vec![Mint::asset_numeric(2_u32, rose_carol.clone())],
+            Repeats::Indefinitely,
+            ALICE_ID.clone(),
+            AccountEventFilter::new()
+                .for_account(carol.0.clone())
+                .for_events(AccountEventSet::Created),
+        ),
+    );
+    let (network, _rt) = NetworkBuilder::new()
+        .with_genesis_instruction(SetParameter::new(Parameter::Sumeragi(
+            // This reset to the default matters for some reason
+            SumeragiParameter::BlockTimeMs(2_000),
+        )))
+        .with_genesis_instruction(Register::trigger(mint_roses_on_carol_creation))
+        .start_blocking()?;
+    let test_client = network.client();
+
+    test_client.submit(Register::account(Account::new(carol.0.clone())))?;
+    test_client.submit_blocking(Burn::asset_numeric(1_u32, rose_carol.clone()))?;
+    assert_eq!(2, test_client.get_status().unwrap().blocks);
+    assert_eq!(numeric!(1), get_asset_value(&test_client, rose_carol));
+
+    Ok(())
+}
+
+mod matches_a_batch_of_events {
+    use std::collections::BTreeMap;
+
+    use iroha_data_model::isi::Instruction;
+    use iroha_test_samples::load_sample_wasm;
+
+    use super::*;
+
+    /// # Scenario
+    ///
+    /// 0. Transaction: [mint a rose, mint another rose]
+    /// 0. Trigger execution: asset minted (some roses) -> burn both roses
+    #[test]
+    #[ignore = "enable in #4937"]
+    fn accumulation() -> Result<()> {
+        let carol = gen_account_in("wonderland");
+        let mint_a_rose = Mint::asset_numeric(1_u32, format!("rose##{}", carol.0).parse().unwrap());
+
+        test((0..2).map(|_| mint_a_rose.clone()), |_roses| todo!())
+    }
+
+    /// # Scenario
+    ///
+    /// 0. Transaction: [register Carol, register Dave]
+    /// 0. Trigger execution: account created (Carol and Dave) -> mint a rose for each
+    #[test]
+    #[ignore = "enable in #4937"]
+    fn union() -> Result<()> {
+        todo!()
+    }
+
+    fn test(
+        when: impl Iterator<Item = impl Instruction>,
+        predicate: impl Fn(BTreeMap<AssetId, Numeric>) -> bool,
+    ) -> Result<()> {
+        let matches_a_batch_of_events = Trigger::new(
+            "matches_a_batch_of_events".parse().unwrap(),
+            Action::new(
+                load_sample_wasm("matches_a_batch_of_events"),
+                Repeats::Indefinitely,
+                ALICE_ID.clone(),
+                DomainEventFilter::new().for_domain("wonderland".parse().unwrap()),
+            ),
+        );
+        let (network, _rt) = NetworkBuilder::new()
+            .with_genesis_instruction(Register::trigger(matches_a_batch_of_events))
+            .start_blocking()?;
+        let test_client = network.client();
+
+        test_client.submit_all_blocking(when)?;
+        let roses = test_client
+            .query(FindAssets)
+            .filter_with(|asset| asset.id.definition.eq("rose#wonderland".parse().unwrap()))
+            .select_with(|asset| (asset.id, asset.value))
+            .execute()?
+            .collect::<Result<BTreeMap<_, _>, _>>()?;
+        assert!(predicate(roses));
+
+        Ok(())
+    }
+}
+
+/// # Scenario
+///
+/// 0. Register `trigger_1` with `filter_1`
+/// 0. Register `trigger_2` with `filter_2`
+/// 0. Emit an event that matches both `filter_1` and `filter_2`
+/// 0. Both `trigger_1` and `trigger_2` execute
+#[test]
+fn subscribe_events() -> Result<()> {
     let (network, _rt) = NetworkBuilder::new().start_blocking()?;
     let test_client = network.client();
 

--- a/crates/iroha/tests/triggers/event_trigger.rs
+++ b/crates/iroha/tests/triggers/event_trigger.rs
@@ -1,9 +1,6 @@
 use eyre::Result;
-use iroha::data_model::prelude::*;
-use iroha_test_network::*;
-use iroha_test_samples::ALICE_ID;
 
-use crate::triggers::get_asset_value;
+use super::*;
 
 #[test]
 fn test_mint_asset_when_new_asset_definition_created() -> Result<()> {

--- a/crates/iroha/tests/triggers/mod.rs
+++ b/crates/iroha/tests/triggers/mod.rs
@@ -2,9 +2,11 @@ use iroha::{
     client::Client,
     data_model::{
         asset::AssetId,
-        prelude::{FindAssets, Numeric, QueryBuilderExt},
+        prelude::{FindAssets, Numeric, QueryBuilderExt, *},
     },
 };
+use iroha_test_network::*;
+use iroha_test_samples::{gen_account_in, load_sample_wasm, ALICE_ID};
 
 mod by_call_trigger;
 mod data_trigger;
@@ -22,4 +24,103 @@ fn get_asset_value(client: &Client, asset_id: AssetId) -> Numeric {
         .unwrap();
 
     *asset.value()
+}
+
+/// See the corresponding unit test `iroha_tree::state::tests::detects_event_loop`.
+#[cfg(feature = "prediction")]
+#[test]
+fn not_registered_when_potential_event_loop_detected() -> eyre::Result<()> {
+    // Trigger that:
+    // - Subscribes to changes in the domain "dom_{i}" with statuses "{s}", which denotes `xxx`.
+    // - Publishes the deletion of the domain "dom_{j}".
+    let when_i_xxx_then_j_del = |i: usize, s: &str, xxx: DomainEventSet, j: usize| {
+        Trigger::new(
+            format!("trg_{i}{s}_{j}d").parse().unwrap(),
+            Action::new(
+                vec![Unregister::domain(format!("dom_{j}").parse().unwrap())],
+                Repeats::Indefinitely,
+                ALICE_ID.clone(),
+                DomainEventFilter::new()
+                    .for_domain(format!("dom_{i}").parse().unwrap())
+                    .for_events(xxx),
+            ),
+        )
+    };
+    let when_0_del_then_1_del = when_i_xxx_then_j_del(0, "d", DomainEventSet::Deleted, 1);
+    // A potential connection exists through the deletion of "dom_1".
+    let when_1_del_then_2_del = when_i_xxx_then_j_del(1, "d", DomainEventSet::Deleted, 2);
+    let (network, _rt) = NetworkBuilder::new()
+        .with_genesis_instruction(Register::trigger(when_0_del_then_1_del))
+        .with_genesis_instruction(Register::trigger(when_1_del_then_2_del))
+        .start_blocking()?;
+    let test_client = network.client();
+
+    for (entry, leads_to_event_loop) in [
+        // Short-circuiting.
+        (
+            when_i_xxx_then_j_del(2, "d", DomainEventSet::Deleted, 0),
+            true,
+        ),
+        // No short-circuiting due to status mismatch.
+        (
+            when_i_xxx_then_j_del(
+                2,
+                "cu",
+                DomainEventSet::Created | DomainEventSet::OwnerChanged,
+                0,
+            ),
+            false,
+        ),
+        // Extending the graph.
+        (
+            when_i_xxx_then_j_del(2, "d", DomainEventSet::Deleted, 3),
+            false,
+        ),
+        // Creating another cyclic cluster.
+        (
+            when_i_xxx_then_j_del(3, "d", DomainEventSet::Deleted, 3),
+            true,
+        ),
+        // Creating another acyclic cluster.
+        (
+            when_i_xxx_then_j_del(3, "d", DomainEventSet::Deleted, 4),
+            false,
+        ),
+        {
+            let when_3_del_then_register_another = Trigger::new(
+                "trg_3d_register_another".parse().unwrap(),
+                Action::new(
+                    vec![Register::trigger(when_i_xxx_then_j_del(
+                        10,
+                        "d",
+                        DomainEventSet::Deleted,
+                        20,
+                    ))],
+                    Repeats::Indefinitely,
+                    ALICE_ID.clone(),
+                    DomainEventFilter::new()
+                        .for_domain("dom_3".parse().unwrap())
+                        .for_events(DomainEventSet::Deleted),
+                ),
+            );
+            // Creating an additional trigger.
+            (when_3_del_then_register_another, true)
+        },
+    ] {
+        match test_client.submit_blocking(Register::trigger(entry)) {
+            Ok(_) => assert!(!leads_to_event_loop),
+            Err(err) => {
+                use iroha_data_model::isi::error::InstructionExecutionError;
+                match err.root_cause().downcast_ref::<InstructionExecutionError>() {
+                    Some(InstructionExecutionError::InvariantViolation(msg)) => {
+                        assert!(msg.contains("trigger registration leads to event loop"))
+                    }
+                    _ => eyre::bail!("failed due to an unexpected error:{err}"),
+                }
+                assert!(leads_to_event_loop);
+            }
+        }
+    }
+
+    Ok(())
 }

--- a/crates/iroha/tests/triggers/orphans.rs
+++ b/crates/iroha/tests/triggers/orphans.rs
@@ -1,9 +1,6 @@
-use iroha::{
-    client::Client,
-    data_model::{prelude::*, query::trigger::FindTriggers},
-};
-use iroha_test_network::*;
-use iroha_test_samples::gen_account_in;
+use iroha::{client::Client, data_model::query::trigger::FindTriggers};
+
+use super::*;
 
 fn find_trigger(iroha: &Client, trigger_id: &TriggerId) -> Option<Trigger> {
     iroha

--- a/crates/iroha/tests/triggers/time_trigger.rs
+++ b/crates/iroha/tests/triggers/time_trigger.rs
@@ -6,14 +6,11 @@ use iroha::{
     data_model::{
         asset::AssetId,
         events::pipeline::{BlockEventFilter, BlockStatus},
-        prelude::*,
         Level,
     },
 };
-use iroha_test_network::*;
-use iroha_test_samples::{gen_account_in, load_sample_wasm, ALICE_ID};
 
-use crate::triggers::get_asset_value;
+use super::*;
 
 fn curr_time() -> Duration {
     use std::time::SystemTime;
@@ -142,6 +139,10 @@ fn pre_commit_trigger_should_be_executed() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    feature = "prediction",
+    ignore = "prediction through Wasm executables is not yet implemented"
+)]
 fn mint_nft_for_every_user_every_1_sec() -> Result<()> {
     const TRIGGER_PERIOD: Duration = Duration::from_millis(1000);
     const EXPECTED_COUNT: u64 = 4;

--- a/crates/iroha/tests/triggers/trigger_rollback.rs
+++ b/crates/iroha/tests/triggers/trigger_rollback.rs
@@ -1,9 +1,9 @@
 use eyre::Result;
-use iroha::data_model::{prelude::*, trigger::TriggerId};
-use iroha_test_network::*;
-use iroha_test_samples::ALICE_ID;
+
+use super::*;
 
 #[test]
+#[cfg_attr(feature = "prediction", ignore = "depends on deprecated event types")]
 fn failed_trigger_revert() -> Result<()> {
     let (network, _rt) = NetworkBuilder::new().start_blocking()?;
     let client = network.client();

--- a/crates/iroha_authorizer/Cargo.toml
+++ b/crates/iroha_authorizer/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "iroha_authorizer"
+edition.workspace = true
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+repository.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+iroha_tree = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/iroha_authorizer/src/lib.rs
+++ b/crates/iroha_authorizer/src/lib.rs
@@ -1,0 +1,105 @@
+//! A crate enabling user-defined logic to authorize or reject executables and queries based on the authority’s permissions and ownerships.
+//!
+//! This is a stripped-down version of the executor, focused solely on permission validation.
+//! It does not define or execute instructions.
+
+#![no_std]
+
+extern crate alloc;
+use alloc::rc::Rc;
+use core::ops::BitOr;
+
+use iroha_tree::{dm, event, fuzzy_node, permission, readset, some, state, Filtered};
+
+/// User-defined logic responsible for permission validation:
+///
+/// - Validates write access using event predictions.
+/// - Performs post-execution validation for read access to world entities using actual events.
+/// - Performs post-execution validation for read access to transactions using events derived from transaction executables.
+pub trait Authorizer {
+    /// Query declaration to retrieve the data required for authorization.
+    fn context_request(&self) -> readset::ReadSet;
+
+    /// Authorizes or rejects read or write requests based on events and contexts, which typically include the authority's permissions.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the event-based access attempt is determined to exceed the given context's permissions.
+    fn authorize(
+        &self,
+        event: &event::Event,
+        context: &state::StateView,
+    ) -> Result<(), PermissionDenied>;
+}
+
+/// Indicates an authorization failure.
+/// In post-execution validation for queries, this error should not reveal information about data existence.
+pub enum PermissionDenied {
+    /// Informs that authorization could have passed if this permission were present.
+    MissingPermission(permission::Permission),
+    /// Only indicates that the authorization has failed.
+    Forbidden,
+}
+
+// TODO: Implement equivalent logic to the following in Wasm.
+
+/// A sample authorizer with standard behavior.
+#[derive(Debug)]
+pub struct DefaultAuthorizer {
+    authority: dm::AccountId,
+}
+
+impl Authorizer for DefaultAuthorizer {
+    fn context_request(&self) -> readset::ReadSet {
+        use readset::UnitR;
+
+        let key = (
+            some!(self.authority.signatory.clone()),
+            some!(self.authority.domain.clone()),
+        );
+        let (acc, dom) = (|| key.0.clone(), || key.1.clone());
+
+        // TODO: The `state::WorldState::load` should complete relevant primary entities, similar to the data integrity check in `state::WorldState::sanitize`.
+        readset::ReadSet::from_iter([
+            fuzzy_node!(AccountRole, acc(), dom(), None, UnitR),
+            fuzzy_node!(AccountPermission, acc(), dom(), None, UnitR),
+            fuzzy_node!(DomainAdmin, None, acc(), dom(), UnitR),
+            fuzzy_node!(AssetAdmin, None, None, acc(), dom(), UnitR),
+            fuzzy_node!(NftAdmin, None, None, acc(), dom(), UnitR),
+            fuzzy_node!(NftOwner, None, None, acc(), dom(), UnitR),
+            fuzzy_node!(TriggerAdmin, None, acc(), dom(), UnitR),
+        ])
+    }
+
+    fn authorize(
+        &self,
+        event: &event::Event,
+        _context: &state::StateView,
+    ) -> Result<(), PermissionDenied> {
+        // TODO: Implement data retrieval from `context`.
+        let role_permission = permission::Permission::default();
+        let account_permission = permission::Permission::default();
+        let domain_admin = permission::Permission::default();
+        let asset_admin = permission::Permission::default();
+        let nft_admin = permission::Permission::default();
+        let nft_owner = permission::Permission::default();
+        let trigger_admin = permission::Permission::default();
+
+        let permission = [
+            account_permission,
+            role_permission,
+            domain_admin,
+            asset_admin,
+            nft_admin,
+            nft_owner,
+            trigger_admin,
+        ]
+        .into_iter()
+        .reduce(BitOr::bitor)
+        .unwrap();
+
+        event
+            .passes(&permission)
+            .map_err(PermissionDenied::MissingPermission)
+    }
+}

--- a/crates/iroha_core/Cargo.toml
+++ b/crates/iroha_core/Cargo.toml
@@ -24,6 +24,8 @@ telemetry = []
 expensive-telemetry = ["iroha_telemetry/metric-instrumentation"]
 # Profiler integration for wasmtime
 profiling = []
+# Abstract instructions, events, and event filters into a generic structure to simulate possible execution paths.
+prediction = ["dep:iroha_tree"]
 
 [badges]
 is-it-maintained-issue-resolution = { repository = "https://github.com/hyperledger-iroha/iroha" }
@@ -44,6 +46,7 @@ iroha_primitives = { workspace = true }
 iroha_genesis = { workspace = true }
 iroha_wasm_codec = { workspace = true }
 mv = { workspace = true, features = ["serde"] }
+iroha_tree = { workspace = true, optional = true }
 
 async-trait = { workspace = true }
 dashmap = { workspace = true }

--- a/crates/iroha_core/src/lib.rs
+++ b/crates/iroha_core/src/lib.rs
@@ -14,6 +14,8 @@ pub mod smartcontracts;
 pub mod snapshot;
 pub mod state;
 pub mod sumeragi;
+#[cfg(feature = "prediction")]
+pub mod tree;
 pub mod tx;
 
 use core::time::Duration;

--- a/crates/iroha_core/src/smartcontracts/isi/mod.rs
+++ b/crates/iroha_core/src/smartcontracts/isi/mod.rs
@@ -383,6 +383,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(feature = "prediction", ignore = "depends on deprecated event types")]
     async fn unauthorized_trigger_execution_should_return_error() -> Result<()> {
         let kura = Kura::blank_kura_for_testing();
         let state = state_with_test_domains(&kura)?;

--- a/crates/iroha_core/src/tree/mod.rs
+++ b/crates/iroha_core/src/tree/mod.rs
@@ -1,0 +1,121 @@
+//! Transitional interface for [`iroha_tree`].
+
+use std::rc::Rc;
+
+use iroha_tree::{
+    changeset, event, node, readset, receptor, state, transitional as tr, FuzzyNodeKey,
+    NodeConflict, NodeEntry,
+};
+use mv::storage::StorageReadOnly;
+
+use crate::{
+    smartcontracts::triggers::{
+        set::{ExecutableRef, SetReadOnly},
+        specialized::LoadedActionTrait,
+    },
+    state::{StateReadOnly, StateTransaction, WorldReadOnly},
+};
+
+/// TODO when instructions as an executable were replaced with a changeset
+#[derive(Debug, Clone, Copy)]
+pub struct InvariantViolation;
+
+impl From<Box<NodeConflict<changeset::Write>>> for InvariantViolation {
+    fn from(_value: Box<NodeConflict<changeset::Write>>) -> Self {
+        unimplemented!("TODO when instructions as an executable were replaced with a changeset")
+    }
+}
+
+impl state::WorldState for StateTransaction<'_, '_> {
+    type InvariantViolation = InvariantViolation;
+
+    fn update_by(
+        &mut self,
+        _entry: NodeEntry<changeset::Write>,
+    ) -> Result<(), Self::InvariantViolation> {
+        unimplemented!("TODO when instructions as an executable were replaced with a changeset")
+    }
+
+    fn sanitize(
+        &self,
+        _event_prediction: &event::Event,
+    ) -> Result<changeset::ChangeSet, Self::InvariantViolation> {
+        // TODO: #4672 Cascade or restrict on delete?
+        unimplemented!("TODO when instructions as an executable were replaced with a changeset")
+    }
+
+    fn load(&self, readset: &readset::ReadSet) -> state::StateView {
+        let mut res = state::StateView::default();
+        for (k, _v) in readset.iter() {
+            match k {
+                FuzzyNodeKey::Trigger(key) => {
+                    self.world()
+                        .triggers()
+                        // FIXME: Other types of triggers are irrelevant as long as this function is used solely for event loop detection.
+                        .data_triggers()
+                        .iter()
+                        .filter(|(id, _)| key.as_ref().map_or(true, |key| **key == **id))
+                        .for_each(|(id, action)| {
+                            let trigger = state::tr::TriggerV::from(action.repeats);
+                            let condition = state::tr::ConditionV::from(receptor::Receptor::from(action.filter.clone()));
+                            let executable = match action.executable() {
+                                ExecutableRef::Wasm(_hash) => {
+                                    let wasm = state::tr::WasmExecutable;
+                                    state::tr::ExecutableV::Dynamic(wasm)
+                                }
+                                ExecutableRef::Instructions(instructions) => {
+                                    let changeset = (
+                                        action.authority.clone(),
+                                        instructions.clone().into_vec(),
+                                    )
+                                        .try_into()
+                                        .expect("instructions that are already registered as an executable should be converted into a changeset");
+                                    state::tr::ExecutableV::Static(changeset)
+                                }
+                            };
+                            let trigger_id = id.clone();
+                            let condition_id = tr::ConditionId::from(&condition);
+                            let executable_id = tr::ExecutableId::from(&executable);
+
+                            for entry in [
+                                node!(Trigger, trigger_id.clone(), trigger),
+                                node!(
+                                    Condition,
+                                    condition_id.clone(),
+                                    condition
+                                ),
+                                node!(
+                                    Executable,
+                                    executable_id.clone(),
+                                    executable
+                                ),
+                                node!(
+                                    TriggerCondition,
+                                    trigger_id.clone(),
+                                    condition_id,
+                                    state::tr::UnitV
+                                ),
+                                node!(
+                                    TriggerExecutable,
+                                    trigger_id.clone(),
+                                    executable_id,
+                                    state::tr::UnitV
+                                ),
+                                node!(
+                                    TriggerAdmin,
+                                    trigger_id,
+                                    action.authority.signatory.clone(),
+                                    action.authority.domain.clone(),
+                                    state::tr::UnitV
+                                ),
+                            ] {
+                                res.insert(entry);
+                            }
+                        })
+                }
+                _ => unimplemented!("no use for now"),
+            }
+        }
+        res
+    }
+}

--- a/crates/iroha_data_model/src/block.rs
+++ b/crates/iroha_data_model/src/block.rs
@@ -2,6 +2,8 @@
 //!
 //! `Block`s are organised into a linear sequence over time (also known as the block chain).
 
+#[cfg(all(feature = "transparent_api", not(feature = "std")))]
+use alloc::{borrow::ToOwned, vec};
 #[cfg(not(feature = "std"))]
 use alloc::{boxed::Box, collections::BTreeMap, format, string::String, vec::Vec};
 use core::{fmt::Display, time::Duration};

--- a/crates/iroha_data_model/src/events/data/filters.rs
+++ b/crates/iroha_data_model/src/events/data/filters.rs
@@ -72,9 +72,9 @@ mod model {
     )]
     pub struct PeerEventFilter {
         /// If specified matches only events originating from this peer
-        pub(super) id_matcher: Option<super::PeerId>,
+        pub id_matcher: Option<super::PeerId>,
         /// Matches only event from this set
-        pub(super) event_set: PeerEventSet,
+        pub event_set: PeerEventSet,
     }
 
     /// An event filter for [`DomainEvent`]s
@@ -94,9 +94,9 @@ mod model {
     )]
     pub struct DomainEventFilter {
         /// If specified matches only events originating from this domain
-        pub(super) id_matcher: Option<super::DomainId>,
+        pub id_matcher: Option<super::DomainId>,
         /// Matches only event from this set
-        pub(super) event_set: DomainEventSet,
+        pub event_set: DomainEventSet,
     }
 
     /// An event filter for [`AccountEvent`]s
@@ -116,9 +116,9 @@ mod model {
     )]
     pub struct AccountEventFilter {
         /// If specified matches only events originating from this account
-        pub(super) id_matcher: Option<super::AccountId>,
+        pub id_matcher: Option<super::AccountId>,
         /// Matches only event from this set
-        pub(super) event_set: AccountEventSet,
+        pub event_set: AccountEventSet,
     }
 
     /// An event filter for [`AssetEvent`]s
@@ -138,9 +138,9 @@ mod model {
     )]
     pub struct AssetEventFilter {
         /// If specified matches only events originating from this asset
-        pub(super) id_matcher: Option<super::AssetId>,
+        pub id_matcher: Option<super::AssetId>,
         /// Matches only event from this set
-        pub(super) event_set: AssetEventSet,
+        pub event_set: AssetEventSet,
     }
 
     /// An event filter for [`AssetDefinitionEvent`]s
@@ -160,9 +160,9 @@ mod model {
     )]
     pub struct AssetDefinitionEventFilter {
         /// If specified matches only events originating from this asset definition
-        pub(super) id_matcher: Option<super::AssetDefinitionId>,
+        pub id_matcher: Option<super::AssetDefinitionId>,
         /// Matches only event from this set
-        pub(super) event_set: AssetDefinitionEventSet,
+        pub event_set: AssetDefinitionEventSet,
     }
 
     /// An event filter for [`NftEvent`]s
@@ -182,9 +182,9 @@ mod model {
     )]
     pub struct NftEventFilter {
         /// If specified matches only events originating from this NFT
-        pub(super) id_matcher: Option<NftId>,
+        pub id_matcher: Option<NftId>,
         /// Matches only event from this set
-        pub(super) event_set: NftEventSet,
+        pub event_set: NftEventSet,
     }
 
     /// An event filter for [`TriggerEvent`]s
@@ -204,9 +204,9 @@ mod model {
     )]
     pub struct TriggerEventFilter {
         /// If specified matches only events originating from this trigger
-        pub(super) id_matcher: Option<super::TriggerId>,
+        pub id_matcher: Option<super::TriggerId>,
         /// Matches only event from this set
-        pub(super) event_set: TriggerEventSet,
+        pub event_set: TriggerEventSet,
     }
 
     /// An event filter for [`RoleEvent`]s
@@ -226,9 +226,9 @@ mod model {
     )]
     pub struct RoleEventFilter {
         /// If specified matches only events originating from this role
-        pub(super) id_matcher: Option<super::RoleId>,
+        pub id_matcher: Option<super::RoleId>,
         /// Matches only event from this set
-        pub(super) event_set: RoleEventSet,
+        pub event_set: RoleEventSet,
     }
 
     /// An event filter for [`ConfigurationEvent`]s
@@ -248,7 +248,7 @@ mod model {
     )]
     pub struct ConfigurationEventFilter {
         /// Matches only event from this set
-        pub(super) event_set: ConfigurationEventSet,
+        pub event_set: ConfigurationEventSet,
     }
 
     /// An event filter for [`ExecutorEvent`].
@@ -269,7 +269,7 @@ mod model {
     pub struct ExecutorEventFilter {
         // executor is a global entity, so no id here
         /// Matches only event from this set
-        pub(super) event_set: ExecutorEventSet,
+        pub event_set: ExecutorEventSet,
     }
 }
 

--- a/crates/iroha_data_model/src/events/mod.rs
+++ b/crates/iroha_data_model/src/events/mod.rs
@@ -46,8 +46,10 @@ mod model {
         /// Time event.
         Time(time::TimeEvent),
         /// Trigger execution event.
+        // TODO #4968 Remove as it is no longer needed.
         ExecuteTrigger(execute_trigger::ExecuteTriggerEvent),
         /// Trigger completion event.
+        // TODO #4968 Merge into pipeline events as an internal transaction.
         TriggerCompleted(trigger_completed::TriggerCompletedEvent),
     }
 

--- a/crates/iroha_data_model_derive/src/event_set.rs
+++ b/crates/iroha_data_model_derive/src/event_set.rs
@@ -247,7 +247,7 @@ impl ToTokens for EventSetEnum {
                 /// Decomposes an `EventSet` into a vector of basis `EventSet`s, each containing a single event
                 ///
                 /// Each of the event set in the vector will be equal to some of the associated constants for the `EventSet`
-                fn decompose(&self) -> Vec<Self> {
+                pub fn decompose(&self) -> Vec<Self> {
                     let mut result = Vec::new();
 
                     #(if self.contains(#flag_idents) {

--- a/crates/iroha_tree/Cargo.toml
+++ b/crates/iroha_tree/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "iroha_tree"
+edition.workspace = true
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+repository.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lints]
+workspace = true
+
+[features]
+std = ["iroha_data_model/std"]
+
+[dependencies]
+iroha_data_model = { workspace = true, features = ["transparent_api"] }
+iroha_executor_data_model = { workspace = true }
+iroha_logger = { workspace = true }
+
+derive_more = { workspace = true, features = ["add"] }
+hashbrown = "0.15"
+parity-scale-codec = { workspace = true }
+serde_with = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/iroha_tree/src/changeset.rs
+++ b/crates/iroha_tree/src/changeset.rs
@@ -1,0 +1,824 @@
+//! Module for [`ChangeSet`] and related components.
+
+use super::*;
+
+/// Represents write access for each node.
+pub type ChangeSet = Tree<Write>;
+
+/// Each node value indicates write access.
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+pub struct Write;
+
+impl Mode for Write {
+    type Authorizer = AuthorizerW;
+    type Parameter = ParameterW;
+    type Peer = UnitW;
+    type Domain = DomainW;
+    type Account = UnitW;
+    type Asset = AssetW;
+    type Nft = NftW;
+    type AccountAsset = AccountAssetW;
+    type Role = UnitW;
+    type Permission = PermissionW;
+    type AccountRole = UnitW;
+    type AccountPermission = UnitW;
+    type RolePermission = UnitW;
+    type Trigger = TriggerW;
+    type Condition = ConditionW;
+    type Executable = ExecutableW;
+    type TriggerCondition = UnitW;
+    type TriggerExecutable = UnitW;
+    type DomainMetadata = MetadataW;
+    type AccountMetadata = MetadataW;
+    type AssetMetadata = MetadataW;
+    type NftData = MetadataW;
+    type TriggerMetadata = MetadataW;
+    type DomainAdmin = UnitW;
+    type AssetAdmin = UnitW;
+    type NftAdmin = UnitW;
+    type NftOwner = UnitW;
+    type TriggerAdmin = UnitW;
+}
+
+/// Write access at `Authorizer` type nodes.
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+pub enum AuthorizerW {
+    Set(state::tr::AuthorizerV),
+}
+
+/// Write access at `Unit` type nodes.
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+pub enum UnitW {
+    Create(()),
+    Delete(()),
+}
+
+/// Write access at `Parameter` type nodes.
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+pub enum ParameterW {
+    Set(state::tr::ParameterV),
+    Unset(()),
+}
+
+/// Write access at `Domain` type nodes.
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+pub enum DomainW {
+    Create(state::tr::DomainV),
+    Delete(()),
+}
+
+/// Write access at `Asset` type nodes.
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+pub enum AssetW {
+    MintabilityUpdate(dm::Mintable),
+    Create(state::tr::AssetV),
+    Delete(()),
+}
+
+/// Write access at `Nft` type nodes.
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+pub enum NftW {
+    Create(state::tr::NftV),
+    Delete(()),
+}
+
+/// Write access at `AccountAsset` type nodes.
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+pub enum AccountAssetW {
+    Receive(dm::Numeric),
+    Send(dm::Numeric),
+    Mint(dm::Numeric),
+    Burn(dm::Numeric),
+}
+
+/// Write access at `Permission` type nodes.
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+pub enum PermissionW {
+    Set(state::tr::PermissionV),
+    Unset(()),
+}
+
+/// Write access at `Trigger` type nodes.
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+pub enum TriggerW {
+    Increase(u32),
+    Decrease(u32),
+    Create(state::tr::TriggerV),
+    Delete(()),
+}
+
+/// Write access at `Condition` type nodes.
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+pub enum ConditionW {
+    Set(state::tr::ConditionV),
+    Unset(()),
+}
+
+/// Write access at `Executable` type nodes.
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+pub enum ExecutableW {
+    Set(state::tr::ExecutableV),
+    Unset(()),
+}
+
+/// Write access at `Metadata` type nodes.
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+pub enum MetadataW {
+    Set(state::tr::MetadataV),
+    Unset(()),
+}
+
+impl NodeReadWrite for ChangeSet {
+    type Status = event::Event;
+
+    fn as_status(&self) -> Self::Status {
+        self.iter()
+            .map(|(k, write)| NodeEntry::try_from((k.clone(), write.into())).unwrap())
+            .collect()
+    }
+}
+
+impl Add for ChangeSet {
+    type Output = Result<Self, Box<NodeConflict<Write>>>;
+
+    fn add(self, mut rhs: Self) -> Self::Output {
+        for (k, v0) in self {
+            let v = match rhs.remove(&k) {
+                None => v0,
+                Some(v1) => match v0 + v1 {
+                    Ok(v) => v,
+                    Err((v0, v1)) => return Err(NodeConflict::new(k, v0, v1).into()),
+                },
+            };
+            rhs.insert(NodeEntry::try_from((k, v)).unwrap());
+        }
+        Ok(rhs)
+    }
+}
+
+macro_rules! impl_add_err {
+    ($($ty:ty,)+) => {
+        $(
+        impl Add for $ty {
+            type Output = Result<Self, (Self, Self)>;
+
+            fn add(self, rhs: Self) -> Self::Output {
+                Err((self, rhs))
+            }
+        }
+        )+
+    };
+}
+
+// Multiple modifications to the same node within a single transaction are generally not allowed.
+impl_add_err!(
+    AuthorizerW,
+    UnitW,
+    ParameterW,
+    DomainW,
+    AssetW,
+    NftW,
+    PermissionW,
+    ConditionW,
+    ExecutableW,
+    MetadataW,
+);
+
+impl Add for AccountAssetW {
+    type Output = Result<Self, (Self, Self)>;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let add = match (self, rhs) {
+            (Self::Receive(l), Self::Receive(r)) => match l.checked_add(r) {
+                Some(add) => Self::Receive(add),
+                _ => return Err((Self::Receive(l), Self::Receive(r))),
+            },
+            (Self::Send(l), Self::Send(r)) => match l.checked_add(r) {
+                Some(add) => Self::Send(add),
+                _ => return Err((Self::Send(l), Self::Send(r))),
+            },
+            (Self::Mint(l), Self::Mint(r)) => match l.checked_add(r) {
+                Some(add) => Self::Mint(add),
+                _ => return Err((Self::Mint(l), Self::Mint(r))),
+            },
+            (Self::Burn(l), Self::Burn(r)) => match l.checked_add(r) {
+                Some(add) => Self::Burn(add),
+                _ => return Err((Self::Burn(l), Self::Burn(r))),
+            },
+            (l, r) => return Err((l, r)),
+        };
+        Ok(add)
+    }
+}
+
+impl Add for TriggerW {
+    type Output = Result<Self, (Self, Self)>;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let add = match (self, rhs) {
+            (Self::Increase(l), Self::Increase(r)) => match l.checked_add(r) {
+                Some(add) => Self::Increase(add),
+                _ => return Err((Self::Increase(l), Self::Increase(r))),
+            },
+            (Self::Decrease(l), Self::Decrease(r)) => match l.checked_add(r) {
+                Some(add) => Self::Decrease(add),
+                _ => return Err((Self::Decrease(l), Self::Decrease(r))),
+            },
+            (l, r) => return Err((l, r)),
+        };
+        Ok(add)
+    }
+}
+
+mod transitional {
+    use super::*;
+
+    impl TryFrom<(dm::AccountId, Vec<dm::InstructionBox>)> for ChangeSet {
+        type Error = Box<NodeConflict<Write>>;
+
+        fn try_from(
+            (authority, instructions): (dm::AccountId, Vec<dm::InstructionBox>),
+        ) -> Result<Self, Self::Error> {
+            instructions
+                .into_iter()
+                .try_fold(Self::default(), |acc, x| {
+                    acc + (authority.clone(), x).try_into()?
+                })
+        }
+    }
+
+    impl TryFrom<(dm::AccountId, dm::InstructionBox)> for ChangeSet {
+        type Error = Box<NodeConflict<Write>>;
+
+        #[expect(clippy::too_many_lines)]
+        fn try_from(
+            (authority, instruction): (dm::AccountId, dm::InstructionBox),
+        ) -> Result<Self, Self::Error> {
+            use dm::{
+                numeric, BurnBox, GrantBox, InstructionBox, MintBox, Numeric, RegisterBox,
+                RemoveKeyValueBox, RevokeBox, SetKeyValueBox, TransferBox, UnregisterBox,
+            };
+
+            let changeset: Self = match instruction {
+                InstructionBox::Register(inst) => match inst {
+                    RegisterBox::Peer(inst) => [node!(Peer, inst.object, UnitW::Create(()))]
+                        .into_iter()
+                        .collect(),
+                    RegisterBox::Domain(inst) => [
+                        node!(
+                            DomainAdmin,
+                            inst.object.id.clone(),
+                            authority.signatory,
+                            authority.domain,
+                            UnitW::Create(())
+                        ),
+                        node!(
+                            Domain,
+                            inst.object.id,
+                            DomainW::Create(inst.object.logo.into())
+                        ),
+                    ]
+                    .into_iter()
+                    .collect(),
+                    RegisterBox::Account(inst) => [node!(
+                        Account,
+                        inst.object.id.signatory,
+                        inst.object.id.domain,
+                        UnitW::Create(())
+                    )]
+                    .into_iter()
+                    .collect(),
+                    RegisterBox::AssetDefinition(inst) => [
+                        node!(
+                            AssetAdmin,
+                            inst.object.id.name.clone(),
+                            inst.object.id.domain.clone(),
+                            authority.signatory,
+                            authority.domain,
+                            UnitW::Create(())
+                        ),
+                        node!(
+                            Asset,
+                            inst.object.id.name,
+                            inst.object.id.domain,
+                            AssetW::Create(state::tr::AssetV::new(
+                                numeric!(0),
+                                inst.object.mintable,
+                                inst.object.logo
+                            ))
+                        ),
+                    ]
+                    .into_iter()
+                    .collect(),
+                    RegisterBox::Nft(inst) => [
+                        node!(
+                            NftAdmin,
+                            inst.object.id.name.clone(),
+                            inst.object.id.domain.clone(),
+                            authority.signatory.clone(),
+                            authority.domain.clone(),
+                            UnitW::Create(())
+                        ),
+                        node!(
+                            NftOwner,
+                            inst.object.id.name.clone(),
+                            inst.object.id.domain.clone(),
+                            authority.signatory,
+                            authority.domain,
+                            UnitW::Create(())
+                        ),
+                        node!(
+                            Nft,
+                            inst.object.id.name.clone(),
+                            inst.object.id.domain.clone(),
+                            NftW::Create(state::tr::NftV)
+                        ),
+                    ]
+                    .into_iter()
+                    .chain(inst.object.content.iter().map(|(k, v)| {
+                        node!(
+                            NftData,
+                            inst.object.id.name.clone(),
+                            inst.object.id.domain.clone(),
+                            k.clone(),
+                            MetadataW::Set(v.clone().into())
+                        )
+                    }))
+                    .collect(),
+                    RegisterBox::Role(inst) => {
+                        [node!(Role, inst.object.inner.id, UnitW::Create(()))]
+                            .into_iter()
+                            .collect()
+                    }
+                    RegisterBox::Trigger(inst) => {
+                        let trigger = state::tr::TriggerV::from(inst.object.action.repeats);
+                        let condition = state::tr::ConditionV::try_from(inst.object.action.filter)
+                            .expect("event filter type should be either data or time");
+                        let executable = state::tr::ExecutableV::try_from((
+                            authority.clone(),
+                            inst.object.action.executable,
+                        ))?;
+                        let trigger_id = inst.object.id;
+                        let condition_id = tr::ConditionId::from(&condition);
+                        let executable_id = tr::ExecutableId::from(&executable);
+                        [
+                            node!(Trigger, trigger_id.clone(), TriggerW::Create(trigger)),
+                            node!(Condition, condition_id.clone(), ConditionW::Set(condition)),
+                            node!(
+                                Executable,
+                                executable_id.clone(),
+                                ExecutableW::Set(executable)
+                            ),
+                            node!(
+                                TriggerCondition,
+                                trigger_id.clone(),
+                                condition_id,
+                                UnitW::Create(())
+                            ),
+                            node!(
+                                TriggerExecutable,
+                                trigger_id.clone(),
+                                executable_id,
+                                UnitW::Create(())
+                            ),
+                            node!(
+                                TriggerAdmin,
+                                trigger_id,
+                                authority.signatory,
+                                authority.domain,
+                                UnitW::Create(())
+                            ),
+                        ]
+                        .into_iter()
+                        .collect()
+                    }
+                },
+                InstructionBox::Unregister(inst) => match inst {
+                    UnregisterBox::Peer(inst) => [node!(Peer, inst.object, UnitW::Delete(()))]
+                        .into_iter()
+                        .collect(),
+                    UnregisterBox::Domain(inst) => {
+                        [node!(Domain, inst.object, DomainW::Delete(()))]
+                            .into_iter()
+                            .collect()
+                    }
+                    UnregisterBox::Account(inst) => [node!(
+                        Account,
+                        inst.object.signatory,
+                        inst.object.domain,
+                        UnitW::Delete(())
+                    )]
+                    .into_iter()
+                    .collect(),
+                    UnregisterBox::AssetDefinition(inst) => [node!(
+                        Asset,
+                        inst.object.name,
+                        inst.object.domain,
+                        AssetW::Delete(())
+                    )]
+                    .into_iter()
+                    .collect(),
+                    UnregisterBox::Nft(inst) => [node!(
+                        Nft,
+                        inst.object.name,
+                        inst.object.domain,
+                        NftW::Delete(())
+                    )]
+                    .into_iter()
+                    .collect(),
+                    UnregisterBox::Role(inst) => [node!(Role, inst.object, UnitW::Delete(()))]
+                        .into_iter()
+                        .collect(),
+                    UnregisterBox::Trigger(inst) => {
+                        [node!(Trigger, inst.object, TriggerW::Delete(()))]
+                            .into_iter()
+                            .collect()
+                    }
+                },
+                InstructionBox::Mint(inst) => match inst {
+                    MintBox::Asset(inst) => [node!(
+                        AccountAsset,
+                        inst.destination.account.signatory,
+                        inst.destination.account.domain,
+                        inst.destination.definition.name,
+                        inst.destination.definition.domain,
+                        AccountAssetW::Mint(inst.object)
+                    )]
+                    .into_iter()
+                    .collect(),
+                    MintBox::TriggerRepetitions(inst) => [node!(
+                        Trigger,
+                        inst.destination,
+                        TriggerW::Increase(inst.object)
+                    )]
+                    .into_iter()
+                    .collect(),
+                },
+                InstructionBox::Burn(inst) => match inst {
+                    BurnBox::Asset(inst) => [node!(
+                        AccountAsset,
+                        inst.destination.account.signatory,
+                        inst.destination.account.domain,
+                        inst.destination.definition.name,
+                        inst.destination.definition.domain,
+                        AccountAssetW::Burn(inst.object)
+                    )]
+                    .into_iter()
+                    .collect(),
+                    BurnBox::TriggerRepetitions(inst) => [node!(
+                        Trigger,
+                        inst.destination,
+                        TriggerW::Increase(inst.object)
+                    )]
+                    .into_iter()
+                    .collect(),
+                },
+                InstructionBox::Transfer(inst) => match inst {
+                    TransferBox::Domain(inst) => [
+                        node!(
+                            DomainAdmin,
+                            inst.object.clone(),
+                            inst.source.signatory,
+                            inst.source.domain,
+                            UnitW::Delete(())
+                        ),
+                        node!(
+                            DomainAdmin,
+                            inst.object,
+                            inst.destination.signatory,
+                            inst.destination.domain,
+                            UnitW::Create(())
+                        ),
+                    ]
+                    .into_iter()
+                    .collect(),
+                    TransferBox::AssetDefinition(inst) => [
+                        node!(
+                            AssetAdmin,
+                            inst.object.name.clone(),
+                            inst.object.domain.clone(),
+                            inst.source.signatory,
+                            inst.source.domain,
+                            UnitW::Delete(())
+                        ),
+                        node!(
+                            AssetAdmin,
+                            inst.object.name,
+                            inst.object.domain,
+                            inst.destination.signatory,
+                            inst.destination.domain,
+                            UnitW::Create(())
+                        ),
+                    ]
+                    .into_iter()
+                    .collect(),
+                    TransferBox::Nft(inst) => [
+                        node!(
+                            NftOwner,
+                            inst.object.name.clone(),
+                            inst.object.domain.clone(),
+                            inst.source.signatory,
+                            inst.source.domain,
+                            UnitW::Delete(())
+                        ),
+                        node!(
+                            NftOwner,
+                            inst.object.name,
+                            inst.object.domain,
+                            inst.destination.signatory,
+                            inst.destination.domain,
+                            UnitW::Create(())
+                        ),
+                    ]
+                    .into_iter()
+                    .collect(),
+                    TransferBox::Asset(inst) => [
+                        node!(
+                            AccountAsset,
+                            inst.source.account.signatory,
+                            inst.source.account.domain,
+                            inst.source.definition.name.clone(),
+                            inst.source.definition.domain.clone(),
+                            AccountAssetW::Send(inst.object)
+                        ),
+                        node!(
+                            AccountAsset,
+                            inst.destination.signatory,
+                            inst.destination.domain,
+                            inst.source.definition.name,
+                            inst.source.definition.domain,
+                            AccountAssetW::Receive(inst.object)
+                        ),
+                    ]
+                    .into_iter()
+                    .collect(),
+                },
+                InstructionBox::SetKeyValue(inst) => match inst {
+                    SetKeyValueBox::Domain(inst) => [node!(
+                        DomainMetadata,
+                        inst.object,
+                        inst.key,
+                        MetadataW::Set(inst.value.into())
+                    )]
+                    .into_iter()
+                    .collect(),
+                    SetKeyValueBox::Account(inst) => [node!(
+                        AccountMetadata,
+                        inst.object.signatory,
+                        inst.object.domain,
+                        inst.key,
+                        MetadataW::Set(inst.value.into())
+                    )]
+                    .into_iter()
+                    .collect(),
+                    SetKeyValueBox::AssetDefinition(inst) => [node!(
+                        AssetMetadata,
+                        inst.object.name,
+                        inst.object.domain,
+                        inst.key,
+                        MetadataW::Set(inst.value.into())
+                    )]
+                    .into_iter()
+                    .collect(),
+                    SetKeyValueBox::Nft(inst) => [node!(
+                        NftData,
+                        inst.object.name,
+                        inst.object.domain,
+                        inst.key,
+                        MetadataW::Set(inst.value.into())
+                    )]
+                    .into_iter()
+                    .collect(),
+                    SetKeyValueBox::Trigger(inst) => [node!(
+                        TriggerMetadata,
+                        inst.object,
+                        inst.key,
+                        MetadataW::Set(inst.value.into())
+                    )]
+                    .into_iter()
+                    .collect(),
+                },
+                InstructionBox::RemoveKeyValue(inst) => match inst {
+                    RemoveKeyValueBox::Domain(inst) => [node!(
+                        DomainMetadata,
+                        inst.object,
+                        inst.key,
+                        MetadataW::Unset(())
+                    )]
+                    .into_iter()
+                    .collect(),
+                    RemoveKeyValueBox::Account(inst) => [node!(
+                        AccountMetadata,
+                        inst.object.signatory,
+                        inst.object.domain,
+                        inst.key,
+                        MetadataW::Unset(())
+                    )]
+                    .into_iter()
+                    .collect(),
+                    RemoveKeyValueBox::AssetDefinition(inst) => [node!(
+                        AssetMetadata,
+                        inst.object.name,
+                        inst.object.domain,
+                        inst.key,
+                        MetadataW::Unset(())
+                    )]
+                    .into_iter()
+                    .collect(),
+                    RemoveKeyValueBox::Nft(inst) => [node!(
+                        NftData,
+                        inst.object.name,
+                        inst.object.domain,
+                        inst.key,
+                        MetadataW::Unset(())
+                    )]
+                    .into_iter()
+                    .collect(),
+                    RemoveKeyValueBox::Trigger(inst) => [node!(
+                        TriggerMetadata,
+                        inst.object,
+                        inst.key,
+                        MetadataW::Unset(())
+                    )]
+                    .into_iter()
+                    .collect(),
+                },
+                InstructionBox::Grant(inst) => match inst {
+                    GrantBox::Permission(inst) => [node!(
+                        AccountPermission,
+                        inst.destination.signatory,
+                        inst.destination.domain,
+                        tr::PermissionId::from(&inst.object),
+                        UnitW::Create(())
+                    )]
+                    .into_iter()
+                    .collect(),
+                    GrantBox::Role(inst) => [node!(
+                        AccountRole,
+                        inst.destination.signatory,
+                        inst.destination.domain,
+                        inst.object,
+                        UnitW::Create(())
+                    )]
+                    .into_iter()
+                    .collect(),
+                    GrantBox::RolePermission(inst) => [node!(
+                        RolePermission,
+                        inst.destination,
+                        tr::PermissionId::from(&inst.object),
+                        UnitW::Create(())
+                    )]
+                    .into_iter()
+                    .collect(),
+                },
+                InstructionBox::Revoke(inst) => match inst {
+                    RevokeBox::Permission(inst) => [node!(
+                        AccountPermission,
+                        inst.destination.signatory,
+                        inst.destination.domain,
+                        tr::PermissionId::from(&inst.object),
+                        UnitW::Delete(())
+                    )]
+                    .into_iter()
+                    .collect(),
+                    RevokeBox::Role(inst) => [node!(
+                        AccountRole,
+                        inst.destination.signatory,
+                        inst.destination.domain,
+                        inst.object,
+                        UnitW::Delete(())
+                    )]
+                    .into_iter()
+                    .collect(),
+                    RevokeBox::RolePermission(inst) => [node!(
+                        RolePermission,
+                        inst.destination,
+                        tr::PermissionId::from(&inst.object),
+                        UnitW::Delete(())
+                    )]
+                    .into_iter()
+                    .collect(),
+                },
+                InstructionBox::ExecuteTrigger(_inst) => unimplemented!(
+                    "planned to be replaced with calls to pre-registered executables"
+                ),
+                InstructionBox::SetParameter(inst) => [node!(
+                    Parameter,
+                    tr::ParameterId,
+                    ParameterW::Set(inst.0.into())
+                )]
+                .into_iter()
+                .collect(),
+                InstructionBox::Upgrade(_inst) => {
+                    [node!(Authorizer, AuthorizerW::Set(state::tr::AuthorizerV))]
+                        .into_iter()
+                        .collect()
+                }
+                InstructionBox::Log(inst) => {
+                    const TARGET: &str = "log_isi";
+                    match inst.level {
+                        dm::Level::TRACE => iroha_logger::trace!(target: TARGET, "{}", inst.msg),
+                        dm::Level::DEBUG => iroha_logger::debug!(target: TARGET, "{}", inst.msg),
+                        dm::Level::INFO => iroha_logger::info!(target: TARGET, "{}", inst.msg),
+                        dm::Level::WARN => iroha_logger::warn!(target: TARGET, "{}", inst.msg),
+                        dm::Level::ERROR => iroha_logger::error!(target: TARGET, "{}", inst.msg),
+                    }
+                    [].into_iter().collect()
+                }
+                InstructionBox::Custom(_inst) => unimplemented!(
+                    "planned to be replaced with calls to pre-registered executables"
+                ),
+            };
+
+            Ok(changeset)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(not(feature = "std"))]
+    use alloc::format;
+
+    use super::*;
+    use crate::event::UnitS;
+
+    #[test]
+    fn aggregates() {
+        let role_w = |i: usize, w: UnitW| node!(Role, format!("role_{i}").parse().unwrap(), w);
+        let role_w_set = |i: usize, w: UnitW| ChangeSet::from_iter([role_w(i, w)]);
+        assert!((role_w_set(0, UnitW::Create(())) + role_w_set(0, UnitW::Create(()))).is_err());
+        assert_eq!(
+            role_w_set(0, UnitW::Create(())) + role_w_set(1, UnitW::Create(())),
+            Ok(ChangeSet::from_iter([
+                role_w(0, UnitW::Create(())),
+                role_w(1, UnitW::Create(()))
+            ]))
+        );
+        assert_eq!(
+            role_w_set(0, UnitW::Create(())) + role_w_set(0, UnitW::Delete(())),
+            Err(Box::new(NodeConflict::new(
+                NodeKey::Role(Rc::new("role_0".parse().unwrap())),
+                NodeValue::Role(UnitW::Create(())),
+                NodeValue::Role(UnitW::Delete(())),
+            )))
+        );
+
+        let trigger_inc =
+            |n: u32| node!(Trigger, "trigger".parse().unwrap(), TriggerW::Increase(n));
+        let trigger_inc_set = |n: u32| ChangeSet::from_iter([trigger_inc(n)]);
+        assert_eq!(
+            (0..5)
+                .map(|_| trigger_inc_set(1))
+                .try_fold(ChangeSet::default(), |acc, x| acc + x),
+            Ok(ChangeSet::from_iter([trigger_inc(5)]))
+        );
+    }
+
+    #[test]
+    fn passes_permission() {
+        use permission::Permission;
+
+        let key = |i: usize| dm::RoleId::from_str(&format!("role_{i}")).unwrap();
+        let changesets = [
+            ChangeSet::default(),
+            ChangeSet::from_iter([node!(Role, key(0), UnitW::Create(()))]),
+            ChangeSet::from_iter([
+                node!(Role, key(0), UnitW::Create(())),
+                node!(Role, key(1), UnitW::Create(())),
+            ]),
+            ChangeSet::from_iter([
+                node!(Role, key(0), UnitW::Create(())),
+                node!(Role, key(1), UnitW::Delete(())),
+            ]),
+        ];
+        let permissions = [
+            Permission::default(),
+            Permission::from_iter([fuzzy_node!(Role, some!(key(0)), UnitS::Create)]),
+            Permission::from_iter([fuzzy_node!(Role, None, FilterU8::from_str("c").unwrap())]),
+            Permission::from_iter([fuzzy_node!(Role, None, FilterU8::from_str("cd").unwrap())]),
+        ];
+
+        let missing_permission = changesets[3].passes(&permissions[1]).unwrap_err();
+        let complemented_permission = permissions[1].clone() | missing_permission;
+        assert!(changesets[3].passes(&complemented_permission).is_ok());
+
+        for (i, changeset) in changesets.iter().enumerate() {
+            for (j, permission) in permissions.iter().enumerate() {
+                assert_eq!(i <= j, changeset.passes(permission).is_ok());
+            }
+        }
+    }
+}

--- a/crates/iroha_tree/src/event.rs
+++ b/crates/iroha_tree/src/event.rs
@@ -1,0 +1,392 @@
+//! Module for [`Event`] and related components.
+
+#![expect(trivial_numeric_casts)] // Why do Decode and Encode invoke this?
+
+use super::*;
+
+/// Represents the read or write status of each node.
+pub type Event = Tree<ReadWriteStatus>;
+
+/// Each node value indicates the read or write status.
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+pub struct ReadWriteStatus;
+
+impl Mode for ReadWriteStatus {
+    type Authorizer = AuthorizerS;
+    type Parameter = ParameterS;
+    type Peer = UnitS;
+    type Domain = DomainS;
+    type Account = UnitS;
+    type Asset = AssetS;
+    type Nft = NftS;
+    type AccountAsset = AccountAssetS;
+    type Role = UnitS;
+    type Permission = PermissionS;
+    type AccountRole = UnitS;
+    type AccountPermission = UnitS;
+    type RolePermission = UnitS;
+    type Trigger = TriggerS;
+    type Condition = ConditionS;
+    type Executable = ExecutableS;
+    type TriggerCondition = UnitS;
+    type TriggerExecutable = UnitS;
+    type DomainMetadata = MetadataS;
+    type AccountMetadata = MetadataS;
+    type AssetMetadata = MetadataS;
+    type NftData = MetadataS;
+    type TriggerMetadata = MetadataS;
+    type DomainAdmin = UnitS;
+    type AssetAdmin = UnitS;
+    type NftAdmin = UnitS;
+    type NftOwner = UnitS;
+    type TriggerAdmin = UnitS;
+}
+
+/// An expansion of the CRUD status of the target node.
+///
+/// - Delete: removing something, either allowing repetition (Unset) or not (Delete)
+/// - Create: creating something, either allowing repetition (Set) or not (Create)
+/// - Burn or Decrease: reducing something, breaking total balance
+/// - Mint or Increase: adding something, breaking total balance
+/// - Update: utility slot for various updates
+/// - Out, effectively Send: reducing something without breaking total balance
+/// - In, effectively Receive: adding something without breaking total balance
+/// - Read: accessing something without modifying it
+pub const STATUS_CHARS: [char; 8] = ['d', 'c', 'b', 'm', 'u', 'o', 'i', 'r'];
+
+macro_rules! u8_status {
+    (d) => {
+        0b1000_0000
+    };
+    (c) => {
+        0b0100_0000
+    };
+    (b) => {
+        0b0010_0000
+    };
+    (m) => {
+        0b0001_0000
+    };
+    (u) => {
+        0b0000_1000
+    };
+    (o) => {
+        0b0000_0100
+    };
+    (i) => {
+        0b0000_0010
+    };
+    (r) => {
+        0b0000_0001
+    };
+}
+
+/// Read or write status at `Authorizer` type nodes.
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Decode, Encode)]
+#[repr(u8)]
+pub enum AuthorizerS {
+    Read = u8_status!(r),
+    Set = u8_status!(c),
+}
+
+/// Read or write status at `Unit` type nodes.
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Decode, Encode)]
+#[repr(u8)]
+pub enum UnitS {
+    Read = u8_status!(r),
+    Create = u8_status!(c),
+    Delete = u8_status!(d),
+}
+
+/// Read or write status at `Parameter` type nodes.
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Decode, Encode)]
+#[repr(u8)]
+pub enum ParameterS {
+    Read = u8_status!(r),
+    Set = u8_status!(c),
+    Unset = u8_status!(d),
+}
+
+/// Read or write status at `Domain` type nodes.
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Decode, Encode)]
+#[repr(u8)]
+pub enum DomainS {
+    Read = u8_status!(r),
+    Create = u8_status!(c),
+    Delete = u8_status!(d),
+}
+
+/// Read or write status at `Asset` type nodes.
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Decode, Encode)]
+#[repr(u8)]
+pub enum AssetS {
+    Read = u8_status!(r),
+    MintabilityUpdate = u8_status!(u),
+    Create = u8_status!(c),
+    Delete = u8_status!(d),
+}
+
+/// Read or write status at `Nft` type nodes.
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Decode, Encode)]
+#[repr(u8)]
+pub enum NftS {
+    Read = u8_status!(r),
+    Create = u8_status!(c),
+    Delete = u8_status!(d),
+}
+
+/// Read or write status at `AccountAsset` type nodes.
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Decode, Encode)]
+#[repr(u8)]
+pub enum AccountAssetS {
+    Read = u8_status!(r),
+    Receive = u8_status!(i),
+    Send = u8_status!(o),
+    Mint = u8_status!(m),
+    Burn = u8_status!(b),
+}
+
+/// Read or write status at `Permission` type nodes.
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Decode, Encode)]
+#[repr(u8)]
+pub enum PermissionS {
+    Read = u8_status!(r),
+    Set = u8_status!(c),
+    Unset = u8_status!(d),
+}
+
+/// Read or write status at `Trigger` type nodes.
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Decode, Encode)]
+#[repr(u8)]
+pub enum TriggerS {
+    Read = u8_status!(r),
+    Increase = u8_status!(m),
+    Decrease = u8_status!(b),
+    Create = u8_status!(c),
+    Delete = u8_status!(d),
+}
+
+/// Read or write status at `Condition` type nodes.
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Decode, Encode)]
+#[repr(u8)]
+pub enum ConditionS {
+    Read = u8_status!(r),
+    Set = u8_status!(c),
+    Unset = u8_status!(d),
+}
+
+/// Read or write status at `Executable` type nodes.
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Decode, Encode)]
+#[repr(u8)]
+pub enum ExecutableS {
+    Read = u8_status!(r),
+    Set = u8_status!(c),
+    Unset = u8_status!(d),
+}
+
+/// Read or write status at `Metadata` type nodes.
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Decode, Encode)]
+#[repr(u8)]
+pub enum MetadataS {
+    Read = u8_status!(r),
+    Set = u8_status!(c),
+    Unset = u8_status!(d),
+}
+
+macro_rules! impl_from_state_write_filtered {
+    ($(($ty:ty, $state:ident, $write:ident: $($variant:ident)|+),)+) => {
+        $(
+        impl From<&state::tr::$state> for $ty {
+            fn from(_value: &state::tr::$state) -> Self {
+                Self::Read
+            }
+        }
+
+        impl From<&changeset::$write> for $ty {
+            fn from(value: &changeset::$write) -> Self {
+                match value {
+                    $(
+                    changeset::$write::$variant(_) => Self::$variant,
+                    )+
+                }
+            }
+        }
+
+        impl Filtered for $ty {
+            type Filter = FilterU8;
+
+            fn passes(&self, filter: &Self::Filter) -> Result<(), Self::Filter> {
+                FilterU8::from(*self).passes(filter)
+            }
+        }
+
+        impl From<$ty> for FilterU8 {
+            fn from(value: $ty) -> Self {
+                (value as u8).into()
+            }
+        }
+        )+
+    };
+}
+
+impl_from_state_write_filtered!(
+    (AuthorizerS, AuthorizerV, AuthorizerW: Set),
+    (UnitS, UnitV, UnitW: Create | Delete),
+    (ParameterS, ParameterV, ParameterW: Set | Unset),
+    (DomainS, DomainV, DomainW: Create | Delete),
+    (AssetS, AssetV, AssetW: MintabilityUpdate | Create | Delete),
+    (NftS, NftV, NftW: Create | Delete),
+    (AccountAssetS, AccountAssetV, AccountAssetW: Receive | Send | Mint | Burn),
+    (PermissionS, PermissionV, PermissionW: Set | Unset),
+    (TriggerS, TriggerV, TriggerW: Increase | Decrease | Create | Delete),
+    (ConditionS, ConditionV, ConditionW: Set | Unset),
+    (ExecutableS, ExecutableV, ExecutableW: Set | Unset),
+    (MetadataS, MetadataV, MetadataW: Set | Unset),
+);
+
+mod transitional {
+    use super::*;
+
+    impl From<dm::DataEvent> for Event {
+        // Other information besides the identifier is abstracted into a status code, but that should be fine since events should be lightweight. Retrieving details should be the role of queries.
+        fn from(value: dm::DataEvent) -> Self {
+            use dm::{
+                AccountEvent, AssetDefinitionEvent, AssetEvent, ConfigurationEvent, DataEvent::*,
+                DomainEvent, ExecutorEvent, NftEvent, PeerEvent, RoleEvent, TriggerEvent,
+            };
+
+            match value {
+                Peer(event) => match event {
+                    PeerEvent::Added(k) => [node!(Peer, k, UnitS::Create)].into_iter().collect(),
+                    PeerEvent::Removed(k) => [node!(Peer, k, UnitS::Delete)].into_iter().collect(),
+                },
+                Domain(event) => match event {
+                    DomainEvent::Created(v) => [node!(Domain, v.id, DomainS::Create)].into_iter().collect(),
+                    DomainEvent::Deleted(k) => [node!(Domain, k, DomainS::Delete)].into_iter().collect(),
+                    DomainEvent::AssetDefinition(event) => match event {
+                        AssetDefinitionEvent::Created(v) => [node!(Asset, v.id.name, v.id.domain, AssetS::Create)].into_iter().collect(),
+                        AssetDefinitionEvent::Deleted(k) => [node!(Asset, k.name, k.domain, AssetS::Delete)].into_iter().collect(),
+                        AssetDefinitionEvent::MetadataInserted(m) => [node!(AssetMetadata, m.target.name, m.target.domain, m.key, MetadataS::Set)].into_iter().collect(),
+                        AssetDefinitionEvent::MetadataRemoved(m) => [node!(AssetMetadata, m.target.name, m.target.domain, m.key, MetadataS::Unset)].into_iter().collect(),
+                        AssetDefinitionEvent::MintabilityChanged(k) => [node!(Asset, k.name, k.domain, AssetS::MintabilityUpdate)].into_iter().collect(),
+                        AssetDefinitionEvent::TotalQuantityChanged(_v) => unimplemented!("total quantities are a secondary state: listen for minting/burning instead"),
+                        AssetDefinitionEvent::OwnerChanged(v) => [
+                            // Not implemented because there is no such field as `AssetDefinitionOwnerChanged::old_owner`.
+                            // node_key_value!(AssetAdmin, v.asset_definition.name, v.asset_definition.domain, v.old_owner.signatory, v.old_owner.domain, UnitS::Delete),
+                            node!(AssetAdmin, v.asset_definition.name, v.asset_definition.domain, v.new_owner.signatory, v.new_owner.domain, UnitS::Create),
+                        ].into_iter().collect(),
+                    },
+                    DomainEvent::Nft(event) => match event {
+                        NftEvent::Created(v) => [node!(Nft, v.id.name, v.id.domain, NftS::Create)].into_iter().collect(),
+                        NftEvent::Deleted(k) => [node!(Nft, k.name, k.domain, NftS::Delete)].into_iter().collect(),
+                        NftEvent::MetadataInserted(m) => [node!(NftData, m.target.name, m.target.domain, m.key, MetadataS::Set)].into_iter().collect(),
+                        NftEvent::MetadataRemoved(m) => [node!(NftData, m.target.name, m.target.domain, m.key, MetadataS::Unset)].into_iter().collect(),
+                        NftEvent::OwnerChanged(v) => [
+                            // Not implemented because there is no such field as `NftOwnerChanged::old_owner`.
+                            // node_key_value!(NftOwner, v.nft.name, v.nft.domain, v.old_owner.signatory, v.old_owner.domain, UnitS::Delete),
+                            node!(NftOwner, v.nft.name, v.nft.domain, v.new_owner.signatory, v.new_owner.domain, UnitS::Create),
+                        ].into_iter().collect(),
+                    },
+                    DomainEvent::Account(event) => match event {
+                        AccountEvent::Created(v) => [node!(Account, v.id.signatory, v.id.domain, UnitS::Create)].into_iter().collect(),
+                        AccountEvent::Deleted(k) => [node!(Account, k.signatory, k.domain, UnitS::Delete)].into_iter().collect(),
+                        AccountEvent::Asset(event) => match event {
+                            // FIXME Ambiguous sources: Mint<Numeric, Asset>, Transfer<Asset, Numeric, Account>
+                            AssetEvent::Created(v) => [node!(AccountAsset, v.id.account.signatory, v.id.account.domain, v.id.definition.name, v.id.definition.domain, AccountAssetS::Mint)].into_iter().collect(),
+                            AssetEvent::Deleted(k) => [node!(AccountAsset, k.account.signatory, k.account.domain, k.definition.name, k.definition.domain, AccountAssetS::Burn)].into_iter().collect(),
+                            // FIXME Ambiguous sources: Mint<Numeric, Asset>, Transfer<Asset, Numeric, Account>
+                            AssetEvent::Added(v) => [node!(AccountAsset, v.asset.account.signatory, v.asset.account.domain, v.asset.definition.name, v.asset.definition.domain, AccountAssetS::Receive)].into_iter().collect(),
+                            // FIXME Ambiguous sources: Burn<Numeric, Asset>, Transfer<Asset, Numeric, Account>
+                            AssetEvent::Removed(v) => [node!(AccountAsset, v.asset.account.signatory, v.asset.account.domain, v.asset.definition.name, v.asset.definition.domain, AccountAssetS::Send)].into_iter().collect(),
+                        },
+                        AccountEvent::PermissionAdded(v) => [node!(AccountPermission, v.account.signatory, v.account.domain, (&v.permission).into(), UnitS::Create)].into_iter().collect(),
+                        AccountEvent::PermissionRemoved(v) => [node!(AccountPermission, v.account.signatory, v.account.domain, (&v.permission).into(), UnitS::Delete)].into_iter().collect(),
+                        AccountEvent::RoleGranted(v) => [node!(AccountRole, v.account.signatory, v.account.domain, v.role, UnitS::Create)].into_iter().collect(),
+                        AccountEvent::RoleRevoked(v) => [node!(AccountRole, v.account.signatory, v.account.domain, v.role, UnitS::Delete)].into_iter().collect(),
+                        AccountEvent::MetadataInserted(m) => [node!(AccountMetadata, m.target.signatory, m.target.domain, m.key, MetadataS::Set)].into_iter().collect(),
+                        AccountEvent::MetadataRemoved(m) => [node!(AccountMetadata, m.target.signatory, m.target.domain, m.key, MetadataS::Unset)].into_iter().collect(),
+                    },
+                    DomainEvent::MetadataInserted(m) => [node!(DomainMetadata, m.target, m.key, MetadataS::Set)].into_iter().collect(),
+                    DomainEvent::MetadataRemoved(m) => [node!(DomainMetadata, m.target, m.key, MetadataS::Unset)].into_iter().collect(),
+                    DomainEvent::OwnerChanged(v) => [
+                        // Not implemented because there is no such field as `DomainOwnerChanged::old_owner`.
+                        // node_key_value!(DomainAdmin, v.domain, v.old_owner.signatory, v.old_owner.domain, UnitS::Delete),
+                        node!(DomainAdmin, v.domain, v.new_owner.signatory, v.new_owner.domain, UnitS::Create),
+                    ].into_iter().collect(),
+                },
+                Trigger(event) => match event {
+                    TriggerEvent::Created(k) => [node!(Trigger, k, TriggerS::Create)].into_iter().collect(),
+                    TriggerEvent::Deleted(k) => [node!(Trigger, k, TriggerS::Delete)].into_iter().collect(),
+                    TriggerEvent::Extended(v) => [node!(Trigger, v.trigger, TriggerS::Increase)].into_iter().collect(),
+                    TriggerEvent::Shortened(v) => [node!(Trigger, v.trigger, TriggerS::Decrease)].into_iter().collect(),
+                    TriggerEvent::MetadataInserted(m) => [node!(TriggerMetadata, m.target, m.key, MetadataS::Set)].into_iter().collect(),
+                    TriggerEvent::MetadataRemoved(m) => [node!(TriggerMetadata, m.target, m.key, MetadataS::Unset)].into_iter().collect(),
+                },
+                Role(event) => match event {
+                    RoleEvent::Created(v) => [node!(Role, v.id, UnitS::Create)].into_iter().collect(),
+                    RoleEvent::Deleted(k) => [node!(Role, k, UnitS::Delete)].into_iter().collect(),
+                    RoleEvent::PermissionAdded(v) => [node!(RolePermission, v.role, (&v.permission).into(), UnitS::Create)].into_iter().collect(),
+                    RoleEvent::PermissionRemoved(v) => [node!(RolePermission, v.role, (&v.permission).into(), UnitS::Delete)].into_iter().collect(),
+                },
+                Configuration(event) => match event {
+                    ConfigurationEvent::Changed(_v) => [node!(Parameter, tr::ParameterId, ParameterS::Set)].into_iter().collect(),
+                },
+                // The executor is planned to be replaced with the authorizer. See the `iroha_authorizer` crate for details.
+                Executor(event) => match event {
+                    ExecutorEvent::Upgraded(_v) => [node!(Authorizer, AuthorizerS::Set)].into_iter().collect(),
+                },
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(not(feature = "std"))]
+    use alloc::format;
+
+    use super::*;
+
+    #[test]
+    fn passes_receptor() {
+        use receptor::Receptor;
+
+        let key = |i: usize| dm::RoleId::from_str(&format!("role_{i}")).unwrap();
+        let events = [
+            Event::default(),
+            Event::from_iter([node!(Role, key(0), UnitS::Create)]),
+            Event::from_iter([
+                node!(Role, key(0), UnitS::Create),
+                node!(Role, key(1), UnitS::Create),
+            ]),
+            Event::from_iter([
+                node!(Role, key(0), UnitS::Create),
+                node!(Role, key(1), UnitS::Delete),
+            ]),
+        ];
+        let receptors = [
+            Receptor::default(),
+            Receptor::from_iter([fuzzy_node!(Role, some!(key(0)), UnitS::Create)]),
+            Receptor::from_iter([fuzzy_node!(Role, None, FilterU8::from_str("c").unwrap())]),
+            Receptor::from_iter([fuzzy_node!(Role, None, FilterU8::from_str("cd").unwrap())]),
+        ];
+
+        for (i, event) in events.iter().enumerate() {
+            for (j, receptor) in receptors.iter().enumerate() {
+                assert_eq!(i <= j, event.passes(receptor).is_ok());
+            }
+        }
+    }
+}

--- a/crates/iroha_tree/src/lib.rs
+++ b/crates/iroha_tree/src/lib.rs
@@ -1,0 +1,633 @@
+//! A transitional crate that might eventually be merged into other crates.
+//!
+//! It aims to integrate executables, events, and event filters while enabling recursive trigger prediction in a static manner.
+//! The prediction is based on the union of possible execution paths, enabling pessimistic event loop detection.
+//!
+//! Additionally, to maintain performance, it consolidates:
+//!
+//! - Instructions into a single [`ChangeSet`] per transaction.
+//! - (Data) events into a single [`Event`] per transaction.
+//! - (Data) event filters into a single [`Receptor`] per trigger.
+//! - Permissions, roles, and ownerships into a single [`Permission`] per validation.
+
+#![expect(missing_copy_implementations)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use core::{
+    convert::Infallible,
+    fmt::{self, Debug, Display},
+    ops::{Add, BitOr},
+    str::FromStr,
+};
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::{
+    boxed::Box,
+    collections::{btree_map, BTreeMap, BTreeSet},
+    rc::Rc,
+    vec,
+    vec::Vec,
+};
+#[cfg(feature = "std")]
+use std::{
+    collections::{btree_map, BTreeMap, BTreeSet},
+    rc::Rc,
+};
+
+use derive_more::{BitOr, Constructor, DebugCustom, From};
+use parity_scale_codec::{Decode, Encode};
+use serde_with::{DeserializeFromStr, SerializeDisplay};
+
+pub mod changeset;
+pub mod event;
+pub mod permission;
+pub mod readset;
+pub mod receptor;
+pub mod state;
+
+/// A flattened node map with a fixed skeleton equivalent to the world state.
+/// Node values may vary by [`Mode`].
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+pub struct Tree<M: Mode>(BTreeMap<NodeKey, NodeValue<M>>);
+
+/// The same structure as [`Tree`], except that node keys can represent a certain group of nodes.
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+pub struct FuzzyTree<M: Mode>(BTreeMap<FuzzyNodeKey, NodeValue<M>>);
+
+macro_rules! declare_nodes {
+    ($(($variant:ident, $key:ident, $fuzzy_key:ident: $($key_element:ty),*),)+) => {
+        /// Exact path to nodes:
+        /// Can be considered as composite primary keys in an RDB.
+        #[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, Decode, Encode)]
+        #[allow(missing_docs)]
+        pub enum NodeKey {
+            $(
+            $variant($key),
+            )+
+        }
+
+        $(
+        declare_nodes!(_key_alias $key: $($key_element),*);
+        )+
+
+        /// Fuzzy path to nodes:
+        /// A `None` key element represents __any__ node.
+        /// For example, `(None, Some(domain)): AccountKey` represents any account within the specified `domain`.
+        #[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, Decode, Encode)]
+        #[allow(missing_docs)]
+        pub enum FuzzyNodeKey {
+            $(
+            $variant($fuzzy_key),
+            )+
+        }
+
+        $(
+        declare_nodes!(_fuzzy_key_alias $fuzzy_key: $($key_element),*);
+        )+
+
+        /// Represents various states such as the current state, intention, result, or readiness at the node.
+        #[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+        #[allow(missing_docs)]
+        pub enum NodeValue<M: Mode> {
+            $(
+            $variant(M::$variant),
+            )+
+        }
+
+        /// This trait implementation serves as a declaration of node values.
+        #[allow(missing_docs)]
+        pub trait Mode {
+            $(
+            type $variant: Debug + PartialEq + Eq + Clone + Decode + Encode;
+            )+
+        }
+    };
+    (_key_alias $key:ident:) => {
+        type $key = ();
+    };
+    (_key_alias $key:ident: $key_element:ty) => {
+        type $key = Rc<$key_element>;
+    };
+    (_key_alias $key:ident: $key_element_head:ty, $($key_element:ty),+) => {
+        type $key = (Rc<$key_element_head>, $(Rc<$key_element>),+);
+    };
+    (_fuzzy_key_alias $key:ident:) => {
+        type $key = ();
+    };
+    (_fuzzy_key_alias $key:ident: $key_element:ty) => {
+        type $key = Option<Rc<$key_element>>;
+    };
+    (_fuzzy_key_alias $key:ident: $key_element_head:ty, $($key_element:ty),+) => {
+        type $key = (Option<Rc<$key_element_head>>, $(Option<Rc<$key_element>>),+);
+    };
+}
+
+declare_nodes!(
+    (Authorizer, AuthorizerK, AuthorizerKF:),
+    (Parameter, ParameterK, ParameterKF: tr::ParameterId),
+    (Peer, PeerK, PeerKF: dm::PeerId),
+    (Domain, DomainK, DomainKF: dm::DomainId),
+    (Account, AccountK, AccountKF: dm::PublicKey, dm::DomainId),
+    (Asset, AssetK, AssetKF: dm::Name, dm::DomainId),
+    (Nft, NftK, NftKF: dm::Name, dm::DomainId),
+    (AccountAsset, AccountAssetK, AccountAssetKF: dm::PublicKey, dm::DomainId, dm::Name, dm::DomainId),
+    (Role, RoleK, RoleKF: dm::RoleId),
+    (Permission, PermissionK, PermissionKF: tr::PermissionId),
+    (AccountRole, AccountRoleK, AccountRoleKF: dm::PublicKey, dm::DomainId, dm::RoleId),
+    (AccountPermission, AccountPermissionK, AccountPermissionKF: dm::PublicKey, dm::DomainId, tr::PermissionId),
+    (RolePermission, RolePermissionK, RolePermissionKF: dm::RoleId, tr::PermissionId),
+    (Trigger, TriggerK, TriggerKF: dm::TriggerId),
+    (Condition, ConditionK, ConditionKF: tr::ConditionId),
+    (Executable, ExecutableK, ExecutableKF: tr::ExecutableId),
+    (TriggerCondition, TriggerConditionK, TriggerConditionKF: dm::TriggerId, tr::ConditionId),
+    (TriggerExecutable, TriggerExecutableK, TriggerExecutableKF: dm::TriggerId, tr::ExecutableId),
+    (DomainMetadata, DomainMetadataK, DomainMetadataKF: dm::DomainId, dm::Name),
+    (AccountMetadata, AccountMetadataK, AccountMetadataKF: dm::PublicKey, dm::DomainId, dm::Name),
+    (AssetMetadata, AssetMetadataK, AssetMetadataKF: dm::Name, dm::DomainId, dm::Name),
+    (NftData, NftDataK, NftDataKF: dm::Name, dm::DomainId, dm::Name),
+    (TriggerMetadata, TriggerMetadataK, TriggerMetadataKF: dm::TriggerId, dm::Name),
+    (DomainAdmin, DomainAdminK, DomainAdminKF: dm::DomainId, dm::PublicKey, dm::DomainId),
+    (AssetAdmin, AssetAdminK, AssetAdminKF: dm::Name, dm::DomainId, dm::PublicKey, dm::DomainId),
+    (NftAdmin, NftAdminK, NftAdminKF: dm::Name, dm::DomainId, dm::PublicKey, dm::DomainId),
+    (NftOwner, NftOwnerK, NftOwnerKF: dm::Name, dm::DomainId, dm::PublicKey, dm::DomainId),
+    (TriggerAdmin, TriggerAdminK, TriggerAdminKF: dm::TriggerId, dm::PublicKey, dm::DomainId),
+);
+
+/// Constructor utility for node key-value pairs.
+#[macro_export]
+macro_rules! node {
+    (_ $node_type:ident, $key:expr, $value:expr) => {
+        $crate::NodeEntry::try_from(($crate::NodeKey::$node_type($key), $crate::NodeValue::$node_type($value.into()))).unwrap()
+    };
+    ($node_type:ident, $value:expr) => {
+        $crate::node!(_ $node_type, (), $value)
+    };
+    ($node_type:ident, $k0:expr, $value:expr) => {
+        $crate::node!(_ $node_type, Rc::new($k0), $value)
+    };
+    ($node_type:ident, $k0:expr, $k1:expr, $value:expr) => {
+        $crate::node!(_ $node_type, (Rc::new($k0), Rc::new($k1)), $value)
+    };
+    ($node_type:ident, $k0:expr, $k1:expr, $k2:expr, $value:expr) => {
+        $crate::node!(_ $node_type, (Rc::new($k0), Rc::new($k1), Rc::new($k2)), $value)
+    };
+    ($node_type:ident, $k0:expr, $k1:expr, $k2:expr, $k3:expr, $value:expr) => {
+        $crate::node!(_ $node_type, (Rc::new($k0), Rc::new($k1), Rc::new($k2), Rc::new($k3)), $value)
+    };
+}
+
+/// Constructor utility for fuzzy node key-value pairs.
+#[macro_export]
+macro_rules! fuzzy_node {
+    (_ $node_type:ident, $key:expr, $value:expr) => {
+        $crate::FuzzyNodeEntry::try_from(($crate::FuzzyNodeKey::$node_type($key), $crate::NodeValue::$node_type($value.into()))).unwrap()
+    };
+    ($node_type:ident, $value:expr) => {
+        $crate::fuzzy_node!(_ $node_type, (), $value)
+    };
+    ($node_type:ident, $k0:expr, $value:expr) => {
+        $crate::fuzzy_node!(_ $node_type, $k0, $value)
+    };
+    ($node_type:ident, $k0:expr, $k1:expr, $value:expr) => {
+        $crate::fuzzy_node!(_ $node_type, ($k0, $k1), $value)
+    };
+    ($node_type:ident, $k0:expr, $k1:expr, $k2:expr, $value:expr) => {
+        $crate::fuzzy_node!(_ $node_type, ($k0, $k1, $k2), $value)
+    };
+    ($node_type:ident, $k0:expr, $k1:expr, $k2:expr, $k3:expr, $value:expr) => {
+        $crate::fuzzy_node!(_ $node_type, ($k0, $k1, $k2, $k3), $value)
+    };
+}
+
+/// Constructor utility for fuzzy node key elements.
+#[macro_export]
+macro_rules! some {
+    ($key_element:expr) => {
+        Some(Rc::new($key_element))
+    };
+}
+
+/// Intention to read or write access, which should be filtered in some way.
+pub trait NodeReadWrite: Filtered {
+    /// Abstract status of read or write access, which should also be filtered in some way.
+    type Status: Filtered;
+
+    /// An abstraction of access.
+    fn as_status(&self) -> Self::Status;
+}
+
+/// Determines whether it passes a certain filter.
+pub trait Filtered {
+    /// Tests whether the challenger can pass the filter.
+    type Filter;
+
+    /// # Errors
+    ///
+    /// Returns the difference from the expected filter required for `self` to pass.
+    fn passes(&self, filter: &Self::Filter) -> Result<(), Self::Filter>;
+}
+
+/// A filter represented as a byte.
+#[derive(
+    DebugCustom,
+    PartialEq,
+    Eq,
+    Clone,
+    Copy,
+    From,
+    BitOr,
+    SerializeDisplay,
+    DeserializeFromStr,
+    Decode,
+    Encode,
+)]
+pub struct FilterU8(#[debug("{_0:#010b}")] u8);
+
+impl Filtered for FilterU8 {
+    type Filter = Self;
+
+    fn passes(&self, filter: &Self::Filter) -> Result<(), Self::Filter> {
+        let obstacle = self.0 & !filter.0;
+        if obstacle == 0 {
+            Ok(())
+        } else {
+            Err(obstacle.into())
+        }
+    }
+}
+
+impl FromStr for FilterU8 {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let byte = event::STATUS_CHARS.into_iter().fold(u8::MIN, |mut acc, c| {
+            acc <<= 1;
+            acc + u8::from(s.contains(c))
+        });
+        Ok(byte.into())
+    }
+}
+
+impl Display for FilterU8 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut byte = self.0;
+        for c in event::STATUS_CHARS {
+            if byte & 0b1000_0000 == 0b1000_0000 {
+                write!(f, "{c}")?;
+            } else {
+                write!(f, "-")?;
+            }
+            byte <<= 1;
+        }
+        Ok(())
+    }
+}
+
+impl FilterU8 {
+    const ANY: Self = Self(u8::MAX);
+    const DENY: Self = Self(u8::MIN);
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Constructor)]
+/// Indicates an invariant violation while aggregating node values at the node key.
+pub struct NodeConflict<M: Mode> {
+    key: NodeKey,
+    lhs: NodeValue<M>,
+    rhs: NodeValue<M>,
+}
+
+/// Indicates a type inconsistency between node keys or values.
+#[derive(Debug, PartialEq, Eq, Clone, Constructor)]
+pub struct NodeTypeMismatch {
+    lhs: NodeType,
+    rhs: NodeType,
+}
+
+trait NodeKeyValue {
+    fn node_type(&self) -> NodeType;
+}
+
+impl NodeKey {
+    fn fuzzy(&self) -> FuzzyNodeKey {
+        self.receptor_keys().last().unwrap().clone()
+    }
+}
+
+macro_rules! impl_for_node_key_values {
+    ($($variant:ident,)+) => {
+        #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+        enum NodeType {
+            $(
+            $variant,
+            )+
+        }
+
+        impl NodeKeyValue for NodeKey {
+            fn node_type(&self) -> NodeType {
+                match self {
+                    $(
+                    Self::$variant(_) => NodeType::$variant,
+                    )+
+                }
+            }
+        }
+
+        impl NodeKeyValue for FuzzyNodeKey {
+            fn node_type(&self) -> NodeType {
+                match self {
+                    $(
+                    Self::$variant(_) => NodeType::$variant,
+                    )+
+                }
+            }
+        }
+
+        impl<M: Mode> NodeKeyValue for NodeValue<M> {
+            fn node_type(&self) -> NodeType {
+                match self {
+                    $(
+                    Self::$variant(_) => NodeType::$variant,
+                    )+
+                }
+            }
+        }
+
+        impl From<&NodeValue<state::View>> for NodeValue<event::ReadWriteStatus> {
+            fn from(value: &NodeValue<state::View>) -> Self {
+                match value {
+                    $(
+                    NodeValue::$variant(view) => Self::$variant(view.into()),
+                    )+
+                }
+            }
+        }
+
+        impl From<&NodeValue<changeset::Write>> for NodeValue<event::ReadWriteStatus> {
+            fn from(value: &NodeValue<changeset::Write>) -> Self {
+                match value {
+                    $(
+                    NodeValue::$variant(write) => Self::$variant(write.into()),
+                    )+
+                }
+            }
+        }
+
+        impl From<&NodeValue<event::ReadWriteStatus>> for FilterU8 {
+            fn from(value: &NodeValue<event::ReadWriteStatus>) -> Self {
+                match value {
+                    $(
+                    NodeValue::$variant(status) => (*status).into(),
+                    )+
+                }
+            }
+        }
+
+        impl From<&NodeValue<receptor::ReadWriteStatusFilter>> for FilterU8 {
+            fn from(value: &NodeValue<receptor::ReadWriteStatusFilter>) -> Self {
+                match value {
+                    $(
+                    NodeValue::$variant(filter_u8) => *filter_u8,
+                    )+
+                }
+            }
+        }
+
+        impl From<(&NodeKey, FilterU8)> for NodeValue<receptor::ReadWriteStatusFilter> {
+            fn from(value: (&NodeKey, FilterU8)) -> Self {
+                match value.0 {
+                    $(
+                    NodeKey::$variant(_) => NodeValue::$variant(value.1),
+                    )+
+                }
+            }
+        }
+
+        impl Add for NodeValue<changeset::Write> {
+            type Output = Result<Self, (Self, Self)>;
+
+            fn add(self, rhs: Self) -> Self::Output {
+                match (self, rhs) {
+                    $(
+                    (Self::$variant(l), Self::$variant(r)) => match l + r {
+                        Ok(add) => Ok(Self::$variant(add)),
+                        Err((l, r)) => Err((Self::$variant(l), Self::$variant(r))),
+                    },
+                    )+
+                    (l, r) => Err((l ,r)),
+                }
+            }
+        }
+
+        impl BitOr for NodeValue<permission::ReadWriteStatusFilter> {
+            type Output = Result<Self, (Self, Self)>;
+
+            fn bitor(self, rhs: Self) -> Self::Output {
+                match (self, rhs) {
+                    $(
+                    (Self::$variant(l), Self::$variant(r)) => Ok(Self::$variant(l | r)),
+                    )+
+                    (l, r) => Err((l ,r)),
+                }
+            }
+        }
+    };
+}
+
+impl_for_node_key_values!(
+    Authorizer,
+    Parameter,
+    Peer,
+    Domain,
+    Account,
+    Asset,
+    Nft,
+    AccountAsset,
+    Role,
+    Permission,
+    AccountRole,
+    AccountPermission,
+    RolePermission,
+    Trigger,
+    Condition,
+    Executable,
+    TriggerCondition,
+    TriggerExecutable,
+    DomainMetadata,
+    AccountMetadata,
+    AssetMetadata,
+    NftData,
+    TriggerMetadata,
+    DomainAdmin,
+    AssetAdmin,
+    NftAdmin,
+    NftOwner,
+    TriggerAdmin,
+);
+
+macro_rules! impl_for_tree {
+    ($(($tree:ident, $key:ty, $entry:ident),)+) => {
+        $(
+        /// Node key-value pair with guaranteed type consistency.
+        #[derive(Debug, PartialEq, Eq, Clone)]
+        pub struct $entry<M: Mode> {
+            key: $key,
+            value: NodeValue<M>,
+        }
+
+        impl<M: Mode> TryFrom<($key, NodeValue<M>)> for $entry<M> {
+            type Error = NodeTypeMismatch;
+
+            fn try_from((key, value): ($key, NodeValue<M>)) -> Result<Self, Self::Error> {
+                let key_type = key.node_type();
+                let value_type = value.node_type();
+                if key_type == value_type {
+                    Ok(Self { key, value })
+                } else {
+                    Err(Self::Error::new(key_type, value_type))
+                }
+            }
+        }
+
+        impl<M: Mode> Default for $tree<M> {
+            fn default() -> Self {
+                Self(BTreeMap::default())
+            }
+        }
+
+        impl<M: Mode> FromIterator<$entry<M>> for $tree<M> {
+            fn from_iter<I: IntoIterator<Item = $entry<M>>>(iter: I) -> Self {
+                $tree(
+                    iter.into_iter()
+                        .map(|entry| (entry.key, entry.value))
+                        .collect::<BTreeMap<_, _>>(),
+                )
+            }
+        }
+
+        impl<M: Mode> IntoIterator for $tree<M> {
+            type Item = ($key, NodeValue<M>);
+            type IntoIter = btree_map::IntoIter<$key, NodeValue<M>>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                self.0.into_iter()
+            }
+        }
+
+        #[allow(missing_docs)]
+        impl<M: Mode> $tree<M> {
+            pub fn is_empty(&self) -> bool {
+                self.0.is_empty()
+            }
+
+            pub fn get(&self, key: &$key) -> Option<&NodeValue<M>> {
+                self.0.get(key)
+            }
+
+            pub fn insert(&mut self, entry: $entry<M>) -> Option<NodeValue<M>> {
+                self.0.insert(entry.key, entry.value)
+            }
+
+            pub fn remove(&mut self, key: &$key) -> Option<NodeValue<M>> {
+                self.0.remove(key)
+            }
+
+            pub fn iter(&self) -> impl Iterator<Item = (&$key, &NodeValue<M>)> {
+                self.0.iter()
+            }
+
+            pub fn keys(&self) -> impl Iterator<Item = &$key> {
+                self.0.keys()
+            }
+        }
+        )+
+    };
+}
+
+impl_for_tree!(
+    (Tree, NodeKey, NodeEntry),
+    (FuzzyTree, FuzzyNodeKey, FuzzyNodeEntry),
+);
+
+#[allow(missing_docs)]
+pub mod transitional {
+    use super::*;
+
+    #[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, Decode, Encode)]
+    pub struct ParameterId;
+
+    macro_rules! declare_ids_from_values {
+        ($(($id:ident, $value:path),)+) => {
+            $(
+            #[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, From, Decode, Encode)]
+            pub struct $id(dm::HashOf<$value>);
+
+            impl From<&$value> for $id {
+                fn from(value: &$value) -> Self {
+                    dm::HashOf::new(value).into()
+                }
+            }
+            )+
+        };
+    }
+
+    declare_ids_from_values!(
+        (PermissionId, state::tr::PermissionV),
+        (ConditionId, state::tr::ConditionV),
+        (ExecutableId, state::tr::ExecutableV),
+    );
+}
+
+use transitional as tr;
+
+/// Re-exports data models for downstream crates.
+/// TODO: Remove this once the transition is complete.
+pub mod dm {
+    pub use iroha_data_model::{ipfs::IpfsPath, prelude::*, Level};
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serde_filter_u8() {
+        use serde_json::{from_str as de, to_string as ser};
+        // Be conservative in what we do.
+        assert_eq!(ser(&FilterU8::DENY).unwrap(), r#""--------""#);
+        assert_eq!(ser(&FilterU8::ANY).unwrap(), r#""dcbmuoir""#);
+        assert_eq!(ser(&FilterU8::from(0b1100_1001)).unwrap(), r#""dc--u--r""#);
+        // Be liberal in what we accept from others.
+        assert_eq!(de::<FilterU8>(r#""""#).unwrap(), FilterU8::DENY);
+        assert_eq!(de::<FilterU8>(r#""--------""#).unwrap(), FilterU8::DENY);
+        assert_eq!(de::<FilterU8>(r#""--------ext""#).unwrap(), FilterU8::DENY);
+        assert_eq!(de::<FilterU8>(r#""dcbmuoir""#).unwrap(), FilterU8::ANY);
+        assert_eq!(de::<FilterU8>(r#""rioumbcd""#).unwrap(), FilterU8::ANY);
+        assert_eq!(de::<FilterU8>(r#""d-------""#).unwrap(), 0b1000_0000.into());
+        assert_eq!(de::<FilterU8>(r#""-------r""#).unwrap(), 0b0000_0001.into());
+        assert_eq!(de::<FilterU8>(r#""dc--u--r""#).unwrap(), 0b1100_1001.into());
+        assert_eq!(de::<FilterU8>(r#""rdrdr""#).unwrap(), 0b1000_0001.into());
+    }
+
+    #[test]
+    fn exact_key_as_fuzzy() {
+        let id = dm::AssetId::from_str(
+            "asset##ed0120CE7FA46C9DCE7EA4B125E2E36BDB63EA33073E7590AC92816AE1E861B7048B03@domain",
+        )
+        .unwrap();
+        let exact_key = NodeKey::AccountAsset((
+            Rc::new(id.account.signatory.clone()),
+            Rc::new(id.account.domain.clone()),
+            Rc::new(id.definition.name.clone()),
+            Rc::new(id.definition.domain.clone()),
+        ));
+        let fuzzy_key = FuzzyNodeKey::AccountAsset((
+            Some(Rc::new(id.account.signatory.clone())),
+            Some(Rc::new(id.account.domain.clone())),
+            Some(Rc::new(id.definition.name.clone())),
+            Some(Rc::new(id.definition.domain.clone())),
+        ));
+        assert_eq!(exact_key.fuzzy(), fuzzy_key);
+    }
+}

--- a/crates/iroha_tree/src/permission.rs
+++ b/crates/iroha_tree/src/permission.rs
@@ -1,0 +1,317 @@
+//! Module for [`Permission`] and related components.
+
+use super::*;
+
+/// Represents readiness for access of each node.
+pub type Permission = FuzzyTree<ReadWriteStatusFilter>;
+
+/// Each node value indicates readiness for access.
+pub type ReadWriteStatusFilter = receptor::ReadWriteStatusFilter;
+
+impl Filtered for state::StateView {
+    type Filter = Permission;
+
+    /// Post-execution validation of read access.
+    fn passes(&self, filter: &Self::Filter) -> Result<(), Self::Filter> {
+        self.as_status().passes(filter)
+    }
+}
+
+impl Filtered for changeset::ChangeSet {
+    type Filter = Permission;
+
+    /// Pre-execution validation of write access.
+    fn passes(&self, filter: &Self::Filter) -> Result<(), Self::Filter> {
+        self.as_status().passes(filter)
+    }
+}
+
+impl BitOr for Permission {
+    type Output = Self;
+
+    fn bitor(self, mut rhs: Self) -> Self::Output {
+        for (k, v0) in self {
+            let v = match rhs.remove(&k) {
+                None => v0,
+                Some(v1) => (v0 | v1).expect("value types should be consistent"),
+            };
+            rhs.insert(FuzzyNodeEntry::try_from((k, v)).unwrap());
+        }
+        rhs
+    }
+}
+
+mod transitional {
+    use event::*;
+    use iroha_executor_data_model::permission as xp;
+
+    use super::*;
+
+    impl From<&dm::Permission> for tr::PermissionId {
+        fn from(value: &dm::Permission) -> Self {
+            Self::from(&state::tr::PermissionV::from(Permission::from(value)))
+        }
+    }
+
+    macro_rules! impl_from_data_model_permission {
+        ($(($can:path, $node_type:ident, |$source:ident| $key:expr, $statuses:expr),)+) => {
+            impl From<&dm::Permission> for Permission {
+                fn from(value: &dm::Permission) -> Self {
+                    $(
+                    if let Ok(can) = <$can as TryFrom<&dm::Permission>>::try_from(value) { return can.into() }
+                    )+
+                    unreachable!("data model permission should convert into one of the permission tokens")
+                }
+            }
+
+            $(
+            impl From<$can> for Permission {
+                fn from($source: $can) -> Self {
+                    [FuzzyNodeEntry::try_from((
+                        FuzzyNodeKey::$node_type($key),
+                        NodeValue::$node_type(
+                            $statuses
+                                .into_iter()
+                                .map(FilterU8::from)
+                                .reduce(|acc, x| acc | x)
+                                .unwrap(),
+                        ),
+                    )).unwrap()]
+                    .into_iter()
+                    .collect()
+                }
+            }
+            )+
+        };
+    }
+
+    impl_from_data_model_permission!(
+        (
+            xp::peer::CanManagePeers,
+            Peer,
+            |_v| None,
+            [UnitS::Create, UnitS::Delete]
+        ),
+        (
+            xp::domain::CanRegisterDomain,
+            Domain,
+            |_v| None,
+            [DomainS::Create]
+        ),
+        (
+            xp::domain::CanUnregisterDomain,
+            Domain,
+            |v| some!(v.domain),
+            [DomainS::Delete]
+        ),
+        (
+            xp::domain::CanModifyDomainMetadata,
+            DomainMetadata,
+            |v| (some!(v.domain), None),
+            [MetadataS::Set, MetadataS::Unset]
+        ),
+        (
+            xp::account::CanRegisterAccount,
+            Account,
+            |v| (None, some!(v.domain)),
+            [UnitS::Create]
+        ),
+        (
+            xp::account::CanUnregisterAccount,
+            Account,
+            |v| (some!(v.account.signatory), some!(v.account.domain)),
+            [UnitS::Delete]
+        ),
+        (
+            xp::account::CanModifyAccountMetadata,
+            AccountMetadata,
+            |v| (some!(v.account.signatory), some!(v.account.domain), None),
+            [MetadataS::Set, MetadataS::Unset]
+        ),
+        (
+            xp::asset_definition::CanRegisterAssetDefinition,
+            Asset,
+            |v| (None, some!(v.domain)),
+            [AssetS::Create]
+        ),
+        (
+            xp::asset_definition::CanUnregisterAssetDefinition,
+            Asset,
+            |v| (
+                some!(v.asset_definition.name),
+                some!(v.asset_definition.domain)
+            ),
+            [AssetS::Delete]
+        ),
+        (
+            xp::asset_definition::CanModifyAssetDefinitionMetadata,
+            AssetMetadata,
+            |v| (
+                some!(v.asset_definition.name),
+                some!(v.asset_definition.domain),
+                None
+            ),
+            [MetadataS::Set, MetadataS::Unset]
+        ),
+        (
+            xp::asset::CanMintAssetWithDefinition,
+            AccountAsset,
+            |v| (
+                None,
+                None,
+                some!(v.asset_definition.name),
+                some!(v.asset_definition.domain)
+            ),
+            [AccountAssetS::Mint]
+        ),
+        (
+            xp::asset::CanBurnAssetWithDefinition,
+            AccountAsset,
+            |v| (
+                None,
+                None,
+                some!(v.asset_definition.name),
+                some!(v.asset_definition.domain)
+            ),
+            [AccountAssetS::Burn]
+        ),
+        (
+            xp::asset::CanTransferAssetWithDefinition,
+            AccountAsset,
+            |v| (
+                None,
+                None,
+                some!(v.asset_definition.name),
+                some!(v.asset_definition.domain)
+            ),
+            [AccountAssetS::Send]
+        ),
+        (
+            xp::asset::CanMintAsset,
+            AccountAsset,
+            |v| (
+                some!(v.asset.account.signatory),
+                some!(v.asset.account.domain),
+                some!(v.asset.definition.name),
+                some!(v.asset.definition.domain)
+            ),
+            [AccountAssetS::Mint]
+        ),
+        (
+            xp::asset::CanBurnAsset,
+            AccountAsset,
+            |v| (
+                some!(v.asset.account.signatory),
+                some!(v.asset.account.domain),
+                some!(v.asset.definition.name),
+                some!(v.asset.definition.domain)
+            ),
+            [AccountAssetS::Burn]
+        ),
+        (
+            xp::asset::CanTransferAsset,
+            AccountAsset,
+            |v| (
+                some!(v.asset.account.signatory),
+                some!(v.asset.account.domain),
+                some!(v.asset.definition.name),
+                some!(v.asset.definition.domain)
+            ),
+            [AccountAssetS::Send]
+        ),
+        (
+            xp::nft::CanRegisterNft,
+            Nft,
+            |v| (None, some!(v.domain)),
+            [NftS::Create]
+        ),
+        (
+            xp::nft::CanUnregisterNft,
+            Nft,
+            |v| (some!(v.nft.name), some!(v.nft.domain)),
+            [NftS::Delete]
+        ),
+        (
+            xp::nft::CanTransferNft,
+            NftOwner,
+            |v| (some!(v.nft.name), some!(v.nft.domain), None, None),
+            [UnitS::Create, UnitS::Delete]
+        ),
+        (
+            xp::nft::CanModifyNftMetadata,
+            NftData,
+            |v| (some!(v.nft.name), some!(v.nft.domain), None),
+            [MetadataS::Set, MetadataS::Unset]
+        ),
+        (
+            xp::parameter::CanSetParameters,
+            Parameter,
+            |_v| None,
+            [ParameterS::Set]
+        ),
+        (
+            xp::role::CanManageRoles,
+            Role,
+            |_v| None,
+            [UnitS::Create, UnitS::Delete]
+        ),
+        // TODO: Separate into registration and ownership transfer.
+        // xp::trigger::CanRegisterTrigger
+
+        // TODO: No validation should be performed when calling Wasm executables, as they are resolved into event predictions and then validated.
+        // xp::trigger::CanExecuteTrigger
+        (
+            xp::trigger::CanUnregisterTrigger,
+            Trigger,
+            |v| some!(v.trigger),
+            [TriggerS::Delete]
+        ),
+        (
+            xp::trigger::CanModifyTrigger,
+            Trigger,
+            |v| some!(v.trigger),
+            [TriggerS::Increase, TriggerS::Decrease]
+        ),
+        (
+            xp::trigger::CanModifyTriggerMetadata,
+            TriggerMetadata,
+            |v| (some!(v.trigger), None),
+            [MetadataS::Set, MetadataS::Unset]
+        ),
+        (
+            xp::executor::CanUpgradeExecutor,
+            Authorizer,
+            |_v| (),
+            [AuthorizerS::Set]
+        ),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(not(feature = "std"))]
+    use alloc::format;
+
+    use super::*;
+
+    #[test]
+    fn aggregates() {
+        let role_f = |i: usize, f: &str| {
+            fuzzy_node!(
+                Role,
+                some!(format!("role_{i}").parse().unwrap()),
+                FilterU8::from_str(f).unwrap()
+            )
+        };
+        let role_f_set = |i: usize, f: &str| Permission::from_iter([role_f(i, f)]);
+        assert_eq!(role_f_set(0, "c") | role_f_set(0, "c"), role_f_set(0, "c"));
+        assert_eq!(
+            role_f_set(0, "c") | role_f_set(1, "c"),
+            Permission::from_iter([role_f(0, "c"), role_f(1, "c")])
+        );
+        assert_eq!(
+            role_f_set(0, "c") | role_f_set(0, "d"),
+            Permission::from_iter([role_f(0, "cd"),])
+        );
+    }
+}

--- a/crates/iroha_tree/src/readset.rs
+++ b/crates/iroha_tree/src/readset.rs
@@ -1,0 +1,45 @@
+//! Module for [`ReadSet`] and related components.
+
+use super::*;
+
+/// Represents read access for each node.
+pub type ReadSet = FuzzyTree<Read>;
+
+/// Each node value indicates read access.
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+pub struct Read;
+
+impl Mode for Read {
+    type Authorizer = UnitR;
+    type Parameter = UnitR;
+    type Peer = UnitR;
+    type Domain = UnitR;
+    type Account = UnitR;
+    type Asset = UnitR;
+    type Nft = UnitR;
+    type AccountAsset = UnitR;
+    type Role = UnitR;
+    type Permission = UnitR;
+    type AccountRole = UnitR;
+    type AccountPermission = UnitR;
+    type RolePermission = UnitR;
+    type Trigger = UnitR;
+    type Condition = UnitR;
+    type Executable = UnitR;
+    type TriggerCondition = UnitR;
+    type TriggerExecutable = UnitR;
+    type DomainMetadata = UnitR;
+    type AccountMetadata = UnitR;
+    type AssetMetadata = UnitR;
+    type NftData = UnitR;
+    type TriggerMetadata = UnitR;
+    type DomainAdmin = UnitR;
+    type AssetAdmin = UnitR;
+    type NftAdmin = UnitR;
+    type NftOwner = UnitR;
+    type TriggerAdmin = UnitR;
+}
+
+/// Read access.
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+pub struct UnitR;

--- a/crates/iroha_tree/src/receptor.rs
+++ b/crates/iroha_tree/src/receptor.rs
@@ -1,0 +1,605 @@
+//! Module for [`Receptor`] and related components.
+
+use super::*;
+
+/// Represents readiness for status of each node.
+pub type Receptor = FuzzyTree<ReadWriteStatusFilter>;
+
+/// Each node value indicates readiness for status.
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+pub struct ReadWriteStatusFilter;
+
+impl Mode for ReadWriteStatusFilter {
+    type Authorizer = FilterU8;
+    type Parameter = FilterU8;
+    type Peer = FilterU8;
+    type Domain = FilterU8;
+    type Account = FilterU8;
+    type Asset = FilterU8;
+    type Nft = FilterU8;
+    type AccountAsset = FilterU8;
+    type Role = FilterU8;
+    type Permission = FilterU8;
+    type AccountRole = FilterU8;
+    type AccountPermission = FilterU8;
+    type RolePermission = FilterU8;
+    type Trigger = FilterU8;
+    type Condition = FilterU8;
+    type Executable = FilterU8;
+    type TriggerCondition = FilterU8;
+    type TriggerExecutable = FilterU8;
+    type DomainMetadata = FilterU8;
+    type AccountMetadata = FilterU8;
+    type AssetMetadata = FilterU8;
+    type NftData = FilterU8;
+    type TriggerMetadata = FilterU8;
+    type DomainAdmin = FilterU8;
+    type AssetAdmin = FilterU8;
+    type NftAdmin = FilterU8;
+    type NftOwner = FilterU8;
+    type TriggerAdmin = FilterU8;
+}
+
+impl Filtered for event::Event {
+    type Filter = Receptor;
+
+    fn passes(&self, filter: &Self::Filter) -> Result<(), Self::Filter> {
+        let mut obstacle = Self::Filter::default();
+        for (key, signal) in self.iter() {
+            let signal: FilterU8 = signal.into();
+            let receptor_keys = key.receptor_keys();
+            let receptor_union = filter
+                .iter()
+                .filter_map(|(k, v)| receptor_keys.contains(k).then_some(v).map(FilterU8::from))
+                .fold(FilterU8::DENY, |acc, x| acc | x);
+            if let Err(obs) = signal.passes(&receptor_union) {
+                obstacle.insert(
+                    FuzzyNodeEntry::try_from((key.fuzzy(), NodeValue::from((key, obs)))).unwrap(),
+                );
+            }
+        }
+        if obstacle.is_empty() {
+            Ok(())
+        } else {
+            Err(obstacle)
+        }
+    }
+}
+
+macro_rules! receptor_keys {
+    (0 $node_type:ident) => {
+        [$node_type(())].into()
+    };
+    (1 $node_type:ident, $key:expr) => {
+        [$node_type(Some($key.clone())), $node_type(None)].into()
+    };
+    (2 $node_type:ident, $key:expr) => {
+        [
+            $node_type((Some($key.0.clone()), Some($key.1.clone()))),
+            $node_type((Some($key.0.clone()), None)),
+            $node_type((None, Some($key.1.clone()))),
+            $node_type((None, None)),
+        ]
+        .into()
+    };
+    (3 $node_type:ident, $key:expr) => {
+        [
+            $node_type((
+                Some($key.0.clone()),
+                Some($key.1.clone()),
+                Some($key.2.clone()),
+            )),
+            $node_type((Some($key.0.clone()), Some($key.1.clone()), None)),
+            $node_type((Some($key.0.clone()), None, Some($key.2.clone()))),
+            $node_type((Some($key.0.clone()), None, None)),
+            $node_type((None, Some($key.1.clone()), Some($key.2.clone()))),
+            $node_type((None, Some($key.1.clone()), None)),
+            $node_type((None, None, Some($key.2.clone()))),
+            $node_type((None, None, None)),
+        ]
+        .into()
+    };
+    (4 $node_type:ident, $key:expr) => {
+        [
+            $node_type((
+                Some($key.0.clone()),
+                Some($key.1.clone()),
+                Some($key.2.clone()),
+                Some($key.3.clone()),
+            )),
+            $node_type((
+                Some($key.0.clone()),
+                Some($key.1.clone()),
+                Some($key.2.clone()),
+                None,
+            )),
+            $node_type((
+                Some($key.0.clone()),
+                Some($key.1.clone()),
+                None,
+                Some($key.3.clone()),
+            )),
+            $node_type((Some($key.0.clone()), Some($key.1.clone()), None, None)),
+            $node_type((
+                Some($key.0.clone()),
+                None,
+                Some($key.2.clone()),
+                Some($key.3.clone()),
+            )),
+            $node_type((Some($key.0.clone()), None, Some($key.2.clone()), None)),
+            $node_type((Some($key.0.clone()), None, None, Some($key.3.clone()))),
+            $node_type((Some($key.0.clone()), None, None, None)),
+            $node_type((
+                None,
+                Some($key.1.clone()),
+                Some($key.2.clone()),
+                Some($key.3.clone()),
+            )),
+            $node_type((None, Some($key.1.clone()), Some($key.2.clone()), None)),
+            $node_type((None, Some($key.1.clone()), None, Some($key.3.clone()))),
+            $node_type((None, Some($key.1.clone()), None, None)),
+            $node_type((None, None, Some($key.2.clone()), Some($key.3.clone()))),
+            $node_type((None, None, Some($key.2.clone()), None)),
+            $node_type((None, None, None, Some($key.3.clone()))),
+            $node_type((None, None, None, None)),
+        ]
+        .into()
+    };
+}
+
+impl NodeKey {
+    pub(crate) fn receptor_keys(&self) -> BTreeSet<FuzzyNodeKey> {
+        use FuzzyNodeKey::*;
+        match self {
+            Self::Authorizer(()) => receptor_keys!(0 Authorizer),
+            Self::Parameter(key) => receptor_keys!(1 Parameter, key),
+            Self::Peer(key) => receptor_keys!(1 Peer, key),
+            Self::Domain(key) => receptor_keys!(1 Domain, key),
+            Self::Account(key) => receptor_keys!(2 Account, key),
+            Self::Asset(key) => receptor_keys!(2 Asset, key),
+            Self::Nft(key) => receptor_keys!(2 Nft, key),
+            Self::AccountAsset(key) => receptor_keys!(4 AccountAsset, key),
+            Self::Role(key) => receptor_keys!(1 Role, key),
+            Self::Permission(key) => receptor_keys!(1 Permission, key),
+            Self::AccountRole(key) => receptor_keys!(3 AccountRole, key),
+            Self::AccountPermission(key) => receptor_keys!(3 AccountPermission, key),
+            Self::RolePermission(key) => receptor_keys!(2 RolePermission, key),
+            Self::Trigger(key) => receptor_keys!(1 Trigger, key),
+            Self::Condition(key) => receptor_keys!(1 Condition, key),
+            Self::Executable(key) => receptor_keys!(1 Executable, key),
+            Self::TriggerCondition(key) => receptor_keys!(2 TriggerCondition, key),
+            Self::TriggerExecutable(key) => receptor_keys!(2 TriggerExecutable, key),
+            Self::DomainMetadata(key) => receptor_keys!(2 DomainMetadata, key),
+            Self::AccountMetadata(key) => receptor_keys!(3 AccountMetadata, key),
+            Self::AssetMetadata(key) => receptor_keys!(3 AssetMetadata, key),
+            Self::NftData(key) => receptor_keys!(3 NftData, key),
+            Self::TriggerMetadata(key) => receptor_keys!(2 TriggerMetadata, key),
+            Self::DomainAdmin(key) => receptor_keys!(3 DomainAdmin, key),
+            Self::AssetAdmin(key) => receptor_keys!(4 AssetAdmin, key),
+            Self::NftAdmin(key) => receptor_keys!(4 NftAdmin, key),
+            Self::NftOwner(key) => receptor_keys!(4 NftOwner, key),
+            Self::TriggerAdmin(key) => receptor_keys!(3 TriggerAdmin, key),
+        }
+    }
+}
+
+mod transitional {
+    use super::*;
+    use crate::event::*;
+
+    impl TryFrom<dm::EventFilterBox> for state::tr::ConditionV {
+        type Error = &'static str;
+
+        fn try_from(value: dm::EventFilterBox) -> Result<Self, Self::Error> {
+            use dm::{EventFilterBox, ExecutionTime};
+            match value {
+                EventFilterBox::Data(filter) => Ok(Receptor::from(filter).into()),
+                EventFilterBox::Time(filter) => match filter.0 {
+                    ExecutionTime::PreCommit => Ok(state::tr::BlockCommit.into()),
+                    ExecutionTime::Schedule(schedule) => Ok(schedule.into()),
+                },
+                EventFilterBox::Pipeline(_) => Err("pipeline triggers are scheduled for removal"),
+                _ => Err("these event types are scheduled for removal"),
+            }
+        }
+    }
+
+    impl From<dm::DataEventFilter> for Receptor {
+        #[expect(clippy::too_many_lines)]
+        fn from(value: dm::DataEventFilter) -> Self {
+            use dm::{
+                AccountEventSet, AssetDefinitionEventSet, AssetEventSet, ConfigurationEventSet,
+                DataEventFilter::*, DomainEventSet, ExecutorEventSet, NftEventSet, PeerEventSet,
+                RoleEventSet, TriggerEventSet,
+            };
+
+            match value {
+                Any => [
+                    fuzzy_node!(Authorizer, FilterU8::ANY),
+                    fuzzy_node!(Parameter, None, FilterU8::ANY),
+                    fuzzy_node!(Peer, None, FilterU8::ANY),
+                    fuzzy_node!(Domain, None, FilterU8::ANY),
+                    fuzzy_node!(Account, None, None, FilterU8::ANY),
+                    fuzzy_node!(Asset, None, None, FilterU8::ANY),
+                    fuzzy_node!(Nft, None, None, FilterU8::ANY),
+                    fuzzy_node!(AccountAsset, None, None, None, None, FilterU8::ANY),
+                    fuzzy_node!(Role, None, FilterU8::ANY),
+                    fuzzy_node!(Permission, None, FilterU8::ANY),
+                    fuzzy_node!(AccountRole, None, None, None, FilterU8::ANY),
+                    fuzzy_node!(AccountPermission, None, None, None, FilterU8::ANY),
+                    fuzzy_node!(RolePermission, None, None, FilterU8::ANY),
+                    fuzzy_node!(Trigger, None, FilterU8::ANY),
+                    fuzzy_node!(Executable, None, FilterU8::ANY),
+                    fuzzy_node!(DomainMetadata, None, None, FilterU8::ANY),
+                    fuzzy_node!(AccountMetadata, None, None, None, FilterU8::ANY),
+                    fuzzy_node!(AssetMetadata, None, None, None, FilterU8::ANY),
+                    fuzzy_node!(NftData, None, None, None, FilterU8::ANY),
+                    fuzzy_node!(TriggerMetadata, None, None, FilterU8::ANY),
+                    fuzzy_node!(DomainAdmin, None, None, None, FilterU8::ANY),
+                    fuzzy_node!(AssetAdmin, None, None, None, None, FilterU8::ANY),
+                    fuzzy_node!(NftAdmin, None, None, None, None, FilterU8::ANY),
+                    fuzzy_node!(NftOwner, None, None, None, None, FilterU8::ANY),
+                    fuzzy_node!(TriggerAdmin, None, None, None, FilterU8::ANY),
+                ]
+                .into_iter()
+                .collect(),
+                Peer(ef) => {
+                    let id = ef.id_matcher.map(Rc::new);
+                    ef.event_set
+                        .decompose()
+                        .into_iter()
+                        .map(|es| match es {
+                            PeerEventSet::Added => {
+                                fuzzy_node!(Peer, id.clone(), UnitS::Create)
+                            }
+                            PeerEventSet::Removed => {
+                                fuzzy_node!(Peer, id.clone(), UnitS::Delete)
+                            }
+                            _ => unreachable!(),
+                        })
+                        .collect()
+                }
+                Domain(ef) => {
+                    let domain = ef.id_matcher.map(Rc::new);
+                    ef.event_set
+                        .decompose()
+                        .into_iter()
+                        .map(|es| match es {
+                            DomainEventSet::Created => {
+                                fuzzy_node!(Domain, domain.clone(), DomainS::Create)
+                            }
+                            DomainEventSet::Deleted => {
+                                fuzzy_node!(Domain, domain.clone(), DomainS::Delete)
+                            }
+                            DomainEventSet::AnyAssetDefinition => {
+                                fuzzy_node!(Asset, None, domain.clone(), FilterU8::ANY)
+                            }
+                            DomainEventSet::AnyNft => {
+                                fuzzy_node!(Nft, None, domain.clone(), FilterU8::ANY)
+                            }
+                            DomainEventSet::AnyAccount => {
+                                fuzzy_node!(Account, None, domain.clone(), FilterU8::ANY)
+                            }
+                            DomainEventSet::MetadataInserted => {
+                                fuzzy_node!(DomainMetadata, domain.clone(), None, MetadataS::Set)
+                            }
+                            DomainEventSet::MetadataRemoved => {
+                                fuzzy_node!(DomainMetadata, domain.clone(), None, MetadataS::Unset)
+                            }
+                            DomainEventSet::OwnerChanged => fuzzy_node!(
+                                DomainAdmin,
+                                domain.clone(),
+                                None,
+                                None,
+                                UnitS::Create as u8 | UnitS::Delete as u8
+                            ),
+                            _ => unreachable!(),
+                        })
+                        .collect()
+                }
+                Account(ef) => {
+                    let (signatory, domain) = match ef.id_matcher {
+                        None => (None, None),
+                        Some(id) => (some!(id.signatory), some!(id.domain)),
+                    };
+                    ef.event_set
+                        .decompose()
+                        .into_iter()
+                        .map(|es| match es {
+                            AccountEventSet::Created => fuzzy_node!(
+                                Account,
+                                signatory.clone(),
+                                domain.clone(),
+                                UnitS::Create
+                            ),
+                            AccountEventSet::Deleted => fuzzy_node!(
+                                Account,
+                                signatory.clone(),
+                                domain.clone(),
+                                UnitS::Delete
+                            ),
+                            AccountEventSet::AnyAsset => fuzzy_node!(
+                                AccountAsset,
+                                signatory.clone(),
+                                domain.clone(),
+                                None,
+                                None,
+                                FilterU8::ANY
+                            ),
+                            AccountEventSet::PermissionAdded => fuzzy_node!(
+                                AccountPermission,
+                                signatory.clone(),
+                                domain.clone(),
+                                None,
+                                UnitS::Create
+                            ),
+                            AccountEventSet::PermissionRemoved => fuzzy_node!(
+                                AccountPermission,
+                                signatory.clone(),
+                                domain.clone(),
+                                None,
+                                UnitS::Delete
+                            ),
+                            AccountEventSet::RoleGranted => fuzzy_node!(
+                                AccountRole,
+                                signatory.clone(),
+                                domain.clone(),
+                                None,
+                                UnitS::Create
+                            ),
+                            AccountEventSet::RoleRevoked => fuzzy_node!(
+                                AccountRole,
+                                signatory.clone(),
+                                domain.clone(),
+                                None,
+                                UnitS::Delete
+                            ),
+                            AccountEventSet::MetadataInserted => fuzzy_node!(
+                                AccountMetadata,
+                                signatory.clone(),
+                                domain.clone(),
+                                None,
+                                MetadataS::Set
+                            ),
+                            AccountEventSet::MetadataRemoved => fuzzy_node!(
+                                AccountMetadata,
+                                signatory.clone(),
+                                domain.clone(),
+                                None,
+                                MetadataS::Unset
+                            ),
+                            _ => unreachable!(),
+                        })
+                        .collect()
+                }
+                Asset(ef) => {
+                    let (account_key, account_domain, asset_name, asset_domain) =
+                        match ef.id_matcher {
+                            None => (None, None, None, None),
+                            Some(id) => (
+                                some!(id.account.signatory),
+                                some!(id.account.domain),
+                                some!(id.definition.name),
+                                some!(id.definition.domain),
+                            ),
+                        };
+                    ef.event_set
+                        .decompose()
+                        .into_iter()
+                        .map(|es| match es {
+                            AssetEventSet::Created => {
+                                fuzzy_node!(
+                                    AccountAsset,
+                                    account_key.clone(),
+                                    account_domain.clone(),
+                                    asset_name.clone(),
+                                    asset_domain.clone(),
+                                    AccountAssetS::Mint
+                                )
+                            }
+                            AssetEventSet::Deleted => {
+                                fuzzy_node!(
+                                    AccountAsset,
+                                    account_key.clone(),
+                                    account_domain.clone(),
+                                    asset_name.clone(),
+                                    asset_domain.clone(),
+                                    AccountAssetS::Burn
+                                )
+                            }
+                            AssetEventSet::Added => {
+                                fuzzy_node!(
+                                    AccountAsset,
+                                    account_key.clone(),
+                                    account_domain.clone(),
+                                    asset_name.clone(),
+                                    asset_domain.clone(),
+                                    AccountAssetS::Receive
+                                )
+                            }
+                            AssetEventSet::Removed => {
+                                fuzzy_node!(
+                                    AccountAsset,
+                                    account_key.clone(),
+                                    account_domain.clone(),
+                                    asset_name.clone(),
+                                    asset_domain.clone(),
+                                    AccountAssetS::Send
+                                )
+                            }
+                            _ => unreachable!(),
+                        })
+                        .collect()
+                }
+                AssetDefinition(ef) => {
+                    let (name, domain) = match ef.id_matcher {
+                        None => (None, None),
+                        Some(id) => (some!(id.name), some!(id.domain)),
+                    };
+                    ef.event_set
+                        .decompose()
+                        .into_iter()
+                        .map(|es| match es {
+                            AssetDefinitionEventSet::Created => {
+                                fuzzy_node!(Asset, name.clone(), domain.clone(), AssetS::Create)
+                            }
+                            AssetDefinitionEventSet::Deleted => {
+                                fuzzy_node!(Asset, name.clone(), domain.clone(), AssetS::Delete)
+                            }
+                            AssetDefinitionEventSet::MetadataInserted => fuzzy_node!(
+                                AssetMetadata,
+                                name.clone(),
+                                domain.clone(),
+                                None,
+                                MetadataS::Set
+                            ),
+                            AssetDefinitionEventSet::MetadataRemoved => fuzzy_node!(
+                                AssetMetadata,
+                                name.clone(),
+                                domain.clone(),
+                                None,
+                                MetadataS::Unset
+                            ),
+                            AssetDefinitionEventSet::MintabilityChanged => fuzzy_node!(
+                                Asset,
+                                name.clone(),
+                                domain.clone(),
+                                AssetS::MintabilityUpdate
+                            ),
+                            AssetDefinitionEventSet::TotalQuantityChanged => fuzzy_node!(
+                                AccountAsset,
+                                None,
+                                None,
+                                name.clone(),
+                                domain.clone(),
+                                AccountAssetS::Mint as u8 | AccountAssetS::Burn as u8
+                            ),
+                            AssetDefinitionEventSet::OwnerChanged => fuzzy_node!(
+                                AssetAdmin,
+                                name.clone(),
+                                domain.clone(),
+                                None,
+                                None,
+                                UnitS::Create as u8 | UnitS::Delete as u8
+                            ),
+                            _ => unreachable!(),
+                        })
+                        .collect()
+                }
+                Nft(ef) => {
+                    let (name, domain) = match ef.id_matcher {
+                        None => (None, None),
+                        Some(id) => (some!(id.name), some!(id.domain)),
+                    };
+                    ef.event_set
+                        .decompose()
+                        .into_iter()
+                        .map(|es| match es {
+                            NftEventSet::Created => {
+                                fuzzy_node!(Nft, name.clone(), domain.clone(), NftS::Create)
+                            }
+                            NftEventSet::Deleted => {
+                                fuzzy_node!(Nft, name.clone(), domain.clone(), NftS::Delete)
+                            }
+                            NftEventSet::MetadataInserted => fuzzy_node!(
+                                NftData,
+                                name.clone(),
+                                domain.clone(),
+                                None,
+                                MetadataS::Set
+                            ),
+                            NftEventSet::MetadataRemoved => fuzzy_node!(
+                                NftData,
+                                name.clone(),
+                                domain.clone(),
+                                None,
+                                MetadataS::Unset
+                            ),
+                            NftEventSet::OwnerChanged => fuzzy_node!(
+                                NftOwner,
+                                name.clone(),
+                                domain.clone(),
+                                None,
+                                None,
+                                UnitS::Create as u8 | UnitS::Delete as u8
+                            ),
+                            _ => unreachable!(),
+                        })
+                        .collect()
+                }
+                Trigger(ef) => {
+                    let id = ef.id_matcher.map(Rc::new);
+                    ef.event_set
+                        .decompose()
+                        .into_iter()
+                        .map(|es| match es {
+                            TriggerEventSet::Created => {
+                                fuzzy_node!(Trigger, id.clone(), TriggerS::Create)
+                            }
+                            TriggerEventSet::Deleted => {
+                                fuzzy_node!(Trigger, id.clone(), TriggerS::Delete)
+                            }
+                            TriggerEventSet::Extended => {
+                                fuzzy_node!(Trigger, id.clone(), TriggerS::Increase)
+                            }
+                            TriggerEventSet::Shortened => {
+                                fuzzy_node!(Trigger, id.clone(), TriggerS::Decrease)
+                            }
+                            TriggerEventSet::MetadataInserted => {
+                                fuzzy_node!(TriggerMetadata, id.clone(), None, MetadataS::Set)
+                            }
+                            TriggerEventSet::MetadataRemoved => {
+                                fuzzy_node!(TriggerMetadata, id.clone(), None, MetadataS::Unset)
+                            }
+                            _ => unreachable!(),
+                        })
+                        .collect()
+                }
+                Role(ef) => {
+                    let id = ef.id_matcher.map(Rc::new);
+                    ef.event_set
+                        .decompose()
+                        .into_iter()
+                        .map(|es| match es {
+                            RoleEventSet::Created => {
+                                fuzzy_node!(Role, id.clone(), UnitS::Create)
+                            }
+                            RoleEventSet::Deleted => {
+                                fuzzy_node!(Role, id.clone(), UnitS::Delete)
+                            }
+                            RoleEventSet::PermissionAdded => {
+                                fuzzy_node!(RolePermission, id.clone(), None, UnitS::Create)
+                            }
+                            RoleEventSet::PermissionRemoved => {
+                                fuzzy_node!(RolePermission, id.clone(), None, UnitS::Delete)
+                            }
+                            _ => unreachable!(),
+                        })
+                        .collect()
+                }
+                Configuration(ef) => ef
+                    .event_set
+                    .decompose()
+                    .into_iter()
+                    .map(|es| match es {
+                        ConfigurationEventSet::Changed => {
+                            fuzzy_node!(Parameter, None, ParameterS::Set)
+                        }
+                        _ => unreachable!(),
+                    })
+                    .collect(),
+                Executor(ef) => ef
+                    .event_set
+                    .decompose()
+                    .into_iter()
+                    .map(|es| match es {
+                        ExecutorEventSet::Upgraded => {
+                            fuzzy_node!(Authorizer, AuthorizerS::Set)
+                        }
+                        _ => unreachable!(),
+                    })
+                    .collect(),
+            }
+        }
+    }
+}

--- a/crates/iroha_tree/src/state.rs
+++ b/crates/iroha_tree/src/state.rs
@@ -1,0 +1,489 @@
+//! Module for [`StateView`] and related components.
+
+use super::*;
+
+/// Represents the state view of each node.
+pub type StateView = Tree<View>;
+
+/// Each node value indicates the state view.
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+pub struct View;
+
+impl Mode for View {
+    type Authorizer = tr::AuthorizerV;
+    type Parameter = tr::ParameterV;
+    type Peer = tr::UnitV;
+    type Domain = tr::DomainV;
+    type Account = tr::UnitV;
+    type Asset = tr::AssetV;
+    type Nft = tr::NftV;
+    type AccountAsset = tr::AccountAssetV;
+    type Role = tr::UnitV;
+    type Permission = tr::PermissionV;
+    type AccountRole = tr::UnitV;
+    type AccountPermission = tr::UnitV;
+    type RolePermission = tr::UnitV;
+    type Trigger = tr::TriggerV;
+    type Condition = tr::ConditionV;
+    type Executable = tr::ExecutableV;
+    type TriggerCondition = tr::UnitV;
+    type TriggerExecutable = tr::UnitV;
+    type DomainMetadata = tr::MetadataV;
+    type AccountMetadata = tr::MetadataV;
+    type AssetMetadata = tr::MetadataV;
+    type NftData = tr::MetadataV;
+    type TriggerMetadata = tr::MetadataV;
+    type DomainAdmin = tr::UnitV;
+    type AssetAdmin = tr::UnitV;
+    type NftAdmin = tr::UnitV;
+    type NftOwner = tr::UnitV;
+    type TriggerAdmin = tr::UnitV;
+}
+
+impl NodeReadWrite for StateView {
+    type Status = event::Event;
+
+    fn as_status(&self) -> Self::Status {
+        self.iter()
+            .map(|(k, v)| NodeEntry::try_from((k.clone(), v.into())).unwrap())
+            .collect()
+    }
+}
+
+/// Interface for interacting with the main state of the application.
+pub trait WorldState {
+    /// Indicates that the write request was rejected due to data integrity violations.
+    type InvariantViolation: From<Box<NodeConflict<changeset::Write>>>;
+
+    /// Applies a write entry to the state.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the update violates data integrity constraints.
+    fn update_by(
+        &mut self,
+        entry: NodeEntry<changeset::Write>,
+    ) -> Result<(), Self::InvariantViolation>;
+
+    /// Scans for inconsistencies based on event predictions and attempts to resolve them, returning an additional changeset.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the expected change is determined to break data integrity.
+    fn sanitize(
+        &self,
+        event_prediction: &event::Event,
+    ) -> Result<changeset::ChangeSet, Self::InvariantViolation>;
+
+    /// Retrieve stored values based on the `readset` query.
+    fn load(&self, readset: &readset::ReadSet) -> StateView;
+
+    /// Applies an unordered changeset to the state, resulting in events.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the update violates data integrity constraints.
+    fn update(
+        &mut self,
+        changeset: changeset::ChangeSet,
+    ) -> Result<event::Event, Self::InvariantViolation> {
+        let event_prediction = changeset.as_status();
+        let changeset = (changeset + self.sanitize(&event_prediction)?)?;
+        let event = changeset.as_status();
+
+        for (key, value) in changeset {
+            self.update_by(NodeEntry::try_from((key, value)).unwrap())?;
+        }
+
+        Ok(event)
+    }
+}
+
+#[allow(missing_docs)]
+pub mod transitional {
+    use hashbrown::{HashMap, HashSet};
+
+    use super::*;
+
+    /// State view at `Unit` type nodes.
+    #[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+    pub struct UnitV;
+
+    /// State view at `Authorizer` type nodes.
+    #[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+    pub struct AuthorizerV;
+
+    /// State view at `Parameter` type nodes.
+    #[derive(Debug, PartialEq, Eq, From, Clone, Decode, Encode)]
+    pub struct ParameterV {
+        pub(crate) parameter: dm::Parameter,
+    }
+
+    /// State view at `Domain` type nodes.
+    #[derive(Debug, PartialEq, Eq, From, Clone, Decode, Encode)]
+    pub struct DomainV {
+        pub(crate) logo: Option<dm::IpfsPath>,
+    }
+
+    /// State view at `Asset` type nodes.
+    #[derive(Debug, PartialEq, Eq, Constructor, Clone, Decode, Encode)]
+    pub struct AssetV {
+        pub(crate) total_quantity: dm::Numeric,
+        pub(crate) mintable: dm::Mintable,
+        pub(crate) logo: Option<dm::IpfsPath>,
+    }
+
+    /// State view at `Nft` type nodes.
+    #[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+    pub struct NftV;
+
+    /// State view at `AccountAsset` type nodes.
+    #[derive(Debug, PartialEq, Eq, From, Clone, Decode, Encode)]
+    pub struct AccountAssetV {
+        pub(crate) balance: dm::Numeric,
+    }
+
+    /// State view at `Permission` type nodes.
+    #[derive(Debug, PartialEq, Eq, From, Clone, Decode, Encode)]
+    pub struct PermissionV {
+        pub(crate) permission: permission::Permission,
+    }
+
+    /// State view at `Trigger` type nodes.
+    #[derive(Debug, PartialEq, Eq, From, Clone, Decode, Encode)]
+    pub struct TriggerV {
+        pub(crate) repeats: dm::Repeats,
+    }
+
+    /// State view at `Condition` type nodes.
+    #[derive(Debug, PartialEq, Eq, From, Clone, Decode, Encode)]
+    pub enum ConditionV {
+        World(receptor::Receptor),
+        Time(dm::TimeSchedule),
+        Block(BlockCommit),
+    }
+
+    #[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+    pub struct BlockCommit;
+
+    /// State view at `Executable` type nodes.
+    #[derive(Debug, PartialEq, Eq, From, Clone, Decode, Encode)]
+    pub enum ExecutableV {
+        Static(changeset::ChangeSet),
+        Dynamic(WasmExecutable),
+    }
+
+    #[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+    pub struct WasmExecutable;
+
+    /// State view at `Metadata` type nodes.
+    #[derive(Debug, PartialEq, Eq, From, Clone, Decode, Encode)]
+    pub struct MetadataV {
+        pub(crate) json: dm::Json,
+    }
+
+    #[derive(Debug, PartialEq, Eq, Constructor, Clone)]
+    pub struct TriggerEntry<'a> {
+        pub id: &'a dm::TriggerId,
+        pub condition: &'a ConditionV,
+        pub executable: &'a ExecutableV,
+    }
+
+    #[derive(Debug, PartialEq, Eq, Constructor, Clone)]
+    pub struct WorldTriggerEntry<'a> {
+        pub id: &'a dm::TriggerId,
+        pub receptor: &'a receptor::Receptor,
+        pub executable: &'a ExecutableV,
+    }
+
+    impl<'a> TryFrom<TriggerEntry<'a>> for WorldTriggerEntry<'a> {
+        type Error = &'static str;
+
+        fn try_from(entry: TriggerEntry<'a>) -> Result<Self, Self::Error> {
+            match entry.condition {
+                ConditionV::World(receptor) => {
+                    Ok(WorldTriggerEntry::new(entry.id, receptor, entry.executable))
+                }
+                _ => Err("conversion succeeds only when this trigger subscribes to world events"),
+            }
+        }
+    }
+
+    impl StateView {
+        pub fn triggers(&self) -> impl Iterator<Item = TriggerEntry> {
+            let ids = self.keys().filter_map(|k| match k {
+                NodeKey::Trigger(id) => Some(&**id),
+                _ => None,
+            });
+            let conditions: HashMap<_, _> = self
+                .keys()
+                .filter_map(|k| match k {
+                    NodeKey::TriggerCondition((trg, con)) => {
+                        let Some(NodeValue::Condition(condition)) =
+                            self.get(&NodeKey::Condition(con.clone()))
+                        else {
+                            panic!("should be loaded into the state view")
+                        };
+                        Some((&**trg, condition))
+                    }
+                    _ => None,
+                })
+                .collect();
+            let executables: HashMap<_, _> = self
+                .keys()
+                .filter_map(|k| match k {
+                    NodeKey::TriggerExecutable((trg, exe)) => {
+                        let Some(NodeValue::Executable(executable)) =
+                            self.get(&NodeKey::Executable(exe.clone()))
+                        else {
+                            panic!("should be loaded into the state view")
+                        };
+                        Some((&**trg, executable))
+                    }
+                    _ => None,
+                })
+                .collect();
+
+            ids.map(move |id| {
+                let condition = *conditions
+                    .get(id)
+                    .expect("should be loaded into the state view");
+                let executable = *executables
+                    .get(id)
+                    .expect("should be loaded into the state view");
+                TriggerEntry::new(id, condition, executable)
+            })
+        }
+
+        pub fn world_triggers(&self) -> impl Iterator<Item = WorldTriggerEntry> {
+            self.triggers().filter_map(|entry| entry.try_into().ok())
+        }
+    }
+
+    impl TriggerEntry<'_> {
+        pub fn leads_to_event_loop(&self, state: &StateView) -> bool {
+            let empty_receptor = receptor::Receptor::default();
+            let mut world_triggers: HashMap<_, _> = state
+                .world_triggers()
+                .map(|entry| (entry.id, (entry.receptor, entry.executable)))
+                .collect();
+            let receptor = match self.condition {
+                ConditionV::World(receptor) => receptor,
+                _ => &empty_receptor,
+            };
+            world_triggers.insert(self.id, (receptor, self.executable));
+            let mut stack = vec![self.id];
+            let mut seen = HashSet::new();
+            while let Some(trigger_id) = stack.pop() {
+                if seen.contains(&trigger_id) {
+                    return true;
+                }
+                seen.insert(trigger_id);
+                let event_expected = match &world_triggers[trigger_id].1 {
+                    state::tr::ExecutableV::Static(changeset) => changeset.as_status(),
+                    state::tr::ExecutableV::Dynamic(_wasm) => {
+                        todo!("Wasm executable should declare the union of possible events")
+                    }
+                };
+                if event_expected.iter().any(|(_k, v)| {
+                    matches!(
+                        v,
+                        NodeValue::TriggerCondition(event::UnitS::Create)
+                            | NodeValue::TriggerExecutable(event::UnitS::Create)
+                    )
+                }) {
+                    // Trigger registration by another trigger is not allowed unless Wasm executables declare the candidate trigger executables.
+                    return true;
+                }
+                let next_trigger_ids = world_triggers.iter().filter_map(|(id, (receptor, _))| {
+                    event_expected.passes(receptor).is_ok().then_some(id)
+                });
+                stack.extend(next_trigger_ids);
+            }
+            false
+        }
+    }
+
+    impl TryFrom<(dm::AccountId, dm::Executable)> for ExecutableV {
+        type Error = Box<NodeConflict<changeset::Write>>;
+
+        fn try_from(
+            (authority, executable): (dm::AccountId, dm::Executable),
+        ) -> Result<Self, Self::Error> {
+            match executable {
+                dm::Executable::Instructions(instructions) => {
+                    let changeset =
+                        changeset::ChangeSet::try_from((authority, instructions.into_vec()))?;
+                    Ok(changeset.into())
+                }
+                dm::Executable::Wasm(_wasm) => Ok(WasmExecutable.into()),
+            }
+        }
+    }
+}
+
+pub use transitional as tr;
+
+#[cfg(test)]
+mod tests {
+    #[cfg(not(feature = "std"))]
+    use alloc::format;
+
+    use dm::{DomainId, Repeats, TriggerId};
+
+    use super::{transitional::TriggerEntry, *};
+    use crate::{
+        changeset::{ChangeSet, ConditionW, DomainW, ExecutableW, TriggerW, UnitW},
+        receptor::Receptor,
+    };
+
+    /// See the corresponding integration test `triggers::not_registered_when_potential_event_loop_detected`.
+    #[expect(clippy::too_many_lines)]
+    #[test]
+    fn detects_event_loop() {
+        // Subscribes to changes in the domain "dom_{i}" with statuses "{s}".
+        let receptor = |i: usize, s: &str| {
+            Receptor::from_iter([fuzzy_node!(
+                Domain,
+                some!(DomainId::from_str(&format!("dom_{i}")).unwrap()),
+                FilterU8::from_str(s).unwrap()
+            )])
+        };
+        // Publishes the deletion of the domain "dom_{j}".
+        let changeset = |j: usize| {
+            ChangeSet::from_iter([node!(
+                Domain,
+                DomainId::from_str(&format!("dom_{j}")).unwrap(),
+                DomainW::Delete(())
+            )])
+        };
+        // Bridges the above subscriber and publisher.
+        let trigger = |i: usize, s: &str, j: usize| {
+            let condition = tr::ConditionV::from(receptor(i, s));
+            let executable = tr::ExecutableV::from(changeset(j));
+            (
+                (
+                    TriggerId::from_str(&format!("trg_{i}{s}_{j}d")).unwrap(),
+                    tr::TriggerV::from(Repeats::Indefinitely),
+                ),
+                (crate::tr::ConditionId::from(&condition), condition),
+                (crate::tr::ExecutableId::from(&executable), executable),
+            )
+        };
+        // A potential connection exists through the deletion of "dom_1".
+        let (trg_0d_1d, trg_1d_2d) = (trigger(0, "d", 1), trigger(1, "d", 2));
+        // The state after registering the above triggers.
+        let state = StateView::from_iter([
+            node!(Condition, trg_0d_1d.1 .0.clone(), trg_0d_1d.1 .1),
+            node!(Condition, trg_1d_2d.1 .0.clone(), trg_1d_2d.1 .1),
+            node!(Executable, trg_0d_1d.2 .0.clone(), trg_0d_1d.2 .1),
+            node!(Executable, trg_1d_2d.2 .0.clone(), trg_1d_2d.2 .1),
+            node!(
+                TriggerCondition,
+                trg_0d_1d.0 .0.clone(),
+                trg_0d_1d.1 .0,
+                tr::UnitV
+            ),
+            node!(
+                TriggerCondition,
+                trg_1d_2d.0 .0.clone(),
+                trg_1d_2d.1 .0,
+                tr::UnitV
+            ),
+            node!(
+                TriggerExecutable,
+                trg_0d_1d.0 .0.clone(),
+                trg_0d_1d.2 .0,
+                tr::UnitV
+            ),
+            node!(
+                TriggerExecutable,
+                trg_1d_2d.0 .0.clone(),
+                trg_1d_2d.2 .0,
+                tr::UnitV
+            ),
+            node!(Trigger, trg_0d_1d.0 .0, trg_0d_1d.0 .1),
+            node!(Trigger, trg_1d_2d.0 .0, trg_1d_2d.0 .1),
+        ]);
+
+        for (entry, leads_to_event_loop) in [
+            // Short-circuiting.
+            (trigger(2, "d", 0), true),
+            // No short-circuiting due to status mismatch.
+            (trigger(2, "cu", 0), false),
+            // Extending the graph.
+            (trigger(2, "d", 3), false),
+            // Creating another cyclic cluster.
+            (trigger(3, "d", 3), true),
+            // Creating another acyclic cluster.
+            (trigger(3, "d", 4), false),
+            {
+                let mut trg_3d_x = trigger(3, "d", 4);
+                let another = trigger(10, "", 20);
+                trg_3d_x.2 .1 = ChangeSet::from_iter([
+                    node!(
+                        Condition,
+                        another.1 .0.clone(),
+                        ConditionW::Set(another.1 .1)
+                    ),
+                    node!(
+                        Executable,
+                        another.2 .0.clone(),
+                        ExecutableW::Set(another.2 .1)
+                    ),
+                    node!(
+                        TriggerCondition,
+                        another.0 .0.clone(),
+                        another.1 .0,
+                        UnitW::Create(())
+                    ),
+                    node!(
+                        TriggerExecutable,
+                        another.0 .0.clone(),
+                        another.2 .0,
+                        UnitW::Create(())
+                    ),
+                    node!(Trigger, another.0 .0, TriggerW::Create(another.0 .1)),
+                ])
+                .into();
+                // Creating an additional trigger.
+                (trg_3d_x, true)
+            },
+        ]
+        .iter()
+        .map(|(trg, b)| (TriggerEntry::new(&trg.0 .0, &trg.1 .1, &trg.2 .1), *b))
+        {
+            assert_eq!(leads_to_event_loop, entry.leads_to_event_loop(&state));
+        }
+    }
+
+    #[test]
+    fn passes_permission() {
+        use permission::Permission;
+
+        let key = |i: usize| dm::RoleId::from_str(&format!("role_{i}")).unwrap();
+        let views = [
+            StateView::default(),
+            StateView::from_iter([node!(Role, key(0), tr::UnitV)]),
+            StateView::from_iter([
+                node!(Role, key(0), tr::UnitV),
+                node!(Role, key(1), tr::UnitV),
+            ]),
+        ];
+        let permissions = [
+            Permission::default(),
+            Permission::from_iter([fuzzy_node!(Role, some!(key(0)), event::UnitS::Read)]),
+            Permission::from_iter([fuzzy_node!(Role, None, FilterU8::from_str("r").unwrap())]),
+        ];
+
+        let missing_permission = views[2].passes(&permissions[1]).unwrap_err();
+        let complemented_permission = permissions[1].clone() | missing_permission;
+        assert!(views[2].passes(&complemented_permission).is_ok());
+
+        for (i, view) in views.iter().enumerate() {
+            for (j, permission) in permissions.iter().enumerate() {
+                assert_eq!(i <= j, view.passes(permission).is_ok());
+            }
+        }
+    }
+}

--- a/crates/irohad/Cargo.toml
+++ b/crates/irohad/Cargo.toml
@@ -19,6 +19,8 @@ workspace = true
 
 [features]
 default = ["telemetry", "schema-endpoint"]
+# Abstract instructions, events, and event filters into a generic structure to simulate possible execution paths.
+prediction = ["default", "iroha_core/prediction"]
 
 # Support lightweight telemetry, including diagnostics
 telemetry = ["iroha_telemetry", "iroha_core/telemetry", "iroha_torii/telemetry"]

--- a/wasm/samples/trigger_transfer_one/Cargo.toml
+++ b/wasm/samples/trigger_transfer_one/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "trigger_transfer_one"
+
+edition.workspace = true
+version.workspace = true
+authors.workspace = true
+
+license.workspace = true
+
+[lib]
+crate-type = ['cdylib']
+
+[dependencies]
+iroha_trigger.workspace = true
+
+panic-halt.workspace = true
+dlmalloc.workspace = true

--- a/wasm/samples/trigger_transfer_one/src/lib.rs
+++ b/wasm/samples/trigger_transfer_one/src/lib.rs
@@ -1,0 +1,24 @@
+//! Transfer one rose to Bob
+
+#![no_std]
+
+#[cfg(not(test))]
+extern crate panic_halt;
+
+use dlmalloc::GlobalDlmalloc;
+use iroha_trigger::prelude::*;
+
+#[global_allocator]
+static ALLOC: GlobalDlmalloc = GlobalDlmalloc;
+
+#[iroha_trigger::main]
+fn main(host: Iroha, context: Context) {
+    let rose = AssetId::new("rose#wonderland".parse().unwrap(), context.authority);
+    let bob: AccountId =
+        "ed012004FF5B81046DDCCF19E2E451C45DFB6F53759D4EB30FA2EFA807284D1CC33016@wonderland"
+            .parse()
+            .unwrap();
+
+    host.submit(&Transfer::asset_numeric(rose, Numeric::ONE, bob))
+        .dbg_expect("should transfer a rose");
+}


### PR DESCRIPTION
## Context

Tracking issue:

- #REC

This PR introduces an abstract structure applicable to executables, events, event filters, and permissions to streamline the execution cycle.

- No API changes are introduced at this stage.
- The `iroha_tree::*::transitional` submodules demonstrate the potential to replace the current structure.
- Partially bypasses existing logic behind the non-default `prediction` feature, enabling loop detection at trigger registration time (for non-Wasm executables).

Since I was unsure whether this change would be a viable atomic change until opening this PR, no RFC was written beforehand. Let's discuss it here.

### Related Work

- Partially resolves the loop detection aspect of #5232
  - To fully implement loop detection, Wasm executables must statically declare the union of possible events: #WXE
- Lays the groundwork for:
  - Trigger per transaction: #4937
  - Executing triggers as internal transactions: #4968

### Migration Guide

- `transitional` submodules serve as interfaces between new and existing structures.
- Any future API changes will result from resolving and removing these `transitional` submodules.

---

### Review Notes

```mermaid
classDiagram
%% note "This is a general note"
%% class Tree
%% class FuzzyTree
class StateView
class ReadSet
class ChangeSet:::prediction
class Event:::prediction
class Receptor:::prediction
class Permission
class Add
class BitOr

classDef prediction color:#f9f

%% FuzzyTree <-- Tree

%% Tree <|.. StateView
%% FuzzyTree <|.. ReadSet
%% Tree <|.. ChangeSet
%% Tree <|.. Event
%% FuzzyTree <|.. Receptor
%% FuzzyTree <|.. Permission

StateView <-- ReadSet : load()
Event <-- StateView : as_status()
Event <-- ChangeSet : as_status()
Permission <-- StateView : passes()
Permission <-- ChangeSet : passes()
Receptor <-- Event : passes()
Receptor .. Permission : type alias
ChangeSet <-- Receptor : triggers

Add <|-- ChangeSet : implements
BitOr <|-- Permission : implements

```

For the loop detection feature:

- Unit test: `iroha_tree::state::tests::detects_event_loop`
- Integration test: `iroha::mod::triggers::not_registered_when_potential_event_loop_detected`

The crate documentation provides an abstract:

#### iroha_tree

> A transitional crate that might eventually be merged into other crates.
>
> It aims to integrate executables, events, and event filters while enabling recursive trigger prediction in a static manner.
> The prediction is based on the union of possible execution paths, enabling pessimistic event loop detection.
>
> Additionally, to maintain performance, it consolidates:
>
> - Instructions into a single [`ChangeSet`] per transaction.
> - (Data) events into a single [`Event`] per transaction.
> - (Data) event filters into a single [`Receptor`] per trigger.
> - Permissions, roles, and ownerships into a single [`Permission`] per validation.

#### iroha_authorizer

> A crate enabling user-defined logic to authorize or reject executables and queries based on the authority’s permissions and ownerships.
>
> This is a stripped-down version of the executor, focused solely on permission validation.
> It does not define or execute instructions.

### Checklist

- [x] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [x] I've written unit tests for the code changes.
- [ ] All review comments have been resolved.
- [ ] All CI checks pass.