### PR TITLE
feat(kagami wasm): forward extra arguments to cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3512,6 +3512,7 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "serde_json",
+ "shell-words",
  "spinoff",
 ]
 
@@ -5725,6 +5726,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shlex"

--- a/crates/iroha_kagami/Cargo.toml
+++ b/crates/iroha_kagami/Cargo.toml
@@ -38,6 +38,7 @@ derive_more.workspace = true
 parity-scale-codec.workspace = true
 
 inquire = "0.6.2"
+shell-words = "1.1.0"
 
 [build-dependencies]
 iroha_data_model = { workspace = true }

--- a/crates/iroha_kagami/CommandLineHelp.md
+++ b/crates/iroha_kagami/CommandLineHelp.md
@@ -323,6 +323,9 @@ Apply `cargo check` to the smartcontract
 
 ###### **Options:**
 
+* `--cargo-args <CARGO_ARGS>` — Extra arguments to pass to `cargo`, e.g. `--locked`
+
+  Default value: ``
 * `--profile <PROFILE>`
 
   Default value: `release`
@@ -341,6 +344,9 @@ Build the smartcontract
 
 ###### **Options:**
 
+* `--cargo-args <CARGO_ARGS>` — Extra arguments to pass to `cargo`, e.g. `--locked`
+
+  Default value: ``
 * `--profile <PROFILE>` — Build profile
 
   Default value: `release`

--- a/crates/iroha_wasm_builder/src/lib.rs
+++ b/crates/iroha_wasm_builder/src/lib.rs
@@ -77,6 +77,7 @@ pub struct Builder<'path, 'out_dir> {
     show_output: bool,
     /// Build profile
     profile: Profile,
+    cargo_args: Vec<String>,
 }
 
 impl<'path, 'out_dir> Builder<'path, 'out_dir> {
@@ -92,7 +93,14 @@ impl<'path, 'out_dir> Builder<'path, 'out_dir> {
             out_dir: None,
             show_output: false,
             profile,
+            cargo_args: <_>::default(),
         }
+    }
+
+    /// Set extra args for underlying `cargo` command
+    pub fn cargo_args(mut self, args: Vec<String>) -> Self {
+        self.cargo_args = args;
+        self
     }
 
     /// Set smartcontract build output directory.
@@ -159,6 +167,7 @@ impl<'path, 'out_dir> Builder<'path, 'out_dir> {
             )?,
             show_output: self.show_output,
             profile: self.profile,
+            cargo_args: self.cargo_args,
         })
     }
 
@@ -213,6 +222,7 @@ mod internal {
         pub out_dir: Cow<'out_dir, Path>,
         pub show_output: bool,
         pub profile: Profile,
+        pub cargo_args: Vec<String>,
     }
 
     impl Builder<'_> {
@@ -260,7 +270,8 @@ mod internal {
                 .stderr(Stdio::inherit())
                 .arg(cmd)
                 .arg(self.build_profile())
-                .args(Self::build_options());
+                .args(Self::build_options())
+                .args(&self.cargo_args);
 
             command
         }
@@ -420,7 +431,7 @@ fn cargo_command() -> Command {
         if let Ok(value) = env::var(var) {
             if value.contains(INSTRUMENT_COVERAGE_FLAG) {
                 eprintln!("WARNING: found `{INSTRUMENT_COVERAGE_FLAG}` rustc flag in `{var}` environment variable\n  \
-                           This directly interferes with `-Z build-std` flag set by `iroha_wasm_builder`\n  \
+                           This directly interferes with `-Z build-std` flag set by `kagami wasm`\n  \
                            See https://github.com/rust-lang/wg-cargo-std-aware/issues/68 \n  \
                            Further execution of `cargo` will most probably fail with `could not find profiler-builtins` error");
             }

--- a/scripts/build_wasm.sh
+++ b/scripts/build_wasm.sh
@@ -68,10 +68,10 @@ build() {
             )
             ;;
         "samples")
-            NAMES=("$(
+            NAMES=($(
                 cargo metadata --no-deps --manifest-path "$CARGO_DIR/Cargo.toml" --format-version=1 |
                 jq '.packages | map(select(.targets[].kind | contains(["cdylib"]))) | map(.manifest_path | split("/")) | map(select(.[-3] == "samples")) | map(.[-2]) | .[]' -r
-            )")
+            ))
     ;; esac
 
     mkdir -p "$TARGET_DIR/$1"

--- a/scripts/build_wasm.sh
+++ b/scripts/build_wasm.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e;
+set -euo pipefail
 
 DEFAULTS_DIR="defaults"
 CARGO_DIR="wasm"
@@ -8,10 +8,10 @@ PROFILE="release"
 SHOW_HELP=false
 
 # Makes possible to set `BIN_KAGAMI=target/release/kagami` without running cargo
-if [ -n "$BIN_KAGAMI" ]; then
-    bin_kagami=("$BIN_KAGAMI")
+if [[ -n "${BIN_KAGAMI:-}" ]]; then
+  read -r -a bin_kagami <<< "$BIN_KAGAMI"
 else
-    bin_kagami=(cargo run --release --bin kagami --)
+  bin_kagami=(cargo run --release --bin kagami --)
 fi
 
 main() {
@@ -32,7 +32,7 @@ main() {
         esac
     done
 
-    if $SHOW_HELP; then
+    if "$SHOW_HELP"; then
         print_help
         exit 0
     fi
@@ -55,7 +55,7 @@ main() {
                 ;;
             *)
                 echo "error: unrecognized target: $target. Target can be either [libs, samples, all]"
-        esac
+        ;; esac
     done
 }
 
@@ -68,16 +68,16 @@ build() {
             )
             ;;
         "samples")
-            NAMES=($(
+            NAMES=("$(
                 cargo metadata --no-deps --manifest-path "$CARGO_DIR/Cargo.toml" --format-version=1 |
                 jq '.packages | map(select(.targets[].kind | contains(["cdylib"]))) | map(.manifest_path | split("/")) | map(select(.[-3] == "samples")) | map(.[-2]) | .[]' -r
-            ))
-    esac
+            )")
+    ;; esac
 
     mkdir -p "$TARGET_DIR/$1"
-    for name in ${NAMES[@]}; do
+    for name in "${NAMES[@]}"; do
         out_file="$TARGET_DIR/$1/$name.wasm"
-        "${bin_kagami[@]}" wasm build "$CARGO_DIR/$1/$name" --profile=$PROFILE --out-file "$out_file"
+        "${bin_kagami[@]}" wasm build "$CARGO_DIR/$1/$name" --profile="$PROFILE" --out-file "$out_file" --cargo-args="--locked"
     done
 
     echo "profile = \"${PROFILE}\"" > "$TARGET_DIR/build_config.toml"
@@ -89,15 +89,15 @@ build() {
 command() {
     case $1 in
         "libs")
-            build $1
+            build "$1"
             cp -r "$TARGET_DIR/$1" "$DEFAULTS_DIR/"
             mv "$DEFAULTS_DIR/$1/default_executor.wasm" "$DEFAULTS_DIR/executor.wasm"
             echo "info: copied wasm $1 to $DEFAULTS_DIR/$1/"
             echo "info: copied default executor to $DEFAULTS_DIR/executor.wasm"
             ;;
         "samples")
-            build $1
-    esac
+            build "$1"
+    ;; esac
 }
 
 


### PR DESCRIPTION
While working on #5443 and trying to set `--locked` as one of the ways to fix the problem (https://github.com/hyperledger-iroha/iroha/issues/5443#issuecomment-2903877041), I found that it is not possible to pass this argument to Cargo in `build_wasm.sh`.

Now it is possible:

```shell
kagami wasm check path/to/wasm \
  --out-file test.wasm \
  --cargo-args='--locked'
```