### PR TITLE
ci: test debug build of `irohad` 

### DIFF
--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -102,8 +102,8 @@ jobs:
         run: |
           mv ${{ env.WASM_TARGET_DIR }}/libs ${{ env.DEFAULTS_DIR }}/libs
           mv ${{ env.DEFAULTS_DIR }}/libs/default_executor.wasm ${{ env.DEFAULTS_DIR }}/executor.wasm
-      - name: Install irohad
-        run: which irohad || cargo install --path crates/irohad --locked
+      - name: Build irohad (debug, all features)
+        run: cargo build --bin irohad --all-features
       - name: Test with no default features
         id: test_no_features
         run: >

--- a/crates/iroha/tests/roles.rs
+++ b/crates/iroha/tests/roles.rs
@@ -265,7 +265,7 @@ fn grant_revoke_role_permissions() -> Result<()> {
 }
 
 #[test]
-#[should_panic(expected = "a peer exited unexpectedly")]
+#[should_panic(expected = "peer exited unexpectedly")]
 fn grant_unexisting_role_in_genesis_fail() {
     // Grant Alice UNEXISTING role
     let alice_id = ALICE_ID.clone();

--- a/crates/iroha_data_model/src/parameter.rs
+++ b/crates/iroha_data_model/src/parameter.rs
@@ -78,7 +78,7 @@ mod model {
         pub block_time_ms: u64,
         /// Time (in milliseconds) a peer will wait for a block to be committed.
         ///
-        /// If this period expires the block will request a view change
+        /// If this period expires, peer will request a view change
         #[serde(default = "defaults::sumeragi::commit_time_ms")]
         pub commit_time_ms: u64,
         /// Maximal allowed random deviation from the nominal rate


### PR DESCRIPTION
### Changes

`iroha_test_network` uses `target/debug/irohad` by default (override with `IROHAD_BIN` env).

### Why

To run `irohad` with `debug_assertions` enabled, catching potential internal bugs not visible in `release`.

### Dev migration

Preparation to run integration tests:

```shell
# Before
cargo install --path crates/irohad --locked

# After
cargo build --bin irohad
```

### TODO

- [ ] In CI, separate tests using `irohad` from the rest
- [ ] Set up CI so that it runs _integration_ tests with both debug and release `irohad`.