### PR TITLE
perf: Reduce memory usage of `World::accounts` and similar maps

### DIFF
--- a/crates/iroha_core/examples/memory.rs
+++ b/crates/iroha_core/examples/memory.rs
@@ -1,0 +1,121 @@
+#![allow(unused)]
+
+//! This code can be used to measure memory usage of
+//! structs like `Account`, `Asset` and `Nft`.
+
+use iroha_core::prelude::*;
+use iroha_data_model::prelude::*;
+use util::*;
+
+const N: usize = 1 << 20;
+
+fn main() {
+    // measure_accounts_in_vec();
+    measure_accounts_in_world();
+    // measure_assets_in_world();
+    // measure_nfts_in_world();
+}
+
+fn measure_accounts_in_vec() {
+    let (genesis_domain, _genesis_account) = genesis_domain_and_account();
+
+    let v = (0..N)
+        .map(|_| gen_account_in(&genesis_domain.id).0)
+        .map(|id| Account::new(id).into_account())
+        .collect::<Vec<_>>();
+    done(v);
+}
+
+fn measure_accounts_in_world() {
+    let (genesis_domain, _genesis_account) = genesis_domain_and_account();
+
+    let accounts = (0..N)
+        .map(|_| gen_account_in(&genesis_domain.id).0)
+        .map(|id| Account::new(id).into_account());
+    let world = World::with_assets([], accounts, [], [], []);
+    done(world);
+}
+
+fn measure_assets_in_world() {
+    let (genesis_domain, _genesis_account) = genesis_domain_and_account();
+    let asset_definition_id: AssetDefinitionId =
+        format!("mandatory#{genesis_domain}").parse().unwrap();
+
+    let assets = (0..N).map(|_| gen_asset(asset_definition_id.clone()));
+    let world = World::with_assets([], [], [], assets, []);
+    done(world);
+}
+
+fn measure_nfts_in_world() {
+    let (genesis_domain, _genesis_account) = genesis_domain_and_account();
+    let owner = gen_account_in(&genesis_domain.id).0;
+
+    let nfts = (0..N).map(|_| gen_nft(&owner));
+    let world = World::with_assets([], [], [], [], nfts);
+    done(world);
+}
+
+fn print_world_memory_usage() {
+    macro_rules! gen {
+        ($($p:ident,)+) => {
+            $(
+                println!(
+                    "{}Id:  {} bytes\n{}:   {} bytes",
+                    stringify!($p),
+                    size_of::<<$p as Identifiable>::Id>(),
+                    stringify!($p),
+                    size_of::<$p>()
+                );
+            )+
+        };
+    }
+    gen!(Domain, Account, AssetDefinition, Asset, Nft, Role,);
+}
+
+mod util {
+    use std::fmt::Display;
+
+    use iroha_core::smartcontracts::Registrable;
+    use iroha_crypto::KeyPair;
+    use iroha_data_model::prelude::*;
+
+    pub fn genesis_domain_and_account() -> (Domain, Account) {
+        let genesis_public_key: PublicKey =
+            "ed012003415E0E516BE83870CE5A2165605E8719216B5ECCCE4AEDFB0B2B77862B3798"
+                .parse()
+                .unwrap();
+        let genesis_account_id =
+            AccountId::new(iroha_genesis::GENESIS_DOMAIN_ID.clone(), genesis_public_key);
+        let genesis_account = Account::new(genesis_account_id.clone()).build(&genesis_account_id);
+        let genesis_domain =
+            Domain::new(iroha_genesis::GENESIS_DOMAIN_ID.clone()).build(&genesis_account.id);
+        (genesis_domain, genesis_account)
+    }
+
+    pub fn gen_account_in(domain: impl Display) -> (AccountId, KeyPair) {
+        let key_pair = KeyPair::random();
+        let account_id = format!("{}@{}", key_pair.public_key(), domain)
+            .parse()
+            .unwrap();
+        (account_id, key_pair)
+    }
+
+    pub fn gen_asset(asset_definition: AssetDefinitionId) -> Asset {
+        let account_id = gen_account_in(&asset_definition.domain).0;
+        let asset_id = AssetId::new(asset_definition, account_id);
+        let value: u64 = rand::random();
+        Asset::new(asset_id, value)
+    }
+
+    pub fn gen_nft(owner: &AccountId) -> Nft {
+        let value: u64 = rand::random();
+        let nft_id = format!("n{}${}", value, &owner.domain).parse().unwrap();
+        Nft::new(nft_id, Metadata::default()).build(owner)
+    }
+
+    pub fn done<T>(value: T) {
+        eprintln!("Done");
+        std::thread::sleep(std::time::Duration::from_secs(86400));
+        std::hint::black_box(value);
+    }
+}

--- a/crates/iroha_core/src/smartcontracts/isi/account.rs
+++ b/crates/iroha_core/src/smartcontracts/isi/account.rs
@@ -361,8 +361,8 @@ pub mod query {
             Ok(state_ro
                 .world()
                 .accounts_iter()
-                .filter(move |&account| filter.applies(account))
-                .cloned())
+                .filter(move |&account| filter.applies_to_entry(account))
+                .map(Into::into))
         }
     }
 
@@ -389,8 +389,8 @@ pub mod query {
                         ))
                         .is_some()
                 })
-                .filter(move |&account| filter.applies(account))
-                .cloned())
+                .filter(move |&account| filter.applies_to_entry(account))
+                .map(Into::into))
         }
     }
 }

--- a/crates/iroha_core/src/smartcontracts/isi/account.rs
+++ b/crates/iroha_core/src/smartcontracts/isi/account.rs
@@ -361,8 +361,8 @@ pub mod query {
             Ok(state_ro
                 .world()
                 .accounts_iter()
-                .filter(move |&account| filter.applies_to_entry(account))
-                .map(Into::into))
+                .filter(move |account| filter.applies_to_entry(account))
+                .map(|account| account.to_owned()))
         }
     }
 
@@ -389,8 +389,8 @@ pub mod query {
                         ))
                         .is_some()
                 })
-                .filter(move |&account| filter.applies_to_entry(account))
-                .map(Into::into))
+                .filter(move |account| filter.applies_to_entry(account))
+                .map(|account| account.to_owned()))
         }
     }
 }

--- a/crates/iroha_core/src/smartcontracts/isi/asset.rs
+++ b/crates/iroha_core/src/smartcontracts/isi/asset.rs
@@ -259,8 +259,8 @@ pub mod query {
             Ok(state_ro
                 .world()
                 .assets_iter()
-                .filter(move |&asset| filter.applies_to_entry(asset))
-                .map(Into::into))
+                .filter(move |asset| filter.applies_to_entry(asset))
+                .map(|asset| asset.to_owned()))
         }
     }
     impl ValidQuery for FindAssetsDefinitions {

--- a/crates/iroha_core/src/smartcontracts/isi/asset.rs
+++ b/crates/iroha_core/src/smartcontracts/isi/asset.rs
@@ -259,8 +259,8 @@ pub mod query {
             Ok(state_ro
                 .world()
                 .assets_iter()
-                .filter(move |&asset| filter.applies(asset))
-                .cloned())
+                .filter(move |&asset| filter.applies_to_entry(asset))
+                .map(Into::into))
         }
     }
     impl ValidQuery for FindAssetsDefinitions {

--- a/crates/iroha_core/src/smartcontracts/isi/domain.rs
+++ b/crates/iroha_core/src/smartcontracts/isi/domain.rs
@@ -58,7 +58,7 @@ pub mod isi {
             state_transaction
                 .world
                 .accounts
-                .insert(account_id, account.clone());
+                .insert(account_id, (&account).into());
 
             state_transaction
                 .world

--- a/crates/iroha_core/src/smartcontracts/isi/domain.rs
+++ b/crates/iroha_core/src/smartcontracts/isi/domain.rs
@@ -26,7 +26,10 @@ impl Registrable for iroha_data_model::domain::NewDomain {
 /// - update metadata
 /// - transfer, etc.
 pub mod isi {
-    use iroha_data_model::isi::error::{InstructionExecutionError, RepetitionError};
+    use iroha_data_model::{
+        isi::error::{InstructionExecutionError, RepetitionError},
+        IntoKeyValue,
+    };
     use iroha_logger::prelude::*;
 
     use super::*;
@@ -39,7 +42,7 @@ pub mod isi {
             state_transaction: &mut StateTransaction<'_, '_>,
         ) -> Result<(), Error> {
             let account: Account = self.object.build(authority);
-            let account_id = account.id().clone();
+            let (account_id, account_value) = account.clone().into_key_value();
 
             if *account_id.domain() == *iroha_genesis::GENESIS_DOMAIN_ID {
                 return Err(InstructionExecutionError::InvariantViolation(
@@ -58,7 +61,7 @@ pub mod isi {
             state_transaction
                 .world
                 .accounts
-                .insert(account_id, (&account).into());
+                .insert(account_id, account_value);
 
             state_transaction
                 .world

--- a/crates/iroha_core/src/smartcontracts/isi/mod.rs
+++ b/crates/iroha_core/src/smartcontracts/isi/mod.rs
@@ -270,7 +270,8 @@ mod tests {
             .execute(&account_id, &mut state_transaction)?;
         state_transaction.apply();
         state_block.commit();
-        let nft = state.view().world.nft(&nft_id)?;
+        let state_view = state.view();
+        let nft = state_view.world.nft(&nft_id)?;
         let value = nft.content.get(&key).cloned();
         assert_eq!(value, Some(vec![1_u32, 2_u32, 3_u32,].into()));
         Ok(())

--- a/crates/iroha_core/src/smartcontracts/isi/nft.rs
+++ b/crates/iroha_core/src/smartcontracts/isi/nft.rs
@@ -49,7 +49,7 @@ pub mod isi {
                 .domain(&nft_id.domain)
                 .expect("INTERNAL BUG: Can't find domain of NFT to register");
 
-            state_transaction.world.nfts.insert(nft_id, nft.clone());
+            state_transaction.world.nfts.insert(nft_id, (&nft).into());
 
             state_transaction
                 .world
@@ -195,8 +195,8 @@ pub mod query {
             Ok(state_ro
                 .world()
                 .nfts_iter()
-                .filter(move |&nft| filter.applies(nft))
-                .cloned())
+                .filter(move |&nft| filter.applies_to_entry(nft))
+                .map(Into::into))
         }
     }
 }

--- a/crates/iroha_core/src/state.rs
+++ b/crates/iroha_core/src/state.rs
@@ -23,6 +23,7 @@ use iroha_data_model::{
     prelude::*,
     query::error::{FindError, QueryExecutionFail},
     role::RoleId,
+    IntoKeyValue,
 };
 use iroha_logger::prelude::*;
 use iroha_primitives::numeric::Numeric;
@@ -346,7 +347,7 @@ impl World {
             .collect();
         let accounts = accounts
             .into_iter()
-            .map(|account| (account.id().clone(), account.into()))
+            .map(IntoKeyValue::into_key_value)
             .collect();
         let asset_definitions = asset_definitions
             .into_iter()
@@ -354,12 +355,9 @@ impl World {
             .collect();
         let assets = assets
             .into_iter()
-            .map(|asset| (asset.id().clone(), asset.into()))
+            .map(IntoKeyValue::into_key_value)
             .collect();
-        let nfts = nfts
-            .into_iter()
-            .map(|nft| (nft.id().clone(), nft.into()))
-            .collect();
+        let nfts = nfts.into_iter().map(IntoKeyValue::into_key_value).collect();
         Self {
             domains,
             accounts,
@@ -937,7 +935,8 @@ impl WorldTransaction<'_, '_> {
                 &mut self.internal_event_buf,
                 Some(AssetEvent::Created(asset.clone())),
             );
-            self.assets.insert(asset_id.clone(), asset.into());
+            let (asset_id, asset_value) = asset.into_key_value();
+            self.assets.insert(asset_id, asset_value);
         }
         Ok(self
             .assets

--- a/crates/iroha_core/src/tx.rs
+++ b/crates/iroha_core/src/tx.rs
@@ -715,7 +715,7 @@ mod tests {
                     .iter()
                     .map(|(name, num)| Asset::new(asset(name), *num));
 
-                World::with_assets([domain], accounts, [asset_def], assets)
+                World::with_assets([domain], accounts, [asset_def], assets, [])
             };
             let kura = crate::kura::Kura::blank_kura_for_testing();
             let query_handle = crate::query::store::LiveQueryStore::start_test();

--- a/crates/iroha_data_model/src/account.rs
+++ b/crates/iroha_data_model/src/account.rs
@@ -12,8 +12,8 @@ use serde_with::{DeserializeFromStr, SerializeDisplay};
 
 pub use self::model::*;
 use crate::{
-    domain::prelude::*, metadata::Metadata, HasMetadata, Identifiable, ParseError, PublicKey,
-    Registered,
+    domain::prelude::*, metadata::Metadata, HasMetadata, Identifiable, IntoKeyValue, ParseError,
+    PublicKey, Registered,
 };
 
 #[model]
@@ -79,7 +79,6 @@ mod model {
 
     /// Read-only reference to [`Account`].
     /// Used in query filters to avoid copying.
-    #[derive(Copy, Clone)]
     pub struct AccountEntry<'world> {
         /// Identification of the [`Account`].
         pub id: &'world AccountId,
@@ -225,30 +224,24 @@ impl<'world> AccountEntry<'world> {
     pub fn metadata(&self) -> &Metadata {
         self.metadata
     }
-}
 
-impl From<AccountEntry<'_>> for Account {
-    fn from(value: AccountEntry) -> Self {
-        Self {
-            id: value.id.clone(),
-            metadata: value.metadata.clone(),
+    /// Converts to `Account`
+    pub fn to_owned(&self) -> Account {
+        Account {
+            id: self.id.clone(),
+            metadata: self.metadata.clone(),
         }
     }
 }
 
-impl From<&Account> for AccountValue {
-    fn from(account: &Account) -> Self {
-        Self {
-            metadata: account.metadata.clone(),
-        }
-    }
-}
-
-impl From<Account> for AccountValue {
-    fn from(account: Account) -> Self {
-        Self {
-            metadata: account.metadata,
-        }
+impl IntoKeyValue for Account {
+    type Key = AccountId;
+    type Value = AccountValue;
+    fn into_key_value(self) -> (Self::Key, Self::Value) {
+        let value = AccountValue {
+            metadata: self.metadata,
+        };
+        (self.id, value)
     }
 }
 

--- a/crates/iroha_data_model/src/account.rs
+++ b/crates/iroha_data_model/src/account.rs
@@ -77,24 +77,6 @@ mod model {
         pub metadata: Metadata,
     }
 
-    /// Read-only reference to [`Account`].
-    /// Used in query filters to avoid copying.
-    pub struct AccountEntry<'world> {
-        /// Identification of the [`Account`].
-        pub id: &'world AccountId,
-        /// Metadata of this account as a key-value store.
-        pub metadata: &'world Metadata,
-    }
-
-    /// [`Account`] without `id`.
-    /// Needed only for [`World::accounts`] map to reduce memory usage.
-    /// In other places use [`Account`] directly.
-    #[derive(Clone, Deserialize, Serialize)]
-    pub struct AccountValue {
-        /// Metadata of this account as a key-value store.
-        pub metadata: Metadata,
-    }
-
     /// Builder which should be submitted in a transaction to create a new [`Account`]
     #[derive(
         DebugCustom, Display, Clone, IdEqOrdHash, Decode, Encode, Serialize, Deserialize, IntoSchema,
@@ -109,6 +91,24 @@ mod model {
         /// Metadata that should be submitted with the builder
         pub metadata: Metadata,
     }
+}
+
+/// Read-only reference to [`Account`].
+/// Used in query filters to avoid copying.
+pub struct AccountEntry<'world> {
+    /// Identification of the [`Account`].
+    pub id: &'world AccountId,
+    /// Metadata of this account as a key-value store.
+    pub metadata: &'world Metadata,
+}
+
+/// [`Account`] without `id`.
+/// Needed only for [`World::accounts`] map to reduce memory usage.
+/// In other places use [`Account`] directly.
+#[derive(Clone, Deserialize, Serialize)]
+pub struct AccountValue {
+    /// Metadata of this account as a key-value store.
+    pub metadata: Metadata,
 }
 
 impl AccountId {

--- a/crates/iroha_data_model/src/asset.rs
+++ b/crates/iroha_data_model/src/asset.rs
@@ -17,7 +17,7 @@ use serde_with::{DeserializeFromStr, SerializeDisplay};
 pub use self::model::*;
 use crate::{
     account::prelude::*, domain::prelude::*, ipfs::IpfsPath, metadata::Metadata, HasMetadata,
-    Identifiable, Name, ParseError, Registered,
+    Identifiable, IntoKeyValue, Name, ParseError, Registered,
 };
 
 /// [`AssetTotalQuantityMap`] provides an API to work with collection of key([`AssetDefinitionId`])-value([`Numeric`])
@@ -156,7 +156,6 @@ mod model {
 
     /// Read-only reference to [`Asset`].
     /// Used in query filters to avoid copying.
-    #[derive(Copy, Clone)]
     pub struct AssetEntry<'world> {
         /// Component Identification.
         pub id: &'world AssetId,
@@ -404,20 +403,22 @@ impl<'world> AssetEntry<'world> {
     pub fn value(&self) -> &Numeric {
         self.value
     }
-}
 
-impl From<AssetEntry<'_>> for Asset {
-    fn from(value: AssetEntry) -> Self {
-        Self {
-            id: value.id.clone(),
-            value: *value.value,
+    /// Converts to `Asset`
+    pub fn to_owned(&self) -> Asset {
+        Asset {
+            id: self.id.clone(),
+            value: *self.value,
         }
     }
 }
 
-impl From<Asset> for AssetValue {
-    fn from(asset: Asset) -> Self {
-        Self { value: asset.value }
+impl IntoKeyValue for Asset {
+    type Key = AssetId;
+    type Value = AssetValue;
+    fn into_key_value(self) -> (Self::Key, Self::Value) {
+        let value = AssetValue { value: self.value };
+        (self.id, value)
     }
 }
 

--- a/crates/iroha_data_model/src/asset.rs
+++ b/crates/iroha_data_model/src/asset.rs
@@ -154,24 +154,6 @@ mod model {
         pub value: Numeric,
     }
 
-    /// Read-only reference to [`Asset`].
-    /// Used in query filters to avoid copying.
-    pub struct AssetEntry<'world> {
-        /// Component Identification.
-        pub id: &'world AssetId,
-        /// Asset's Quantity.
-        pub value: &'world Numeric,
-    }
-
-    /// [`Asset`] without `id` field.
-    /// Needed only for [`World::assets`] map to reduce memory usage.
-    /// In other places use [`Asset`] directly.
-    #[derive(Clone, Deserialize, Serialize)]
-    pub struct AssetValue {
-        /// Asset's Quantity.
-        pub value: Numeric,
-    }
-
     /// Builder which can be submitted in a transaction to create a new [`AssetDefinition`]
     #[derive(
         Debug, Display, Clone, IdEqOrdHash, Decode, Encode, Deserialize, Serialize, IntoSchema,
@@ -224,6 +206,24 @@ mod model {
         Not,
         // TODO: Support more variants using bit-compacted tag, and `u32` mintability tokens.
     }
+}
+
+/// Read-only reference to [`Asset`].
+/// Used in query filters to avoid copying.
+pub struct AssetEntry<'world> {
+    /// Component Identification.
+    pub id: &'world AssetId,
+    /// Asset's Quantity.
+    pub value: &'world Numeric,
+}
+
+/// [`Asset`] without `id` field.
+/// Needed only for [`World::assets`] map to reduce memory usage.
+/// In other places use [`Asset`] directly.
+#[derive(Copy, Clone, Deserialize, Serialize)]
+pub struct AssetValue {
+    /// Asset's Quantity.
+    pub value: Numeric,
 }
 
 impl AssetDefinition {

--- a/crates/iroha_data_model/src/lib.rs
+++ b/crates/iroha_data_model/src/lib.rs
@@ -447,6 +447,17 @@ pub trait Registered: Identifiable {
     type With;
 }
 
+/// Auxiliary trait for objects which are stored in parts in `World`.
+/// E.g. `Account` is stored as `AccountId`+`AccountEntry` in `World::accounts`
+pub trait IntoKeyValue {
+    /// Object ID
+    type Key;
+    /// Object data
+    type Value;
+    /// Method to split object into parts
+    fn into_key_value(self) -> (Self::Key, Self::Value);
+}
+
 mod ffi {
     //! Definitions and implementations of FFI related functionalities
 

--- a/crates/iroha_data_model/src/nft.rs
+++ b/crates/iroha_data_model/src/nft.rs
@@ -5,6 +5,7 @@ use alloc::{format, string::String, vec::Vec};
 use core::str::FromStr;
 
 use iroha_data_model_derive::model;
+use serde::{Deserialize, Serialize};
 
 pub use self::model::*;
 use crate::{metadata::Metadata, prelude::AccountId, IntoKeyValue, ParseError, Registered};
@@ -16,7 +17,6 @@ mod model {
     use iroha_data_model_derive::IdEqOrdHash;
     use iroha_schema::IntoSchema;
     use parity_scale_codec::{Decode, Encode};
-    use serde::{Deserialize, Serialize};
     use serde_with::{DeserializeFromStr, SerializeDisplay};
 
     use super::*;
@@ -86,28 +86,6 @@ mod model {
         pub owned_by: AccountId,
     }
 
-    /// Read-only reference to [`Nft`].
-    /// Used in query filters to avoid copying.
-    pub struct NftEntry<'world> {
-        /// An Identification of the [`Nft`].
-        pub id: &'world NftId,
-        /// Content of the [`Nft`], as a key-value store.
-        pub content: &'world Metadata,
-        /// The account that owns this NFT.
-        pub owned_by: &'world AccountId,
-    }
-
-    /// [`Nft`] without `id` field.
-    /// Needed only for [`World::nfts`] map to reduce memory usage.
-    /// In other places use [`Nft`] directly.
-    #[derive(Clone, Deserialize, Serialize)]
-    pub struct NftValue {
-        /// Content of the [`Nft`], as a key-value store.
-        pub content: Metadata,
-        /// The account that owns this NFT.
-        pub owned_by: AccountId,
-    }
-
     /// Builder which can be submitted in a transaction to create a new [`Nft`]
     #[derive(
         Debug, Display, Clone, IdEqOrdHash, Decode, Encode, Deserialize, Serialize, IntoSchema,
@@ -121,6 +99,28 @@ mod model {
         /// Content of the [`Nft`], as a key-value store.
         pub content: Metadata,
     }
+}
+
+/// Read-only reference to [`Nft`].
+/// Used in query filters to avoid copying.
+pub struct NftEntry<'world> {
+    /// An Identification of the [`Nft`].
+    pub id: &'world NftId,
+    /// Content of the [`Nft`], as a key-value store.
+    pub content: &'world Metadata,
+    /// The account that owns this NFT.
+    pub owned_by: &'world AccountId,
+}
+
+/// [`Nft`] without `id` field.
+/// Needed only for [`World::nfts`] map to reduce memory usage.
+/// In other places use [`Nft`] directly.
+#[derive(Clone, Deserialize, Serialize)]
+pub struct NftValue {
+    /// Content of the [`Nft`], as a key-value store.
+    pub content: Metadata,
+    /// The account that owns this NFT.
+    pub owned_by: AccountId,
 }
 
 impl Nft {

--- a/crates/iroha_data_model/src/query/dsl/compound_predicate.rs
+++ b/crates/iroha_data_model/src/query/dsl/compound_predicate.rs
@@ -10,7 +10,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
     account::{Account, AccountEntry},
     asset::{Asset, AssetEntry},
-    prelude::{AccountProjection, AssetProjection},
+    nft::{Nft, NftEntry},
+    prelude::{AccountProjection, AssetProjection, NftProjection},
     query::dsl::{BaseProjector, EvaluatePredicate, HasProjection, HasPrototype, PredicateMarker},
 };
 
@@ -92,6 +93,10 @@ impl CompoundPredicate<Asset> {
     impl_applies!(applies_to_entry AssetEntry);
 }
 
+impl CompoundPredicate<Nft> {
+    impl_applies!(applies_to_entry NftEntry);
+}
+
 impl AccountProjection<PredicateMarker> {
     fn applies_to_entry(&self, input: AccountEntry) -> bool {
         use AccountProjection::*;
@@ -110,6 +115,18 @@ impl AssetProjection<PredicateMarker> {
             Atom(atom) => match *atom {},
             Id(field) => field.applies(input.id),
             Value(field) => field.applies(input.value),
+        }
+    }
+}
+
+impl NftProjection<PredicateMarker> {
+    fn applies_to_entry(&self, input: NftEntry) -> bool {
+        use NftProjection::*;
+        match self {
+            Atom(atom) => match *atom {},
+            Id(field) => field.applies(input.id),
+            Metadata(field) => field.applies(input.content),
+            AccountId(field) => field.applies(input.owned_by),
         }
     }
 }

--- a/crates/iroha_data_model/src/query/dsl/compound_predicate.rs
+++ b/crates/iroha_data_model/src/query/dsl/compound_predicate.rs
@@ -86,19 +86,19 @@ where
 // Alternatively we can use `*Entry` classes directly in `type_descriptions!()`,
 // but because of lifetimes it will be very complicated.
 impl CompoundPredicate<Account> {
-    impl_applies!(applies_to_entry AccountEntry);
+    impl_applies!(applies_to_entry & AccountEntry);
 }
 
 impl CompoundPredicate<Asset> {
-    impl_applies!(applies_to_entry AssetEntry);
+    impl_applies!(applies_to_entry & AssetEntry);
 }
 
 impl CompoundPredicate<Nft> {
-    impl_applies!(applies_to_entry NftEntry);
+    impl_applies!(applies_to_entry & NftEntry);
 }
 
 impl AccountProjection<PredicateMarker> {
-    fn applies_to_entry(&self, input: AccountEntry) -> bool {
+    fn applies_to_entry(&self, input: &AccountEntry) -> bool {
         use AccountProjection::*;
         match self {
             Atom(atom) => match *atom {},
@@ -109,7 +109,7 @@ impl AccountProjection<PredicateMarker> {
 }
 
 impl AssetProjection<PredicateMarker> {
-    fn applies_to_entry(&self, input: AssetEntry) -> bool {
+    fn applies_to_entry(&self, input: &AssetEntry) -> bool {
         use AssetProjection::*;
         match self {
             Atom(atom) => match *atom {},
@@ -120,7 +120,7 @@ impl AssetProjection<PredicateMarker> {
 }
 
 impl NftProjection<PredicateMarker> {
-    fn applies_to_entry(&self, input: NftEntry) -> bool {
+    fn applies_to_entry(&self, input: &NftEntry) -> bool {
         use NftProjection::*;
         match self {
             Atom(atom) => match *atom {},

--- a/crates/iroha_data_model/src/query/dsl/compound_predicate.rs
+++ b/crates/iroha_data_model/src/query/dsl/compound_predicate.rs
@@ -9,7 +9,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     account::{Account, AccountEntry},
-    prelude::AccountProjection,
+    asset::{Asset, AssetEntry},
+    prelude::{AccountProjection, AssetProjection},
     query::dsl::{BaseProjector, EvaluatePredicate, HasProjection, HasPrototype, PredicateMarker},
 };
 
@@ -87,6 +88,10 @@ impl CompoundPredicate<Account> {
     impl_applies!(applies_to_entry AccountEntry);
 }
 
+impl CompoundPredicate<Asset> {
+    impl_applies!(applies_to_entry AssetEntry);
+}
+
 impl AccountProjection<PredicateMarker> {
     fn applies_to_entry(&self, input: AccountEntry) -> bool {
         use AccountProjection::*;
@@ -94,6 +99,17 @@ impl AccountProjection<PredicateMarker> {
             Atom(atom) => match *atom {},
             Id(field) => field.applies(input.id),
             Metadata(field) => field.applies(input.metadata),
+        }
+    }
+}
+
+impl AssetProjection<PredicateMarker> {
+    fn applies_to_entry(&self, input: AssetEntry) -> bool {
+        use AssetProjection::*;
+        match self {
+            Atom(atom) => match *atom {},
+            Id(field) => field.applies(input.id),
+            Value(field) => field.applies(input.value),
         }
     }
 }


### PR DESCRIPTION
## Context

Closes #5034
Related #5280

### Solution

This PR changes `World::accounts`, `World::assets` and `World::nfts` maps. I choose only these maps (and not e.g. `World::domains`) because it is most likely that they will have a lot of entries and thus it is worth optimizing their memory usage. See https://github.com/hyperledger-iroha/iroha/issues/5034#issuecomment-2940939359 for overview of all maps in `World`.

---

Comparison of memory usage:
* `Account` struct in `World`:
    * master: 485 bytes per account
    * pr: 338 bytes per account
* `Asset` struct in `World`:
    * master: 672 bytes per account
    * pr: 423 bytes per account
* `Nft` struct in `World`:
    * master: 586 bytes per account
    * pr: 454 bytes per account

I used this code to check memory usage:

<details>

```rust
#![allow(warnings, unused)]

//! .

use iroha_core::{prelude::*, smartcontracts::Registrable, Peers};
use iroha_crypto::PublicKey;
use iroha_data_model::{permission::Permissions, prelude::*};
use mv::{cell::Cell, storage::Storage};
use util::*;

const N: usize = 1 << 20;

fn main() {
    // measure_accounts_in_vec();
    measure_accounts_in_world();
    // measure_assets_in_world();
    // measure_nfts_in_world();
}

fn measure_accounts_in_vec() {
    let (genesis_domain, _genesis_account) = genesis_domain_and_account();

    let v = (0..N)
        .map(|_| gen_account_in(&genesis_domain.id).0)
        .map(|id| Account::new(id).into_account())
        .collect::<Vec<_>>();
    eprintln!("Done");
    std::thread::sleep(std::time::Duration::from_secs(86400));
    dbg!(v.len());
}

fn measure_accounts_in_world() {
    let (genesis_domain, _genesis_account) = genesis_domain_and_account();

    let accounts = (0..N)
        .map(|_| gen_account_in(&genesis_domain.id).0)
        .map(|id| Account::new(id).into_account());
    let world = World::with_assets([], accounts, [], [], []);
    eprintln!("Done");
    std::thread::sleep(std::time::Duration::from_secs(86400));
    dbg!(world.view().accounts_iter().count());
}

fn measure_assets_in_world() {
    let (genesis_domain, genesis_account) = genesis_domain_and_account();
    let asset_definition_id: AssetDefinitionId =
        format!("mandatory#{genesis_domain}").parse().unwrap();

    let assets = (0..N).map(|_| gen_asset(asset_definition_id.clone()));
    let world = World::with_assets([], [], [], assets, []);
    eprintln!("Done");
    std::thread::sleep(std::time::Duration::from_secs(86400));
    dbg!(world.view().assets_iter().count());
}

fn measure_nfts_in_world() {
    let (genesis_domain, genesis_account) = genesis_domain_and_account();
    let owner = gen_account_in(&genesis_domain.id).0;

    let nfts = (0..N).map(|_| gen_nft(&owner));
    let world = World::with_assets([], [], [], [], nfts);
    eprintln!("Done");
    std::thread::sleep(std::time::Duration::from_secs(86400));
    dbg!(world.view().nfts_iter().count());
}

fn print_world_memory_usage() {
    macro_rules! gen {
        ($($p:ident,)+) => {
            $(
                println!(
                    "{}Id:  {} bytes\n{}:   {} bytes",
                    stringify!($p),
                    size_of::<<$p as Identifiable>::Id>(),
                    stringify!($p),
                    size_of::<$p>()
                );
            )+
        };
    }
    gen!(Domain, Account, AssetDefinition, Asset, Nft, Role,);
}

mod util {
    use std::fmt::Display;

    use iroha_core::smartcontracts::Registrable;
    use iroha_crypto::KeyPair;
    use iroha_data_model::prelude::*;

    pub fn genesis_domain_and_account() -> (Domain, Account) {
        let genesis_public_key: PublicKey =
            "ed012003415E0E516BE83870CE5A2165605E8719216B5ECCCE4AEDFB0B2B77862B3798"
                .parse()
                .unwrap();
        let genesis_account_id =
            AccountId::new(iroha_genesis::GENESIS_DOMAIN_ID.clone(), genesis_public_key);
        let genesis_account = Account::new(genesis_account_id.clone()).build(&genesis_account_id);
        let genesis_domain =
            Domain::new(iroha_genesis::GENESIS_DOMAIN_ID.clone()).build(&genesis_account.id);
        (genesis_domain, genesis_account)
    }

    pub fn gen_account_in(domain: impl Display) -> (AccountId, KeyPair) {
        let key_pair = KeyPair::random();
        let account_id = format!("{}@{}", key_pair.public_key(), domain)
            .parse()
            .unwrap();
        (account_id, key_pair)
    }

    pub fn gen_asset(asset_definition: AssetDefinitionId) -> Asset {
        let account_id = gen_account_in(&asset_definition.domain).0;
        let asset_id = AssetId::new(asset_definition, account_id);
        let value: u64 = rand::random();
        Asset::new(asset_id, value)
    }

    pub fn gen_nft(owner: &AccountId) -> Nft {
        let value: u64 = rand::random();
        let nft_id = format!("n{}${}", value, &owner.domain).parse().unwrap();
        Nft::new(nft_id, Metadata::default()).build(owner)
    }
}
```

</details>

---

### Review notes

It is not possible to use structs with lifetimes directly in filters (e.g. `type_descriptions!` macro), and I don't want to introduce major changes by this PR. So instead I added a bridge method `applies_to_entry` which e.g. accepts `AccountEntry` class, but under the hood uses impls for `Account` (from `type_descriptions!` macro).

### Checklist

- [ ] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.
- [ ] All CI checks pass.
