### PR TITLE
ci: disable defectdojo job

### DIFF
--- a/.github/workflows/iroha2-dev-sonar-dojo.yml
+++ b/.github/workflows/iroha2-dev-sonar-dojo.yml
@@ -33,18 +33,18 @@ jobs:
           args: >
             -Dcommunity.rust.clippy.reportPaths=lints/clippy.json
             -Dcommunity.rust.lcov.reportPaths=lints/lcov.info
-      - name: DefectDojo
-        id: defectdojo
-        uses: C4tWithShell/defectdojo-action@1.0.6
-        with:
-          token: ${{ secrets.DEFECTOJO_TOKEN }}
-          defectdojo_url: ${{ secrets.DEFECTOJO_URL }}
-          product_type: iroha2
-          engagement: ${{ github.ref_name }}
-          tools: "SonarQube API Import,Github Vulnerability Scan"
-          sonar_projectKey: hyperledger:iroha
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          github_repository: ${{ github.repository }}
-          product: ${{ github.repository }}
-          environment: Test
-          reports: '{"Github Vulnerability Scan": "github.json"}'
+      # - name: DefectDojo
+      #   id: defectdojo
+      #   uses: C4tWithShell/defectdojo-action@1.0.6
+      #   with:
+      #     token: ${{ secrets.DEFECTOJO_TOKEN }}
+      #     defectdojo_url: ${{ secrets.DEFECTOJO_URL }}
+      #     product_type: iroha2
+      #     engagement: ${{ github.ref_name }}
+      #     tools: "SonarQube API Import,Github Vulnerability Scan"
+      #     sonar_projectKey: hyperledger:iroha
+      #     github_token: ${{ secrets.GITHUB_TOKEN }}
+      #     github_repository: ${{ github.repository }}
+      #     product: ${{ github.repository }}
+      #     environment: Test
+      #     reports: '{"Github Vulnerability Scan": "github.json"}'


### PR DESCRIPTION
## Context
Pipelines are failed due to `DefectDojo` ruined job. It's failed since it doesn't available more at this time.

### Solution
Disable `DefectDojo` CI job do not failed pipelines. I would still continue to keeping it commented because it could be become actual again in future. Or be free to remove it to keep a clean code.

### Checklist

- [ ] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.
- [ ] All CI checks pass.