### PR TITLE
feat(iroha_torii): stubs for feature-gated endpoints

### DIFF
--- a/crates/iroha_torii/src/lib.rs
+++ b/crates/iroha_torii/src/lib.rs
@@ -156,7 +156,7 @@ impl Torii {
         let router = router
             .route(uri::STATUS, get(routing::telemetry_not_implemented))
             .route(
-                format!("{}/*rest", uri::STATUS),
+                &format!("{}/*rest", uri::STATUS),
                 get(routing::telemetry_not_implemented),
             )
             .route(uri::METRICS, get(routing::telemetry_not_implemented))

--- a/crates/iroha_torii/src/lib.rs
+++ b/crates/iroha_torii/src/lib.rs
@@ -152,9 +152,20 @@ impl Torii {
                     move || core::future::ready(routing::handle_metrics(&metrics_reporter))
                 }),
             );
+        #[cfg(not(feature = "telemetry"))]
+        let router = router
+            .route(uri::STATUS, get(routing::telemetry_not_implemented))
+            .route(
+                format!("{}/*rest", uri::STATUS),
+                get(routing::telemetry_not_implemented),
+            )
+            .route(uri::METRICS, get(routing::telemetry_not_implemented))
+            .route(uri::PEERS, get(routing::telemetry_not_implemented));
 
         #[cfg(feature = "schema")]
         let router = router.route(uri::SCHEMA, get(routing::handle_schema));
+        #[cfg(not(feature = "schema"))]
+        let router = router.route(uri::SCHEMA, get(routing::schema_not_implemented));
 
         #[cfg(feature = "profiling")]
         let router = router.route(
@@ -167,6 +178,8 @@ impl Torii {
                 }
             }),
         );
+        #[cfg(not(feature = "profiling"))]
+        let router = router.route(uri::PROFILE, get(routing::profiling_not_implemented));
 
         let router = router
             .route(

--- a/crates/iroha_torii/src/routing.rs
+++ b/crates/iroha_torii/src/routing.rs
@@ -257,6 +257,33 @@ pub async fn handle_version(state: Arc<State>) -> String {
         .to_string()
 }
 
+#[cfg(not(feature = "telemetry"))]
+pub async fn telemetry_not_implemented() -> impl IntoResponse {
+    (
+        StatusCode::NOT_IMPLEMENTED,
+        "This endpoint is not available on this version of \"irohad\", \
+          as it was compiled without the \"telemetry\" feature flag",
+    )
+}
+
+#[cfg(not(feature = "schema"))]
+pub async fn schema_not_implemented() -> impl IntoResponse {
+    (
+        StatusCode::NOT_IMPLEMENTED,
+        "This endpoint is not available on this version of \"irohad\", \
+          as it was compiled without the \"schema-endpoint\" feature flag",
+    )
+}
+
+#[cfg(not(feature = "profiling"))]
+pub async fn profiling_not_implemented() -> impl IntoResponse {
+    (
+        StatusCode::NOT_IMPLEMENTED,
+        "This endpoint is not available on this version of \"irohad\", \
+          as it was compiled without the \"profiling-endpoint\" feature flag",
+    )
+}
+
 #[cfg(feature = "telemetry")]
 fn update_metrics_gracefully(metrics_reporter: &MetricsReporter) {
     if let Err(error) = metrics_reporter.update_metrics() {

--- a/crates/irohad/Cargo.toml
+++ b/crates/irohad/Cargo.toml
@@ -30,6 +30,8 @@ dev-telemetry = ["telemetry", "iroha_telemetry/dev-telemetry", "iroha_logger/tok
 # Support schema generation from the `schema` endpoint in the local binary.
 # Useful for debugging issues with decoding in SDKs.
 schema-endpoint = ["iroha_torii/schema"]
+# Enable profiling endpoint
+profiling-endpoint = ["iroha_torii/profiling"]
 
 [badges]
 is-it-maintained-issue-resolution = { repository = "https://github.com/hyperledger-iroha/iroha" }


### PR DESCRIPTION
Close #5383 

- Covered endpoints gated by `telemetry`, `schema`, and `profiling` features
- Added `profiling-endpoint` feature to `irohad`

### API Changes

When endpoints are feature-gated away, they no longer return `404 Not Found`, but `501 Not Implemented` with a descriptive message. For example, for `GET /status`:

```
HTTP/1.1 501 Not Implemented
content-type: text/plain; charset=utf-8
content-length: 115
date: Mon, 31 Mar 2025 02:03:48 GMT

This endpoint is not available on this version of "irohad", as it was compiled without the "telemetry" feature flag
```