### PR TITLE
ci(xx): remove soramitsu tag from default image too

### DIFF
--- a/.github/workflows/publish_xx.yml
+++ b/.github/workflows/publish_xx.yml
@@ -52,9 +52,10 @@ jobs:
           push: true
           file: Dockerfile.cross
           platforms: linux/amd64,linux/arm64
+          # FIXME: cannot push to Soramitsu: 401 unauthorized
+          # docker.soramitsu.co.jp/hyperledger/iroha:${{ env.TAG_BASE }}-${{ github.sha }}
           tags: |
             hyperledger/iroha:${{ env.TAG_BASE }}-${{ github.sha }}
-            docker.soramitsu.co.jp/hyperledger/iroha:${{ env.TAG_BASE }}-${{ github.sha }}
           labels: commit=${{ github.sha }}
           context: .
 


### PR DESCRIPTION
I did not notice this small thing. Again.
Maybe it will work this time?
