### PR TITLE
perf: Implemented custom storage for transactions hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,6 +1346,7 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+ "serde",
 ]
 
 [[package]]
@@ -3224,6 +3225,7 @@ dependencies = [
 name = "iroha_core"
 version = "2.0.0-rc.1.0"
 dependencies = [
+ "arc-swap",
  "async-trait",
  "criterion",
  "crossbeam-queue",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ wasmtime = "22.0.0"
 tracing = { version = "0.1.40", features = ["log"] }
 tracing-subscriber = { version = "0.3.18", default-features = false }
 
-dashmap = "5.5.3"
+dashmap = { version = "5.5.3", features = ["serde"] }
 rustc-hash = "1.1.0"
 
 serde = { version = "1.0.204", default-features = false }

--- a/crates/iroha_core/Cargo.toml
+++ b/crates/iroha_core/Cargo.toml
@@ -64,6 +64,7 @@ nonzero_ext = { workspace = true }
 
 uuid = { version = "1.10.0", features = ["v4"] }
 indexmap = "2.2.6"
+arc-swap = "1.7.1"
 
 [dev-dependencies]
 iroha_executor_data_model = { workspace = true }

--- a/crates/iroha_core/src/block.rs
+++ b/crates/iroha_core/src/block.rs
@@ -342,11 +342,14 @@ mod valid {
 
     use commit::CommittedBlock;
     use iroha_data_model::{account::AccountId, events::pipeline::PipelineEventBox, ChainId};
-    use mv::storage::StorageReadOnly;
 
     use super::*;
     use crate::{
-        smartcontracts::wasm::cache::WasmCache, state::StateBlock, sumeragi::network_topology::Role,
+        smartcontracts::wasm::cache::WasmCache,
+        state::{
+            storage_transactions::TransactionsReadOnly, StateBlock, StateReadOnlyWithTransactions,
+        },
+        sumeragi::network_topology::Role,
     };
 
     /// Block that was validated and accepted
@@ -521,7 +524,7 @@ mod valid {
             block: &SignedBlock,
             topology: &Topology,
             genesis_account: &AccountId,
-            state: &impl StateReadOnly,
+            state: &impl StateReadOnlyWithTransactions,
             soft_fork: bool,
         ) -> Result<(), BlockValidationError> {
             let expected_block_height = if soft_fork {

--- a/crates/iroha_core/src/snapshot.rs
+++ b/crates/iroha_core/src/snapshot.rs
@@ -254,6 +254,7 @@ mod tests {
 
     use iroha_crypto::KeyPair;
     use iroha_data_model::peer::PeerId;
+    use nonzero_ext::nonzero;
     use tempfile::tempdir;
     use tokio::test;
 
@@ -354,7 +355,10 @@ mod tests {
         let peer_key_pair = KeyPair::random();
         let peer_id = PeerId::new(peer_key_pair.public_key().clone());
         let topology = Topology::new(vec![peer_id]);
-        let valid_block = ValidBlock::new_dummy(peer_key_pair.private_key());
+        let valid_block =
+            ValidBlock::new_dummy_and_modify_header(peer_key_pair.private_key(), |header| {
+                header.height = nonzero!(1u64);
+            });
         let committed_block = valid_block
             .clone()
             .commit(&topology)
@@ -371,7 +375,7 @@ mod tests {
 
         let valid_block =
             ValidBlock::new_dummy_and_modify_header(peer_key_pair.private_key(), |header| {
-                header.height = header.height.checked_add(1).unwrap();
+                header.height = nonzero!(2u64);
             });
         let committed_block = valid_block
             .clone()
@@ -412,7 +416,10 @@ mod tests {
         let peer_key_pair = KeyPair::random();
         let peer_id = PeerId::new(peer_key_pair.public_key().clone());
         let topology = Topology::new(vec![peer_id]);
-        let valid_block = ValidBlock::new_dummy(peer_key_pair.private_key());
+        let valid_block =
+            ValidBlock::new_dummy_and_modify_header(peer_key_pair.private_key(), |header| {
+                header.height = nonzero!(1u64);
+            });
         let committed_block = valid_block
             .clone()
             .commit(&topology)
@@ -429,7 +436,7 @@ mod tests {
 
         let valid_block =
             ValidBlock::new_dummy_and_modify_header(peer_key_pair.private_key(), |header| {
-                header.height = header.height.checked_add(1).unwrap();
+                header.height = nonzero!(2u64);
             });
         let committed_block = valid_block
             .clone()
@@ -448,7 +455,7 @@ mod tests {
         // This case imitate situation when snapshot was created for block which later is discarded as soft-fork
         let valid_block =
             ValidBlock::new_dummy_and_modify_header(peer_key_pair.private_key(), |header| {
-                header.height = header.height.checked_add(1).unwrap();
+                header.height = nonzero!(2u64);
                 header.view_change_index += 1;
             });
         let committed_block = valid_block

--- a/crates/iroha_core/src/state/storage_transactions.rs
+++ b/crates/iroha_core/src/state/storage_transactions.rs
@@ -1,0 +1,282 @@
+//! Multi-version append-only key value storage for transactions
+
+#![allow(clippy::disallowed_types)]
+
+use std::{borrow::Borrow, collections::HashSet, hash::Hash, num::NonZeroUsize, sync::Arc};
+
+use arc_swap::ArcSwapOption;
+use dashmap::DashMap;
+use iroha_crypto::HashOf;
+use iroha_data_model::prelude::SignedTransaction;
+use parking_lot::{lock_api::MutexGuard, Mutex, RawMutex};
+use serde::{Deserialize, Serialize};
+
+type Key = HashOf<SignedTransaction>;
+type Value = NonZeroUsize;
+
+/// Multi-version append-only key value storage for transactions
+/// This is analogue of [`mv::storage::Storage`] or `HashMap<Key, Value>`.
+/// Contains hashes of transactions mapped onto block height where they are stored.
+///
+/// * Q: Why don't we use `HashMap`/`BTreeMap`?
+///   A: Because we need multi-version storage with transactional behaviour
+///   (`.view()`, `.block()`, `.block_and_revert()`, `.commit()`)
+/// * Q: Why don't we use [`mv::storage::Storage`]?
+///   A: Because transactions map consumes 80%+ RAM of iroha.
+///      This storage is memory-optimized and consumes ~3x less memory.
+pub struct TransactionsStorage {
+    /// Latest block. Stored separately because of reverts.
+    /// `None` when there are no blocks yet, otherwise must be not `None`.
+    latest_block: ArcSwapOption<BlockInfo>,
+    /// Map with aggregated transactions of multiple blocks, EXCEPT for the latest block.
+    blocks: DashMap<Key, Value>,
+    write_lock: Mutex<()>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct BlockInfo {
+    /// Transactions added in the block
+    transactions: HashSet<Key>,
+    /// Height of the block.
+    height: NonZeroUsize,
+}
+
+impl TransactionsStorage {
+    /// Construct new [`Self`]
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self {
+            latest_block: ArcSwapOption::empty(),
+            blocks: DashMap::new(),
+            write_lock: Mutex::new(()),
+        }
+    }
+
+    /// Create persistent view of storage at certain point in time
+    pub fn view(&self) -> TransactionsView {
+        TransactionsView {
+            latest_block: self.latest_block.load_full(),
+            blocks: &self.blocks,
+        }
+    }
+
+    /// Create block to aggregate updates
+    pub fn block(&self) -> TransactionsBlock {
+        self.block_impl(false)
+    }
+
+    /// Create block to aggregate updates and revert changes created in the latest block
+    pub fn block_and_revert(&self) -> TransactionsBlock {
+        self.block_impl(true)
+    }
+
+    fn block_impl(&self, revert: bool) -> TransactionsBlock {
+        let guard = self.write_lock.lock();
+        TransactionsBlock {
+            latest_block_ref: &self.latest_block,
+            blocks_ref: &self.blocks,
+            _guard: guard,
+            revert,
+            current_block: None,
+        }
+    }
+}
+
+/// Persistent view of storage at certain point in time
+pub trait TransactionsReadOnly {
+    /// Read entry from the storage
+    fn get<Q>(&self, key: &Q) -> Option<Value>
+    where
+        Key: Borrow<Q>,
+        Q: Hash + Eq + ?Sized;
+}
+
+/// Module for [`TransactionsView`] and it's related impls
+mod view {
+    use super::*;
+
+    /// Consistent view of the storage at the certain version
+    pub struct TransactionsView<'storage> {
+        pub(super) latest_block: Option<Arc<BlockInfo>>,
+        /// Some transactions may be added to the map after `Self` is created,
+        /// but for us exists only transactions with `height < latest_block.height`
+        pub(super) blocks: &'storage DashMap<Key, Value>,
+    }
+
+    impl TransactionsReadOnly for TransactionsView<'_> {
+        fn get<Q>(&self, key: &Q) -> Option<Value>
+        where
+            Key: Borrow<Q>,
+            Q: Hash + Eq + ?Sized,
+        {
+            let Some(block) = &self.latest_block else {
+                return None;
+            };
+            let block_height = block.height;
+            if block.transactions.contains(key) {
+                return Some(block_height);
+            }
+
+            self.blocks
+                .get(key)
+                .map(|h| *h)
+                .filter(|&h| h < block_height)
+        }
+    }
+}
+pub use view::TransactionsView;
+
+/// Module for [`TransactionsBlock`] and it's related impls
+mod block {
+    use std::ops::Deref;
+
+    use super::*;
+
+    /// Batched update to the storage that can be reverted later
+    pub struct TransactionsBlock<'storage> {
+        /// References to [`TransactionsStorage`] struct
+        pub(super) latest_block_ref: &'storage ArcSwapOption<BlockInfo>,
+        pub(super) blocks_ref: &'storage DashMap<Key, Value>,
+        pub(super) _guard: MutexGuard<'storage, RawMutex, ()>,
+
+        /// Own fields
+        pub(super) revert: bool,
+        pub(super) current_block: Option<Arc<BlockInfo>>,
+    }
+
+    impl TransactionsBlock<'_> {
+        /// Add transactions of the block
+        pub fn insert_block(&mut self, transactions: HashSet<Key>, height: Value) {
+            let block_info = BlockInfo {
+                transactions,
+                height,
+            };
+            assert!(
+                self.current_block.is_none(),
+                "Should add block transactions only once"
+            );
+            self.current_block = Some(Arc::new(block_info));
+        }
+
+        #[cfg(test)]
+        pub fn insert_block_with_single_tx(&mut self, tx: Key, height: Value) {
+            let transactions = [tx].into_iter().collect();
+            self.insert_block(transactions, height);
+        }
+
+        /// Apply aggregated changes to the storage
+        pub fn commit(self) {
+            let previous_block = &self.latest_block_ref.load();
+            let previous_block = previous_block.as_ref();
+
+            // Check previous and current block height consistency
+            //
+            // Note that in production `current_block` must be not `None`.
+            // We support `None` case here for tests,
+            // in which `.block()` + `.commit()` is used to populate store,
+            // without actually adding block with transactions.
+            #[cfg(debug_assertions)]
+            if let Some(current_block) = &self.current_block {
+                let current_height = current_block.height.get();
+                let previous_height = previous_block.map_or(0, |b| b.height.get());
+                let addition = usize::from(!self.revert);
+                debug_assert_eq!(previous_height + addition, current_height);
+            }
+
+            if !self.revert {
+                if let Some(previous_block) = previous_block {
+                    for &transaction in &previous_block.transactions {
+                        self.blocks_ref.insert(transaction, previous_block.height);
+                    }
+                }
+            }
+
+            self.latest_block_ref.store(self.current_block);
+        }
+    }
+
+    impl TransactionsReadOnly for TransactionsBlock<'_> {
+        fn get<Q>(&self, key: &Q) -> Option<Value>
+        where
+            Key: Borrow<Q>,
+            Q: Hash + Eq + ?Sized,
+        {
+            if let Some(current_block) = &self.current_block {
+                if current_block.transactions.contains(key) {
+                    return Some(current_block.height);
+                }
+            }
+
+            #[allow(clippy::explicit_deref_methods)]
+            if let Some(latest_block) = self.latest_block_ref.load().deref() {
+                if latest_block.transactions.contains(key) {
+                    return Some(latest_block.height);
+                }
+            }
+
+            self.blocks_ref.get(key).map(|h| *h)
+        }
+    }
+}
+pub use block::TransactionsBlock;
+
+/// Module with serialization and deserialization of [`TransactionsStorage`]
+mod serialization {
+    use super::*;
+
+    impl Serialize for TransactionsStorage {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            #[derive(Serialize)]
+            struct Storage<'a> {
+                latest_block: Option<Arc<BlockInfo>>,
+                blocks: &'a DashMap<Key, Value>,
+            }
+
+            // Note that some new entries may be added to `blocks` during serialization.
+            // We will filter such entries later during deserialization.
+            // Potential alternative implementations:
+            // * Clone `blocks`, filter, then serialize
+            //   Bad approach, will have 2x peak memory usage
+            // * Write custom serialization with filtration
+            //   (using `serializer.serialize_map()`
+            let storage = Storage {
+                latest_block: self.latest_block.load_full(),
+                blocks: &self.blocks,
+            };
+            storage.serialize(serializer)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for TransactionsStorage {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            #[derive(Deserialize)]
+            struct Storage {
+                latest_block: Option<Arc<BlockInfo>>,
+                blocks: DashMap<Key, Value>,
+            }
+
+            let storage = Storage::deserialize(deserializer)?;
+            // See `serialize` implementation why filter is needed here
+            if let Some(latest_block) = &storage.latest_block {
+                let latest_block_height = latest_block.height;
+                storage
+                    .blocks
+                    .retain(|_, &mut height| height < latest_block_height);
+            } else {
+                storage.blocks.clear();
+            }
+
+            Ok(TransactionsStorage {
+                latest_block: ArcSwapOption::from(storage.latest_block),
+                blocks: storage.blocks,
+                write_lock: Mutex::new(()),
+            })
+        }
+    }
+}

--- a/crates/iroha_core/src/sumeragi/main_loop.rs
+++ b/crates/iroha_core/src/sumeragi/main_loop.rs
@@ -12,7 +12,7 @@ use super::{view_change::ProofBuilder, *};
 use crate::telemetry::Telemetry;
 use crate::{
     block::*, peers_gossiper::PeersGossiperHandle, queue::TransactionGuard,
-    sumeragi::tracing::instrument,
+    state::StateReadOnlyWithTransactions, sumeragi::tracing::instrument,
 };
 
 /// `Sumeragi` is the implementation of the consensus.


### PR DESCRIPTION

## Context

This PR reduces memory usage of Iroha ~3 times.
* Currently:
  * ~270 bytes per transaction
  * ~2.7 GB after 10 million transactions
* This PR:
  * ~80 bytes per transaction
  * ~0.9 GB after 10 million transactions

(numbers for "bytes per transaction" correspond only to transaction hashes map, without actual transaction details; numbers for "after 10 million transactions" correspond to total Iroha memory usage)
 
Related: https://github.com/hyperledger-iroha/iroha/issues/5083#issuecomment-2379804636
Related: https://github.com/hyperledger-iroha/iroha/issues/5378#issuecomment-2801936386

### Solution

Implement custom version of storage for `State::transactions` map. It uses concurrent map from [`dashmap`](https://github.com/xacrimon/dashmap) crate to implement memory efficient storage for transaction hashes.

### Review notes

This PR can be divided into two parts
1. Remove `transactions` field from `StateTransaction`, since it is not used there and implementation will be simpler without it.
2. Actual implementation of transactions hashes storage in `crates/iroha_core/src/state/storage_transactions.rs`

### Checklist

- [ ] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.
- [ ] All CI checks pass.
