### PR TITLE
perf: Store public keys in compact format

### DIFF
--- a/crates/iroha_crypto/src/signature/ed25519.rs
+++ b/crates/iroha_crypto/src/signature/ed25519.rs
@@ -106,7 +106,7 @@ mod test {
             PrivateKey::from_hex(Algorithm::Ed25519, PRIVATE_KEY).unwrap()
         );
         assert_eq!(
-            PublicKey(Box::new(crate::PublicKeyInner::Ed25519(p1))),
+            PublicKey::new(crate::PublicKeyFull::Ed25519(p1)),
             PublicKey::from_hex(Algorithm::Ed25519, PUBLIC_KEY).unwrap()
         );
     }


### PR DESCRIPTION
## Context

Related: #5280
Related: https://github.com/hyperledger-iroha/iroha/issues/5280#issuecomment-2904395318
Related: #5048

### Solution

This PR changes the storage of the `PublicKey` struct. Now, public keys are always stored in compact (encoded) format. In such format, keys can be compared with each other, which is what iroha mostly does with public keys. Public keys will be decoded when signing functionality is needed (e.g., query/transaction signature check).

---

Comparison of memory usage:
* `Account` struct (as is):
  * main: 354 bytes
  * pr: 116 bytes
* `Account` struct in `World`:
  * main: 1006 bytes per account
  * pr: 485 bytes per account

I used this code to check memory usage:

<details>

```rust
#![allow(warnings, unused)]

//! .

use iroha_core::{prelude::*, smartcontracts::Registrable};
use iroha_crypto::PublicKey;
use iroha_data_model::prelude::*;
use util::*;

const N: usize = 1 << 20;

fn main() {
    measure_accounts_in_world();
    // measure_accounts_in_vec();
}

fn measure_accounts_in_world() {
    let genesis_public_key: PublicKey =
        "ed012003415E0E516BE83870CE5A2165605E8719216B5ECCCE4AEDFB0B2B77862B3798"
            .parse()
            .unwrap();
    let genesis_domain = genesis_domain(genesis_public_key.clone());
    let genesis_domain_id = genesis_domain.id().clone();
    let genesis_account = genesis_account(genesis_public_key.clone());
    let genesis_account_id = genesis_account.id().clone();

    let asset_definition_id: AssetDefinitionId =
        format!("mandatory#{genesis_domain}").parse().unwrap();
    let asset_definition =
        AssetDefinition::numeric(asset_definition_id.clone()).build(&genesis_account_id);

    let accounts = (0..N)
        .map(|_| gen_account_in(&genesis_domain_id).0)
        .map(|id| Account::new(id).into_account());
    let assets = [];
    let world = World::with_assets([genesis_domain], accounts, [asset_definition], assets);
    eprintln!("Done");
    std::thread::sleep(std::time::Duration::from_secs(86400));
    dbg!(world.view().accounts_iter().count());
}

fn measure_accounts_in_vec() {
    let genesis_public_key: PublicKey =
        "ed012003415E0E516BE83870CE5A2165605E8719216B5ECCCE4AEDFB0B2B77862B3798"
            .parse()
            .unwrap();
    let genesis_domain = genesis_domain(genesis_public_key.clone());
    let genesis_domain_id = genesis_domain.id().clone();

    let v = (0..N)
        .map(|_| gen_account_in(&genesis_domain_id).0)
        .map(|id| Account::new(id).into_account())
        .collect::<Vec<_>>();
    eprintln!("Done");
    std::thread::sleep(std::time::Duration::from_secs(86400));
    dbg!(v.len());
}

mod util {
    use iroha_core::smartcontracts::Registrable;
    use iroha_crypto::KeyPair;
    use iroha_data_model::prelude::*;

    pub fn genesis_account(public_key: PublicKey) -> Account {
        let genesis_account_id =
            AccountId::new(iroha_genesis::GENESIS_DOMAIN_ID.clone(), public_key);
        Account::new(genesis_account_id.clone()).build(&genesis_account_id)
    }

    pub fn genesis_domain(public_key: PublicKey) -> Domain {
        let genesis_account = genesis_account(public_key);
        Domain::new(iroha_genesis::GENESIS_DOMAIN_ID.clone()).build(&genesis_account.id)
    }

    pub fn gen_account_in(domain: impl core::fmt::Display) -> (AccountId, KeyPair) {
        let key_pair = KeyPair::random();
        let account_id = format!("{}@{}", key_pair.public_key(), domain)
            .parse()
            .expect("domain name should be valid");
        (account_id, key_pair)
    }
}
```

</details>

### Checklist

- [ ] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.
- [ ] All CI checks pass.
