### PR TITLE
fix(CI): Fix python static analysis workflow for poetry v2

### DIFF
--- a/.github/workflows/iroha2-dev-pr-static.yml
+++ b/.github/workflows/iroha2-dev-pr-static.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install dependencies using Poetry for pytests/${{ matrix.suite }}
         working-directory: pytests/${{ matrix.suite }}
         run: |
-          poetry lock --no-update
+          poetry lock
           poetry install --no-root
       - name: Check code formatting with Black in pytests/${{ matrix.suite }}
         working-directory: pytests/${{ matrix.suite }}


### PR DESCRIPTION
Looks like we now use poetry v2 on CI, as a result python static analysis workflow fails with error

> The option "--no-update" does not exist

* [Example of failed workflow](https://github.com/hyperledger-iroha/iroha/actions/runs/13901677856/job/38894759162?pr=5373)
* [Workflow history](https://github.com/hyperledger-iroha/iroha/actions/workflows/iroha2-dev-pr-static.yml)

---

In poetry v2 option `--no-update` was removed (it became default behaviour). See https://github.com/python-poetry/poetry/issues/9136