### PR TITLE
ci: fix labeler

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -278,20 +278,6 @@ jobs:
           header: pr-title-lint-error
           delete: true
 
-  check_config_label:
-    permissions:
-      contents: read
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      - id: label-the-PR
-        uses: actions/labeler@v5
-      - uses: mshick/add-pr-comment@v2
-        if: contains(steps.label-the-PR.outputs.all-labels, 'config-changes')
-        with:
-          message: |
-            @BAStos525
-
   check_links:
     runs-on: [ubuntu-latest]
     steps:

--- a/.github/workflows/pr_labels.yml
+++ b/.github/workflows/pr_labels.yml
@@ -1,7 +1,8 @@
 name: Pull Request Labels
 
 on:
-  pull_request_target:
+  pull_request:
+    branches: [main]
 
 jobs:
   config_changes:

--- a/.github/workflows/pr_labels.yml
+++ b/.github/workflows/pr_labels.yml
@@ -1,20 +1,14 @@
-name: Pull Request Labels
+name: Pull Request Labeler
 
 on:
-  pull_request:
-    branches: [main]
+  pull_request_target:
 
 jobs:
-  config_changes:
+  labeler:
     permissions:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - id: label-the-PR
-        uses: actions/labeler@v5
-      - uses: mshick/add-pr-comment@v2
-        if: contains(steps.label-the-PR.outputs.all-labels, 'config-changes')
-        with:
-          message: |
-            @BAStos525
+      # NOTE: uses `.github/labeler.yml` config
+      - uses: actions/labeler@v5

--- a/.github/workflows/pr_labels.yml
+++ b/.github/workflows/pr_labels.yml
@@ -1,0 +1,19 @@
+name: Pull Request Labels
+
+on:
+  pull_request_target:
+
+jobs:
+  config_changes:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - id: label-the-PR
+        uses: actions/labeler@v5
+      - uses: mshick/add-pr-comment@v2
+        if: contains(steps.label-the-PR.outputs.all-labels, 'config-changes')
+        with:
+          message: |
+            @BAStos525


### PR DESCRIPTION
## Context

Labeler jobs fails with no good reason.

**Example: on the first step**

https://github.com/hyperledger-iroha/iroha/actions/runs/14928905341/job/42104002157?pr=5420

```
Warning: The action requires write permission to add labels to pull requests. For more information please refer to the action documentation: https://github.com/actions/labeler#permissions
Error: Resource not accessible by integration
```

**Example: on the second step**

https://github.com/hyperledger-iroha/iroha/actions/runs/14987302747/job/42103506612?pr=5394
```
Error: Resource not accessible by integration
```

The permissions are clearly there, so the errors are confusing.

## Solution

~~Moving the job back to a dedicated workflow file, as it was before. Maybe this will fix something.~~

- Dedicated workflow file, `on: pull_request_target`
- Remove step with tagging of Vasiliy