### PR TITLE
fix(ci): disable Rust cache for `wasm` workspace

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,11 +24,15 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      # FIXME: it caches well for binaries build, but seems to ignore wasm32 target
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: "true"
-          workspaces: ".\n./wasm -> wasm32-unknown-unknown"
+          # NOTE: Intentionally do not include `wasm` as it has dependencies to the main workspace and something weird happens
+          #       #5443
+          #       Instead, rely on the default ". -> target"
+          # workspaces: |
+          #   .
+          #   ./wasm -> ../target/wasm32-unknown-unknown
       - name: Build binaries (irohad, iroha, kagami) (release)
         run: |
           cargo build --release --bin irohad --bin iroha --bin kagami

--- a/.github/workflows/pr_docker_compose.yml
+++ b/.github/workflows/pr_docker_compose.yml
@@ -23,11 +23,15 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      # FIXME: it caches well for binaries build, but seems to ignore wasm32 target
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: "true"
-          workspaces: ".\n./wasm -> wasm32-unknown-unknown"
+          # NOTE: Intentionally do not include `wasm` as it has dependencies to the main workspace and something weird happens
+          #       #5443
+          #       Instead, rely on the default ". -> target"
+          # workspaces: |
+          #   .
+          #   ./wasm -> ../target/wasm32-unknown-unknown
       - name: Build WASMs
         run: ./scripts/build_wasm.sh
       - name: Upload WASMs


### PR DESCRIPTION
Rust cache is hard: https://blog.arriven.wtf/posts/rust-ci-cache/

Using defaults of the `Swatinem/rust-cache` action.

Hopefully closes #5443 
Relates to #5413 