### PR TITLE
feat(testnet): add default roles with modifiable permissions

### DIFF
--- a/crates/iroha_cli/samples/permission.json
+++ b/crates/iroha_cli/samples/permission.json
@@ -1,0 +1,4 @@
+{
+  "name": "CanRegisterDomain",
+  "payload": null
+}

--- a/crates/iroha_executor/src/default/mod.rs
+++ b/crates/iroha_executor/src/default/mod.rs
@@ -1137,7 +1137,17 @@ pub mod role {
             let permission = $isi.object();
 
             if let Ok(any_permission) = AnyPermission::try_from(permission) {
-                if !$executor.context().curr_block.is_genesis() {
+                let admin: AccountId =
+                    "ed0120FC126A7272403803751DFFC2A40B7E1A6860D6FDE5637E36E783E0032488ACCF@wonderland"
+                        .parse()
+                        .unwrap();
+                let is_exception = [
+                    $executor.context().authority == admin,
+                    $executor.context().curr_block.is_genesis(),
+                ]
+                .into_iter()
+                .any(core::convert::identity);
+                if !is_exception {
                     if !find_account_roles($executor.context().authority.clone(), $executor.host())
                         .any(|authority_role_id| authority_role_id == role_id)
                     {

--- a/crates/iroha_kagami/src/genesis/generate.rs
+++ b/crates/iroha_kagami/src/genesis/generate.rs
@@ -7,7 +7,7 @@ use clap::{Parser, Subcommand};
 use color_eyre::eyre::WrapErr as _;
 use iroha_data_model::{isi::InstructionBox, parameter::Parameters, prelude::*};
 use iroha_executor_data_model::permission::{
-    domain::CanRegisterDomain, parameter::CanSetParameters, peer::CanManagePeers,
+    domain::CanRegisterDomain, parameter::CanSetParameters,
 };
 use iroha_genesis::{
     GenesisBuilder, GenesisWasmAction, GenesisWasmTrigger, RawGenesisTransaction, GENESIS_DOMAIN_ID,
@@ -147,61 +147,72 @@ pub fn generate_default(
         grant_permission_to_register_domains.into(),
     ];
 
-    for isi in instructions
-        .into_iter()
-        .chain(extension_from_test_genesis())
-    {
+    for isi in instructions {
         builder = builder.append_instruction(isi);
     }
 
-    let airdrop = GenesisWasmTrigger::new(
-        "airdrop".parse().unwrap(),
-        GenesisWasmAction::new(
-            "trigger_airdrop.wasm",
-            Repeats::Indefinitely,
-            ALICE_ID.clone(),
-            AccountEventFilter::new().for_events(AccountEventSet::Created),
-        ),
-    );
-    builder = builder.append_wasm_trigger(airdrop);
+    builder = extend_for_testnet(builder);
 
     Ok(builder.build_raw())
 }
 
-/// For testnet only
-fn extension_from_test_genesis() -> impl Iterator<Item = InstructionBox> {
+fn extend_for_testnet(mut builder: GenesisBuilder) -> GenesisBuilder {
     use iroha_executor_data_model::permission::{
         asset::CanMintAssetWithDefinition, domain::CanUnregisterDomain,
-        executor::CanUpgradeExecutor, role::CanManageRoles,
+        executor::CanUpgradeExecutor, peer::CanManagePeers, role::CanManageRoles,
     };
 
-    let rose_definition_id = "rose#wonderland".parse::<AssetDefinitionId>().unwrap();
-    let grant_modify_rose_permission = Grant::account_permission(
-        CanMintAssetWithDefinition {
-            asset_definition: rose_definition_id.clone(),
-        },
-        ALICE_ID.clone(),
-    );
-    let grant_manage_peers_permission = Grant::account_permission(CanManagePeers, ALICE_ID.clone());
-    let grant_manage_roles_permission = Grant::account_permission(CanManageRoles, ALICE_ID.clone());
-    let grant_unregister_wonderland_domain = Grant::account_permission(
+    // iroha_test_network::config::genesis
+    for extension_from_test_genesis in [
+        CanUpgradeExecutor.into(),
+        CanManagePeers.into(),
+        CanManageRoles.into(),
         CanUnregisterDomain {
             domain: "wonderland".parse().unwrap(),
-        },
-        ALICE_ID.clone(),
-    );
-    let grant_upgrade_executor_permission =
-        Grant::account_permission(CanUpgradeExecutor, ALICE_ID.clone());
-
-    [
-        grant_modify_rose_permission,
-        grant_manage_peers_permission,
-        grant_manage_roles_permission,
-        grant_unregister_wonderland_domain,
-        grant_upgrade_executor_permission,
+        }
+        .into(),
+        CanMintAssetWithDefinition {
+            asset_definition: "rose#wonderland".parse().unwrap(),
+        }
+        .into(),
     ]
     .into_iter()
-    .map(Into::into)
+    .map(|permission: Permission| Grant::account_permission(permission, ALICE_ID.clone()))
+    {
+        builder = builder.append_instruction(extension_from_test_genesis);
+    }
+
+    for trigger_on_account_creation in [
+        ("airdrop", "trigger_airdrop.wasm"),
+        ("default_roles", "trigger_default_roles.wasm"),
+    ]
+    .into_iter()
+    .map(|(id, executable)| {
+        GenesisWasmTrigger::new(
+            id.parse().unwrap(),
+            GenesisWasmAction::new(
+                executable,
+                Repeats::Indefinitely,
+                ALICE_ID.clone(),
+                AccountEventFilter::new().for_events(AccountEventSet::Created),
+            ),
+        )
+    }) {
+        builder = builder.append_wasm_trigger(trigger_on_account_creation)
+    }
+
+    for other_prerequisite in [Register::role(
+        Role::new("volunteers".parse().unwrap(), ALICE_ID.clone())
+            .add_permission(CanRegisterDomain),
+    )
+    .into()]
+    .into_iter()
+    .map(|instruction: InstructionBox| instruction)
+    {
+        builder = builder.append_instruction(other_prerequisite);
+    }
+
+    builder
 }
 
 fn generate_synthetic(

--- a/defaults/genesis.json
+++ b/defaults/genesis.json
@@ -154,10 +154,8 @@
       "Grant": {
         "Permission": {
           "object": {
-            "name": "CanMintAssetWithDefinition",
-            "payload": {
-              "asset_definition": "rose#wonderland"
-            }
+            "name": "CanUpgradeExecutor",
+            "payload": null
           },
           "destination": "ed0120FC126A7272403803751DFFC2A40B7E1A6860D6FDE5637E36E783E0032488ACCF@wonderland"
         }
@@ -202,10 +200,26 @@
       "Grant": {
         "Permission": {
           "object": {
-            "name": "CanUpgradeExecutor",
-            "payload": null
+            "name": "CanMintAssetWithDefinition",
+            "payload": {
+              "asset_definition": "rose#wonderland"
+            }
           },
           "destination": "ed0120FC126A7272403803751DFFC2A40B7E1A6860D6FDE5637E36E783E0032488ACCF@wonderland"
+        }
+      }
+    },
+    {
+      "Register": {
+        "Role": {
+          "id": "volunteers",
+          "permissions": [
+            {
+              "name": "CanRegisterDomain",
+              "payload": null
+            }
+          ],
+          "grant_to": "ed0120FC126A7272403803751DFFC2A40B7E1A6860D6FDE5637E36E783E0032488ACCF@wonderland"
         }
       }
     }
@@ -216,6 +230,24 @@
       "id": "airdrop",
       "action": {
         "executable": "trigger_airdrop.wasm",
+        "repeats": "Indefinitely",
+        "authority": "ed0120FC126A7272403803751DFFC2A40B7E1A6860D6FDE5637E36E783E0032488ACCF@wonderland",
+        "filter": {
+          "Data": {
+            "Account": {
+              "id_matcher": null,
+              "event_set": [
+                "Created"
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "default_roles",
+      "action": {
+        "executable": "trigger_default_roles.wasm",
         "repeats": "Indefinitely",
         "authority": "ed0120FC126A7272403803751DFFC2A40B7E1A6860D6FDE5637E36E783E0032488ACCF@wonderland",
         "filter": {

--- a/scripts/build_wasm.sh
+++ b/scripts/build_wasm.sh
@@ -12,6 +12,7 @@ build() {
                 # order by dependency
                 "default_executor"
                 "trigger_airdrop"
+                "trigger_default_roles"
             )
             ;;
         "samples")

--- a/wasm/libs/default_executor/src/lib.rs
+++ b/wasm/libs/default_executor/src/lib.rs
@@ -6,7 +6,7 @@
 extern crate panic_halt;
 
 use dlmalloc::GlobalDlmalloc;
-use iroha_executor::{data_model::block::BlockHeader, prelude::*};
+use iroha_executor::prelude::*;
 
 #[global_allocator]
 static ALLOC: GlobalDlmalloc = GlobalDlmalloc;
@@ -23,17 +23,6 @@ struct Executor {
     verdict: Result,
 }
 
-impl Executor {
-    fn ensure_genesis(curr_block: BlockHeader) {
-        if !curr_block.is_genesis() {
-            dbg_panic!(
-                "Default Executor is intended to be used only in genesis. \
-                 Write your own executor if you need to upgrade executor on existing chain.",
-            );
-        }
-    }
-}
-
 /// Migrate previous executor to the current version.
 /// Called by Iroha once just before upgrading executor.
 ///
@@ -44,7 +33,6 @@ impl Executor {
 /// If `migrate()` entrypoint fails then the whole `Upgrade` instruction
 /// will be denied and previous executor will stay unchanged.
 #[iroha_executor::migrate]
-fn migrate(host: Iroha, context: Context) {
-    Executor::ensure_genesis(context.curr_block);
+fn migrate(host: Iroha, _context: Context) {
     DataModelBuilder::with_default_permissions().build_and_set(&host);
 }

--- a/wasm/libs/trigger_default_roles/Cargo.toml
+++ b/wasm/libs/trigger_default_roles/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "trigger_default_roles"
+
+edition.workspace = true
+version.workspace = true
+authors.workspace = true
+
+license.workspace = true
+
+[lib]
+crate-type = ['cdylib']
+
+[dependencies]
+iroha_trigger.workspace = true
+
+panic-halt.workspace = true
+dlmalloc.workspace = true

--- a/wasm/libs/trigger_default_roles/src/lib.rs
+++ b/wasm/libs/trigger_default_roles/src/lib.rs
@@ -1,0 +1,25 @@
+//! Grant roles upon each account registration.
+
+#![no_std]
+
+#[cfg(not(test))]
+extern crate panic_halt;
+
+use dlmalloc::GlobalDlmalloc;
+use iroha_trigger::prelude::*;
+
+#[global_allocator]
+static ALLOC: GlobalDlmalloc = GlobalDlmalloc;
+
+#[iroha_trigger::main]
+fn main(host: Iroha, context: Context) {
+    let EventBox::Data(DataEvent::Domain(DomainEvent::Account(AccountEvent::Created(account)))) =
+        context.event
+    else {
+        dbg_panic!("only account-created events should pass");
+    };
+    let volunteers: RoleId = "volunteers".parse().dbg_unwrap();
+
+    host.submit(&Grant::account_role(volunteers, account.id().clone()))
+        .dbg_expect("should succeed");
+}


### PR DESCRIPTION
## Context

Describes the runtime upgrade on the [testnet](https://explorer.fujiwara.sora.org), including the executor and a trigger called `default_roles`:

> Transaction `4C008F982B592B9C75CDBA60E531474BC28B26C186F448402B94542CF2E7C36D`:
> 
> - Upgraded the executor to allow the admin to modify role permissions
> 
> Transaction `2ABBA254385409676E4791E221848868D3D0424D61E0E6F752E08D5000B11D73`:
> 
> - Registered a role `volunteers`
> 
> Transaction `F6105B5A9903933BA68316DB7AC2DD95A268A4542477E1F023220A33171D5421`:
> 
> - Allowed `volunteers` to register domains
> 
> Transaction `2F450000BEB773D6D195AC45D32F5552C3208540F1A1D262CE20E7435F1254CB`:
> 
> - Registered a trigger `default_roles` that grants the `volunteers` role to new accounts

These changes are included in the default setup, which is useful in case of a clean install later.