### PR TITLE
feat(merkle): implement inclusion proof generation and verification

### DIFF
--- a/crates/iroha_core/src/block.rs
+++ b/crates/iroha_core/src/block.rs
@@ -199,7 +199,7 @@ mod pending {
                     .map(AsRef::as_ref)
                     .map(SignedTransaction::hash)
                     .collect::<MerkleTree<_>>()
-                    .hash(),
+                    .root(),
                 creation_time_ms: creation_time
                     .as_millis()
                     .try_into()

--- a/crates/iroha_crypto/src/lib.rs
+++ b/crates/iroha_crypto/src/lib.rs
@@ -38,7 +38,7 @@ pub use hash::*;
 use iroha_macro::ffi_impl_opaque;
 use iroha_primitives::const_vec::{ConstVec, ToConstVec};
 use iroha_schema::{Declaration, IntoSchema, MetaMap, Metadata, NamedFieldsMeta, TypeId};
-pub use merkle::MerkleTree;
+pub use merkle::{MerkleProof, MerkleTree};
 #[cfg(not(feature = "ffi_import"))]
 use parity_scale_codec::{Decode, Encode};
 use serde::{Deserialize, Serialize, Serializer};

--- a/crates/iroha_crypto/src/merkle.rs
+++ b/crates/iroha_crypto/src/merkle.rs
@@ -1,80 +1,111 @@
-//! Merkle tree implementation.
+//! Merkle tree implementation for light clients to efficiently verify transaction inclusion proofs.
+
 #[cfg(not(feature = "std"))]
 use alloc::{collections::VecDeque, format, string::String, vec, vec::Vec};
 #[cfg(feature = "std")]
 use std::collections::VecDeque;
 
+use derive_more::Display;
 use iroha_schema::{IntoSchema, TypeId};
 use parity_scale_codec::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
 use crate::{Hash, HashOf};
 
-/// [Merkle Tree](https://en.wikipedia.org/wiki/Merkle_tree) used to validate `T`
-#[derive(Debug, TypeId, Decode, Encode, Deserialize, Serialize)]
+/// Array representation of [Merkle tree](https://en.wikipedia.org/wiki/Merkle_tree)
+/// for verifying elements of type `T`.
+#[derive(
+    Debug,
+    Display,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Decode,
+    Encode,
+    Deserialize,
+    Serialize,
+    TypeId,
+)]
 #[repr(transparent)]
 pub struct MerkleTree<T>(Vec<Option<HashOf<T>>>);
 
-/// Iterator over leaves of [`MerkleTree`]
-pub struct LeafHashIterator<T> {
-    tree: MerkleTree<T>,
-    next: usize,
+/// Iterator over the leaf hashes of a [`MerkleTree`], yielding each leaf in left-to-right order.
+pub struct LeafHashIterator<'a, T> {
+    tree: &'a MerkleTree<T>,
+    index: usize,
+    index_back: usize,
 }
 
-/// Complete binary trees.
-trait CompleteBTree<T> {
+/// A complete binary tree supporting indexed access to nodes in breadth-first order.
+trait CompleteBinaryTree {
+    /// The type of value stored in each node.
+    type NodeValue;
+
+    /// Returns the total number of nodes in the tree.
     fn len(&self) -> usize;
 
-    fn get(&self, idx: usize) -> Option<&T>;
+    /// Returns a reference to the node value at `index`, in breadth-first order from the root.
+    fn get(&self, index: usize) -> Option<&Self::NodeValue>;
 
-    /// Get the reference of the `idx`-th leaf node.
-    fn get_leaf(&self, idx: usize) -> Option<&T> {
-        let offset = 2_usize.pow(self.height()) - 1;
-        offset.checked_add(idx).and_then(|i| self.get(i))
+    /// Returns a reference to the leaf node value at `index`, in left-to-right order among leaves.
+    fn get_leaf(&self, index: usize) -> Option<&Self::NodeValue> {
+        let offset = (1 << self.height()) - 1_usize;
+        offset.checked_add(index).and_then(|i| self.get(i))
     }
 
+    /// Returns the height of the tree, defined as the number of edges from root to any leaf.
     fn height(&self) -> u32 {
         (usize::BITS - self.len().leading_zeros()).saturating_sub(1)
     }
 
-    fn max_nodes_at_height(&self) -> usize {
-        2_usize.pow(self.height() + 1) - 1
+    /// Returns the maximum number of nodes the tree can contain without increasing its height.
+    fn capacity(&self) -> usize {
+        (1 << (self.height() + 1)) - 1
     }
 
-    fn parent(&self, idx: usize) -> Option<usize> {
-        if 0 == idx {
+    /// Returns the index of the parent of the node at `index`, or `None` if the node is the root.
+    fn parent_index(&self, index: usize) -> Option<usize> {
+        if 0 == index {
             return None;
         }
-        let idx = (idx - 1).div_euclid(2);
-        (idx < self.len()).then_some(idx)
+        let index = (index - 1) >> 1;
+        (index < self.len()).then_some(index)
     }
 
-    fn l_child(&self, idx: usize) -> Option<usize> {
-        let idx = 2 * idx + 1;
-        (idx < self.len()).then_some(idx)
+    /// Returns the index of the left child of the node at `index`, if it exists.
+    fn l_child_index(&self, index: usize) -> Option<usize> {
+        let index = (index << 1) + 1;
+        (index < self.len()).then_some(index)
     }
 
-    fn r_child(&self, idx: usize) -> Option<usize> {
-        let idx = 2 * idx + 2;
-        (idx < self.len()).then_some(idx)
+    /// Returns the index of the right child of the node at `index`, if it exists.
+    fn r_child_index(&self, index: usize) -> Option<usize> {
+        let index = (index << 1) + 2;
+        (index < self.len()).then_some(index)
     }
 
-    fn get_l_child(&self, idx: usize) -> Option<&T> {
-        self.l_child(idx).and_then(|i| self.get(i))
+    /// Returns a reference to the left child of the node at `index`, if it exists.
+    fn get_l_child(&self, index: usize) -> Option<&Self::NodeValue> {
+        self.l_child_index(index).and_then(|i| self.get(i))
     }
 
-    fn get_r_child(&self, idx: usize) -> Option<&T> {
-        self.r_child(idx).and_then(|i| self.get(i))
+    /// Returns a reference to the right child of the node at `index`, if it exists.
+    fn get_r_child(&self, index: usize) -> Option<&Self::NodeValue> {
+        self.r_child_index(index).and_then(|i| self.get(i))
     }
 }
 
-impl<T> CompleteBTree<Option<HashOf<T>>> for MerkleTree<T> {
+impl<T> CompleteBinaryTree for MerkleTree<T> {
+    type NodeValue = Option<HashOf<T>>;
+
     fn len(&self) -> usize {
         self.0.len()
     }
 
-    fn get(&self, idx: usize) -> Option<&Option<HashOf<T>>> {
-        self.0.get(idx)
+    fn get(&self, index: usize) -> Option<&Self::NodeValue> {
+        self.0.get(index)
     }
 }
 
@@ -83,15 +114,15 @@ impl<T> FromIterator<HashOf<T>> for MerkleTree<T> {
         let mut queue = iter.into_iter().map(Some).collect::<VecDeque<_>>();
 
         let height = usize::BITS - queue.len().saturating_sub(1).leading_zeros();
-        let n_complement = 2_usize.pow(height) - queue.len();
+        let n_complement = (1 << height) - queue.len();
         for _ in 0..n_complement {
             queue.push_back(None);
         }
 
-        let mut tree = Vec::with_capacity(2_usize.pow(height + 1));
+        let mut tree = Vec::with_capacity(1 << (height + 1));
         while let Some(r_node) = queue.pop_back() {
             if let Some(l_node) = queue.pop_back() {
-                queue.push_front(Self::nodes_pair_hash(l_node.as_ref(), r_node.as_ref()));
+                queue.push_front(Self::pair_hash(l_node.as_ref(), r_node.as_ref()));
                 tree.push(r_node);
                 tree.push(l_node);
             } else {
@@ -106,15 +137,6 @@ impl<T> FromIterator<HashOf<T>> for MerkleTree<T> {
         }
 
         Self(tree)
-    }
-}
-
-impl<T> IntoIterator for MerkleTree<T> {
-    type Item = HashOf<T>;
-    type IntoIter = LeafHashIterator<T>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        LeafHashIterator::new(self)
     }
 }
 
@@ -136,39 +158,34 @@ impl<T: IntoSchema> IntoSchema for MerkleTree<T> {
 
 impl<T> Default for MerkleTree<T> {
     fn default() -> Self {
-        Self::new()
+        Self(Vec::new())
+    }
+}
+
+impl<'a, T> MerkleTree<T> {
+    /// Leaf hashes of this Merkle tree.
+    pub fn leaves(&'a self) -> LeafHashIterator<'a, T> {
+        LeafHashIterator::new(self)
     }
 }
 
 impl<T> MerkleTree<T> {
-    /// Construct [`MerkleTree`].
-    pub fn new() -> Self {
-        Self(Vec::new())
-    }
-
-    /// Get the hash of [`MerkleTree`] as the hash of its root node.
-    pub fn hash(&self) -> Option<HashOf<Self>> {
+    /// Returns the hash of the root node, or `None` if the tree has no nodes.
+    pub fn root(&self) -> Option<HashOf<Self>> {
         self.get(0).and_then(|node| node.map(HashOf::transmute))
     }
 
-    /// Get the `idx`-th leaf hash.
-    pub fn get_leaf_hash(&self, idx: usize) -> Option<HashOf<T>> {
-        if let Some(node) = self.get_leaf(idx) {
-            return *node;
-        }
-        None
-    }
-
-    /// Add `hash` to the tail of the tree.
+    /// Appends a leaf hash to the tree and updates all affected parent nodes.
     pub fn add(&mut self, hash: HashOf<T>) {
         // If the tree is perfect, increment its height to double the leaf capacity.
-        if self.max_nodes_at_height() == self.len() {
+        if self.capacity() == self.len() {
+            let height = self.height();
             let mut new_array = vec![None];
-            let mut array = self.0.clone();
-            for depth in 0..self.height() {
-                let capacity_at_depth = 2_usize.pow(depth);
+            let mut array = core::mem::take(&mut self.0);
+            for depth in 0..height {
+                let capacity_at_depth = 1 << depth;
                 let tail = array.split_off(capacity_at_depth);
-                array.extend(core::iter::once(&None).cycle().take(capacity_at_depth));
+                array.extend(vec![None; capacity_at_depth]);
                 new_array.append(&mut array);
                 array = tail;
             }
@@ -177,38 +194,31 @@ impl<T> MerkleTree<T> {
         }
 
         self.0.push(Some(hash));
-        self.update(self.len().saturating_sub(1));
+        self.update(self.len() - 1);
     }
 
-    fn update(&mut self, idx: usize) {
-        let mut node = match self.get(idx) {
-            Some(node) => *node,
-            None => return,
-        };
-        let mut idx = idx;
-        while let Some(parent_idx) = self.parent(idx) {
-            let (l_node, r_node_opt) = match idx % 2 {
-                0 => (
-                    self.get_l_child(parent_idx).expect("Infallible"),
-                    Some(&node),
-                ),
-                1 => (&node, self.get_r_child(parent_idx)),
+    /// Recomputes hashes along the path from the leaf at `index` up to the root.
+    fn update(&mut self, mut index: usize) {
+        let Some(node) = self.get(index) else { return };
+        let mut node = *node;
+        while let Some(parent_index) = self.parent_index(index) {
+            let (l_node, r_node_opt) = match index % 2 {
+                0 => (self.get_l_child(parent_index).unwrap(), Some(&node)),
+                1 => (&node, self.get_r_child(parent_index)),
                 _ => unreachable!(),
             };
             let parent_node = r_node_opt.map_or(*l_node, |r_node| {
-                Self::nodes_pair_hash(l_node.as_ref(), r_node.as_ref())
+                Self::pair_hash(l_node.as_ref(), r_node.as_ref())
             });
-            let parent_mut = self.0.get_mut(parent_idx).expect("Infallible");
+            let parent_mut = self.0.get_mut(parent_index).unwrap();
             *parent_mut = parent_node;
-            idx = parent_idx;
+            index = parent_index;
             node = parent_node;
         }
     }
 
-    fn nodes_pair_hash(
-        l_node: Option<&HashOf<T>>,
-        r_node: Option<&HashOf<T>>,
-    ) -> Option<HashOf<T>> {
+    /// Combines two child hashes into a parent hash.
+    fn pair_hash(l_node: Option<&HashOf<T>>, r_node: Option<&HashOf<T>>) -> Option<HashOf<T>> {
         let (l_hash, r_hash) = match (l_node, r_node) {
             (Some(l_hash), Some(r_hash)) => (l_hash, r_hash),
             (Some(l_hash), None) => return Some(*l_hash),
@@ -225,25 +235,56 @@ impl<T> MerkleTree<T> {
     }
 }
 
-impl<T> Iterator for LeafHashIterator<T> {
+impl<T> Iterator for LeafHashIterator<'_, T> {
     type Item = HashOf<T>;
 
-    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        let opt = match self.tree.get(self.next) {
-            Some(node) => *node,
-            None => return None,
-        };
-        self.next += 1;
-        opt
+        if self.index_back <= self.index {
+            return None;
+        }
+        let leaf = self
+            .tree
+            .get_leaf(self.index)
+            .and_then(|opt| opt.as_ref().copied())
+            .unwrap();
+        // Increment the front index eagerly.
+        self.index += 1;
+        Some(leaf)
     }
 }
 
-impl<T> LeafHashIterator<T> {
-    #[inline]
-    fn new(tree: MerkleTree<T>) -> Self {
-        let next = 2_usize.pow(tree.height()) - 1;
-        Self { tree, next }
+impl<T> DoubleEndedIterator for LeafHashIterator<'_, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.index_back <= self.index {
+            return None;
+        }
+        // Decrement the back index lazily.
+        self.index_back -= 1;
+        let leaf = self
+            .tree
+            .get_leaf(self.index_back)
+            .and_then(|opt| opt.as_ref().copied())
+            .unwrap();
+        Some(leaf)
+    }
+}
+
+impl<T> ExactSizeIterator for LeafHashIterator<'_, T> {
+    fn len(&self) -> usize {
+        self.index_back - self.index
+    }
+}
+
+impl<'a, T> LeafHashIterator<'a, T> {
+    fn new(tree: &'a MerkleTree<T>) -> Self {
+        let last_capacity = (1 << tree.height()) - 1;
+        let n_leaves = tree.len() - last_capacity;
+
+        Self {
+            tree,
+            index: 0,
+            index_back: n_leaves,
+        }
     }
 }
 
@@ -282,34 +323,36 @@ mod tests {
 
     #[test]
     fn iteration() {
-        const N_LEAVES: u8 = 5;
+        let hashes = test_hashes(5);
+        let tree: MerkleTree<_> = hashes.clone().into_iter().collect();
+        let leaves: Vec<_> = tree.leaves().collect();
+        assert_eq!(hashes, leaves);
 
-        let hashes = test_hashes(N_LEAVES);
-        let tree = hashes.clone().into_iter().collect::<MerkleTree<_>>();
-
-        for i in 0..N_LEAVES as usize * 2 {
-            assert_eq!(tree.get_leaf_hash(i).as_ref(), hashes.get(i));
-        }
-        for (testee_hash, tester_hash) in tree.into_iter().zip(hashes) {
-            assert_eq!(testee_hash, tester_hash);
-        }
+        let mut leaves_iter = tree.leaves();
+        assert_eq!(leaves_iter.len(), 5);
+        assert_eq!(leaves_iter.next(), Some(hashes[0]));
+        assert_eq!(leaves_iter.next_back(), Some(hashes[4]));
+        assert_eq!(leaves_iter.len(), 3);
+        assert_eq!(leaves_iter.next(), Some(hashes[1]));
+        assert_eq!(leaves_iter.next_back(), Some(hashes[3]));
+        assert_eq!(leaves_iter.next(), Some(hashes[2]));
+        assert_eq!(leaves_iter.len(), 0);
+        assert_eq!(leaves_iter.next_back(), None);
+        assert_eq!(leaves_iter.next(), None);
+        assert_eq!(leaves_iter.len(), 0);
     }
 
     #[test]
     fn reproduction() {
-        const N_LEAVES: u8 = 5;
+        let hashes = test_hashes(5);
+        let tree: MerkleTree<_> = hashes.clone().into_iter().collect();
 
-        let hashes = test_hashes(N_LEAVES);
-        let tree = hashes.clone().into_iter().collect::<MerkleTree<_>>();
-
-        let mut tree_reproduced = MerkleTree::new();
-        for leaf_hash in hashes {
-            tree_reproduced.add(leaf_hash);
+        let mut tree_reproduced = MerkleTree::default();
+        for hash in hashes {
+            tree_reproduced.add(hash);
         }
 
-        assert_eq!(tree_reproduced.hash(), tree.hash());
-        for (testee_leaf, tester_leaf) in tree_reproduced.into_iter().zip(tree.into_iter()) {
-            assert_eq!(testee_leaf, tester_leaf);
-        }
+        assert_eq!(tree_reproduced.root(), tree.root());
+        assert_eq!(tree_reproduced, tree);
     }
 }

--- a/crates/iroha_crypto/src/merkle.rs
+++ b/crates/iroha_crypto/src/merkle.rs
@@ -424,12 +424,12 @@ mod tests {
 
         let mut leaves_iter = tree.leaves();
         assert_eq!(leaves_iter.len(), 5);
-        assert_eq!(leaves_iter.next(), Some(hashes[0]));
-        assert_eq!(leaves_iter.next_back(), Some(hashes[4]));
+        assert_eq!(leaves_iter.next(), Some(leaves[0]));
+        assert_eq!(leaves_iter.next_back(), Some(leaves[4]));
         assert_eq!(leaves_iter.len(), 3);
-        assert_eq!(leaves_iter.next(), Some(hashes[1]));
-        assert_eq!(leaves_iter.next_back(), Some(hashes[3]));
-        assert_eq!(leaves_iter.next(), Some(hashes[2]));
+        assert_eq!(leaves_iter.next(), Some(leaves[1]));
+        assert_eq!(leaves_iter.next_back(), Some(leaves[3]));
+        assert_eq!(leaves_iter.next(), Some(leaves[2]));
         assert_eq!(leaves_iter.len(), 0);
         assert_eq!(leaves_iter.next_back(), None);
         assert_eq!(leaves_iter.next(), None);
@@ -438,12 +438,12 @@ mod tests {
 
     #[test]
     fn grows_incrementally_and_matches_prebuilt_tree() {
-        let hashes = test_hashes(5);
-        let tree: MerkleTree<_> = hashes.clone().into_iter().collect();
+        let leaves = test_hashes(5);
+        let tree: MerkleTree<_> = leaves.clone().into_iter().collect();
 
         let mut growing_tree = MerkleTree::default();
-        for hash in hashes {
-            growing_tree.add(hash);
+        for leaf in leaves {
+            growing_tree.add(leaf);
         }
 
         assert_eq!(growing_tree.root(), tree.root());

--- a/crates/iroha_data_model/src/block.rs
+++ b/crates/iroha_data_model/src/block.rs
@@ -333,7 +333,7 @@ impl SignedBlock {
             .iter()
             .map(SignedTransaction::hash)
             .collect::<MerkleTree<_>>()
-            .hash()
+            .root()
             .expect("Genesis block must have transactions");
         let creation_time_ms = Self::get_genesis_block_creation_time(&transactions);
         let header = BlockHeader {
@@ -432,7 +432,7 @@ mod candidate {
                 .iter()
                 .map(SignedTransaction::hash)
                 .collect::<MerkleTree<_>>()
-                .hash();
+                .root();
 
             if expected_txs_hash != actual_txs_hash {
                 return Err("Transactions' hash incorrect");


### PR DESCRIPTION
> I've split out the cryptographic part of the trigger execution logs (from #4968) into a separate PR: #5467

## Summary

This PR introduces Merkle proof generation and verification to support inclusion checking, as a prerequisite for #4968 (and possibly #4637). It also includes a fix to the construction of the Merkle tree to ensure correct transaction indexing.

## Changes

### Features

* Added `MerkleProof<T>` struct that includes:
  * `leaf_index`: the position of the leaf in the tree
  * `sibling_hashes`: the list of sibling hashes from the leaf up to the root (excluding the root itself)
* Implemented `MerkleTree::get_proof(leaf_index)` to generate an inclusion proof
* Implemented `MerkleProof::verify(root, max_height)` to verify the proof against a given root

### Fixes

* Fixed the binary operation used to compute parent hashes from child hashes: it was previously commutative (addition), but has been corrected to a non-commutative (ordered) operation. The previous implementation could not preserve transaction index ordering guarantees.

## Notes

* `max_height` is passed explicitly to `verify()` to avoid trusting unbounded proof data.
* The Merkle proof format and verification logic follow a standard binary Merkle tree structure. See:
	* [RFC 6962: Certificate Transparency Merkle Trees](https://datatracker.ietf.org/doc/html/rfc6962#section-2.1)
	* [BSV Technical Standards Committee – Merkle Proof Standardised Format](https://tsc.bsvblockchain.org/standards/merkle-proof-standardised-format/#Executionalgorithm)

## Related

* Closes part of #4968
* Prepares groundwork for cross-chain interoperability: #4637