### PR TITLE
chore(rust): bump Rust toolchain to nightly-2025-05-08

### DIFF
--- a/.github/workflows/ci_image.yml
+++ b/.github/workflows/ci_image.yml
@@ -20,7 +20,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: hyperledger/iroha2-ci:nightly-2024-09-09
+          tags: hyperledger/iroha2-ci:nightly-2025-05-08
           labels: commit=${{ github.sha }}
           file: ${{ github.event.inputs.IROHA2_CI_DOCKERFILE }}
           # This context specification is required

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,7 +20,7 @@ jobs:
   pre_build:
     runs-on: ubuntu-latest
     container:
-      image: hyperledger/iroha2-ci:nightly-2024-09-09
+      image: hyperledger/iroha2-ci:nightly-2025-05-08
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
   consistency:
     runs-on: ubuntu-latest
     container:
-      image: hyperledger/iroha2-ci:nightly-2024-09-09
+      image: hyperledger/iroha2-ci:nightly-2025-05-08
     needs: pre_build
     steps:
       - uses: actions/checkout@v4
@@ -81,7 +81,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache: "false"
-          toolchain: "nightly-2024-09-09"
+          toolchain: "nightly-2025-05-08"
           target: "wasm32-unknown-unknown"
           components: "rustfmt"
       - name: Format
@@ -93,7 +93,7 @@ jobs:
   clippy:
     runs-on: [self-hosted, Linux, iroha2]
     container:
-      image: hyperledger/iroha2-ci:nightly-2024-09-09
+      image: hyperledger/iroha2-ci:nightly-2025-05-08
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
@@ -106,7 +106,7 @@ jobs:
   doc:
     runs-on: [self-hosted, Linux, iroha2]
     container:
-      image: hyperledger/iroha2-ci:nightly-2024-09-09
+      image: hyperledger/iroha2-ci:nightly-2025-05-08
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
@@ -118,7 +118,7 @@ jobs:
   test:
     runs-on: [self-hosted, Linux, iroha2]
     container:
-      image: hyperledger/iroha2-ci:nightly-2024-09-09
+      image: hyperledger/iroha2-ci:nightly-2025-05-08
     needs: pre_build
     env:
       LLVM_PROFILE_FILE_NAME: "iroha-%p-%m.profraw"
@@ -310,7 +310,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     container:
-      image: hyperledger/iroha2-ci:nightly-2024-09-09
+      image: hyperledger/iroha2-ci:nightly-2025-05-08
     steps:
       - uses: actions/checkout@v4
       - name: Download clippy and lcov artifact reports
@@ -333,7 +333,7 @@ jobs:
   test_wasm:
     runs-on: ubuntu-latest
     container:
-      image: hyperledger/iroha2-ci:nightly-2024-09-09
+      image: hyperledger/iroha2-ci:nightly-2025-05-08
     needs: pre_build
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr_docker_compose.yml
+++ b/.github/workflows/pr_docker_compose.yml
@@ -19,7 +19,7 @@ jobs:
   pre_build:
     runs-on: ubuntu-latest
     container:
-      image: hyperledger/iroha2-ci:nightly-2024-09-09
+      image: hyperledger/iroha2-ci:nightly-2025-05-08
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr_python_static.yml
+++ b/.github/workflows/pr_python_static.yml
@@ -14,7 +14,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     container:
-      image: hyperledger/iroha2-ci:nightly-2024-09-09
+      image: hyperledger/iroha2-ci:nightly-2025-05-08
     strategy:
       matrix:
         suite: [iroha_cli_tests, iroha_torii_tests]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
   build_wasm_libs:
     runs-on: ubuntu-latest
     container:
-      image: hyperledger/iroha2-ci:nightly-2024-09-09
+      image: hyperledger/iroha2-ci:nightly-2025-05-08
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -111,7 +111,7 @@ jobs:
     runs-on: [self-hosted, Linux, iroha2]
     needs: build_wasm_libs
     container:
-      image: hyperledger/iroha2-ci:nightly-2024-09-09
+      image: hyperledger/iroha2-ci:nightly-2025-05-08
     steps:
       - uses: actions/checkout@v4
       - name: Download wasm libs

--- a/.github/workflows/publish_custom.yml
+++ b/.github/workflows/publish_custom.yml
@@ -26,7 +26,7 @@ jobs:
   build_wasm_libs:
     runs-on: ubuntu-latest
     container:
-      image: hyperledger/iroha2-ci:nightly-2024-09-09
+      image: hyperledger/iroha2-ci:nightly-2025-05-08
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
     needs: build_wasm_libs
     runs-on: [self-hosted, Linux, iroha2]
     container:
-      image: hyperledger/iroha2-ci:nightly-2024-09-09
+      image: hyperledger/iroha2-ci:nightly-2025-05-08
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/publish_dev.yml
+++ b/.github/workflows/publish_dev.yml
@@ -15,7 +15,7 @@ jobs:
   build_wasm_libs:
     runs-on: ubuntu-latest
     container:
-      image: hyperledger/iroha2-ci:nightly-2024-09-09
+      image: hyperledger/iroha2-ci:nightly-2025-05-08
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -31,7 +31,7 @@ jobs:
   dev_image:
     runs-on: [self-hosted, Linux, iroha2]
     container:
-      image: hyperledger/iroha2-ci:nightly-2024-09-09
+      image: hyperledger/iroha2-ci:nightly-2025-05-08
     needs: build_wasm_libs
     steps:
       - uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ WORKDIR /app
 RUN apt-get update -y && \
     apt-get install -y build-essential mold
 
-RUN rustup toolchain install nightly-2024-09-09
+RUN rustup toolchain install nightly-2025-05-08
 RUN rustup target add wasm32-unknown-unknown
-RUN rustup default nightly-2024-09-09
+RUN rustup default nightly-2025-05-08
 
 COPY . .
 ARG PROFILE="deploy"

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -14,8 +14,8 @@ RUN pacman -Syu rustup mold musl rust-musl openssl libgit2 jq unzip \
     python python-pip --noconfirm --disable-download-timeout && \
     curl -sSL https://install.python-poetry.org | python3 -
 
-RUN rustup toolchain install nightly-2024-09-09-x86_64-unknown-linux-gnu
-RUN rustup default nightly-2024-09-09-x86_64-unknown-linux-gnu
+RUN rustup toolchain install nightly-2025-05-08-x86_64-unknown-linux-gnu
+RUN rustup default nightly-2025-05-08-x86_64-unknown-linux-gnu
 RUN rustup component add llvm-tools-preview clippy
 RUN rustup component add rust-src
 RUN rustup component add rustfmt

--- a/crates/iroha_wasm_builder/src/lib.rs
+++ b/crates/iroha_wasm_builder/src/lib.rs
@@ -15,7 +15,7 @@ use path_absolutize::Absolutize;
 use serde::{Deserialize, Serialize};
 
 /// Current toolchain used to build smartcontracts
-const TOOLCHAIN: &str = "+nightly-2024-09-09";
+const TOOLCHAIN: &str = "+nightly-2025-05-08";
 
 /// Build profile for smartcontracts
 #[derive(

--- a/hooks/pre-commit.sample
+++ b/hooks/pre-commit.sample
@@ -1,5 +1,5 @@
 #!/bin/sh
-# rustup default nightly-2024-09-09
+# rustup default nightly-2025-05-08
 set -e
 # format checks
 cargo fmt --all -- --check

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2024-09-09"
+channel = "nightly-2025-05-08"


### PR DESCRIPTION
Bump Rust toolchain from `nightly-2024-09-09` to `nightly-2025-05-08` across project configs.

## Changes

- Bump `rust-toolchain.toml`, CI workflows, and Dockerfiles to `nightly-2025-05-08`
