### PR TITLE
perf: Inline `algorithm` in `PublicKeyCompact`

### DIFF
--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -655,6 +655,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "executor_with_fuel"
+version = "2.0.0-rc.2.0"
+dependencies = [
+ "dlmalloc",
+ "iroha_data_model",
+ "iroha_executor",
+ "iroha_executor_data_model",
+ "iroha_schema",
+ "iroha_trigger",
+ "panic-halt",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "executor_with_migration_fail"
 version = "2.0.0-rc.2.0"
 dependencies = [
@@ -1712,6 +1727,15 @@ dependencies = [
  "indexmap",
  "toml_datetime",
  "winnow",
+]
+
+[[package]]
+name = "trigger_cat_and_mouse"
+version = "2.0.0-rc.2.0"
+dependencies = [
+ "dlmalloc",
+ "iroha_trigger",
+ "panic-halt",
 ]
 
 [[package]]


### PR DESCRIPTION
## Context

Continuation of #5445
Related: #5280

### Solution

This small PR is a continuation of #5445 and further reduces memory usage of `PublicKey` and related structs (e.g. `Account`).

Comparison of memory usage:
* `Account` struct (as is):
  * master: 116 bytes
  * pr: 109 bytes
* `Account` struct in `World`:
  * master: 485 bytes per account
  * pr: 441 bytes per account

See #5445 for code used to check memory usage.

### Checklist

- [ ] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.
- [ ] All CI checks pass.
