### PR TITLE
ci: fix Docker image build and push by upgrading to latest buildx

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           install: true
+          version: latest
       - name: Get the release tag
         run: |
           RELEASE_VERSION=${{ github.ref_name }}
@@ -142,6 +143,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           install: true
+          version: latest
       - name: Build and push iroha2-profiling image
         uses: docker/build-push-action@v6
         if: always()


### PR DESCRIPTION
This PR restores Docker image build and push by migrating from the deprecated legacy cache service.

## Context

- https://github.com/hyperledger-iroha/iroha/actions/runs/14902602396/job/41858558945
- https://github.com/hyperledger-iroha/iroha/actions/runs/14902602396/job/41858558558

### Solution

- https://github.com/docker/setup-buildx-action/discussions/414#discussioncomment-12693195