### PR TITLE
refactor(iroha_core, iroha_data_model): move `trait Registrable` to the data model

### DIFF
--- a/crates/iroha_core/src/block.rs
+++ b/crates/iroha_core/src/block.rs
@@ -1175,8 +1175,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        kura::Kura, query::store::LiveQueryStore, smartcontracts::isi::Registrable as _,
-        state::State, sumeragi::network_topology::test_topology,
+        kura::Kura, query::store::LiveQueryStore, state::State,
+        sumeragi::network_topology::test_topology,
     };
 
     #[test]

--- a/crates/iroha_core/src/queue.rs
+++ b/crates/iroha_core/src/queue.rs
@@ -412,7 +412,6 @@ pub mod tests {
         block::ValidBlock,
         kura::Kura,
         query::store::LiveQueryStore,
-        smartcontracts::isi::Registrable as _,
         state::{State, World},
     };
 

--- a/crates/iroha_core/src/smartcontracts/isi/account.rs
+++ b/crates/iroha_core/src/smartcontracts/isi/account.rs
@@ -6,15 +6,6 @@ use iroha_telemetry::metrics;
 
 use super::prelude::*;
 
-impl Registrable for iroha_data_model::account::NewAccount {
-    type Target = Account;
-
-    #[inline]
-    fn build(self, _authority: &AccountId) -> Self::Target {
-        self.into_account()
-    }
-}
-
 /// All instructions related to accounts:
 /// - minting/burning public key into account signatories
 /// - minting/burning signature condition check

--- a/crates/iroha_core/src/smartcontracts/isi/asset.rs
+++ b/crates/iroha_core/src/smartcontracts/isi/asset.rs
@@ -10,23 +10,6 @@ use iroha_telemetry::metrics;
 
 use super::prelude::*;
 
-impl Registrable for NewAssetDefinition {
-    type Target = AssetDefinition;
-
-    #[inline]
-    fn build(self, authority: &AccountId) -> Self::Target {
-        Self::Target {
-            id: self.id,
-            spec: self.spec,
-            mintable: self.mintable,
-            logo: self.logo,
-            metadata: self.metadata,
-            owned_by: authority.clone(),
-            total_quantity: Numeric::ZERO,
-        }
-    }
-}
-
 /// ISI module contains all instructions related to assets:
 /// - minting/burning assets
 /// - update metadata

--- a/crates/iroha_core/src/smartcontracts/isi/domain.rs
+++ b/crates/iroha_core/src/smartcontracts/isi/domain.rs
@@ -6,20 +6,6 @@ use iroha_telemetry::metrics;
 
 use super::super::isi::prelude::*;
 
-impl Registrable for iroha_data_model::domain::NewDomain {
-    type Target = Domain;
-
-    #[inline]
-    fn build(self, authority: &AccountId) -> Self::Target {
-        Self::Target {
-            id: self.id,
-            metadata: self.metadata,
-            logo: self.logo,
-            owned_by: authority.clone(),
-        }
-    }
-}
-
 /// ISI module contains all instructions related to domains:
 /// - creating/changing assets
 /// - registering/unregistering accounts

--- a/crates/iroha_core/src/smartcontracts/isi/mod.rs
+++ b/crates/iroha_core/src/smartcontracts/isi/mod.rs
@@ -12,6 +12,7 @@ pub mod tx;
 pub mod world;
 
 use eyre::Result;
+pub use iroha_data_model::Registrable;
 use iroha_data_model::{
     isi::{error::InstructionExecutionError as Error, *},
     prelude::*,
@@ -24,15 +25,6 @@ use crate::{
     smartcontracts::triggers::set::SetReadOnly,
     state::{StateReadOnly, StateTransaction, WorldReadOnly},
 };
-
-/// Trait for proxy objects used for registration.
-pub trait Registrable {
-    /// Constructed type
-    type Target;
-
-    /// Construct [`Self::Target`]
-    fn build(self, authority: &AccountId) -> Self::Target;
-}
 
 impl Execute for InstructionBox {
     fn execute(

--- a/crates/iroha_core/src/smartcontracts/isi/nft.rs
+++ b/crates/iroha_core/src/smartcontracts/isi/nft.rs
@@ -4,19 +4,6 @@ use iroha_telemetry::metrics;
 
 use super::prelude::*;
 
-impl Registrable for NewNft {
-    type Target = Nft;
-
-    #[inline]
-    fn build(self, authority: &AccountId) -> Self::Target {
-        Self::Target {
-            id: self.id,
-            content: self.content,
-            owned_by: authority.clone(),
-        }
-    }
-}
-
 /// ISI module contains all instructions related to NFTs:
 /// - register/unregister NFT
 /// - update metadata

--- a/crates/iroha_core/src/smartcontracts/isi/query.rs
+++ b/crates/iroha_core/src/smartcontracts/isi/query.rs
@@ -358,7 +358,6 @@ mod tests {
         block::*,
         kura::Kura,
         query::store::LiveQueryStore,
-        smartcontracts::isi::Registrable as _,
         state::{State, World},
         sumeragi::network_topology::Topology,
         tx::AcceptedTransaction,

--- a/crates/iroha_core/src/smartcontracts/isi/world.rs
+++ b/crates/iroha_core/src/smartcontracts/isi/world.rs
@@ -5,15 +5,6 @@ use iroha_telemetry::metrics;
 use super::prelude::*;
 use crate::prelude::*;
 
-impl Registrable for NewRole {
-    type Target = Role;
-
-    #[inline]
-    fn build(self, _authority: &AccountId) -> Self::Target {
-        self.inner
-    }
-}
-
 /// Iroha Special Instructions that have `World` as their target.
 pub mod isi {
     use eyre::Result;

--- a/crates/iroha_core/src/smartcontracts/wasm.rs
+++ b/crates/iroha_core/src/smartcontracts/wasm.rs
@@ -1743,10 +1743,7 @@ mod tests {
     use tokio::test;
 
     use super::*;
-    use crate::{
-        block::ValidBlock, kura::Kura, query::store::LiveQueryStore,
-        smartcontracts::isi::Registrable as _, state::State, World,
-    };
+    use crate::{block::ValidBlock, kura::Kura, query::store::LiveQueryStore, state::State, World};
 
     fn world_with_test_account(authority: &AccountId) -> World {
         let domain_id = authority.domain.clone();

--- a/crates/iroha_data_model/src/account.rs
+++ b/crates/iroha_data_model/src/account.rs
@@ -13,7 +13,7 @@ use serde_with::{DeserializeFromStr, SerializeDisplay};
 pub use self::model::*;
 use crate::{
     domain::prelude::*, metadata::Metadata, HasMetadata, Identifiable, IntoKeyValue, ParseError,
-    PublicKey, Registered,
+    PublicKey, Registered, Registrable,
 };
 
 #[model]
@@ -177,6 +177,18 @@ impl HasMetadata for Account {
 
 impl Registered for Account {
     type With = NewAccount;
+}
+
+impl Registrable for NewAccount {
+    type Target = Account;
+
+    #[inline]
+    fn build(self, _authority: &AccountId) -> Self::Target {
+        Account {
+            id: self.id,
+            metadata: self.metadata,
+        }
+    }
 }
 
 impl FromStr for AccountId {

--- a/crates/iroha_data_model/src/asset.rs
+++ b/crates/iroha_data_model/src/asset.rs
@@ -17,7 +17,7 @@ use serde_with::{DeserializeFromStr, SerializeDisplay};
 pub use self::model::*;
 use crate::{
     account::prelude::*, domain::prelude::*, ipfs::IpfsPath, metadata::Metadata, HasMetadata,
-    Identifiable, IntoKeyValue, Name, ParseError, Registered,
+    Identifiable, IntoKeyValue, Name, ParseError, Registered, Registrable,
 };
 
 /// [`AssetTotalQuantityMap`] provides an API to work with collection of key([`AssetDefinitionId`])-value([`Numeric`])
@@ -383,6 +383,23 @@ impl Registered for Asset {
 
 impl Registered for AssetDefinition {
     type With = NewAssetDefinition;
+}
+
+impl Registrable for NewAssetDefinition {
+    type Target = AssetDefinition;
+
+    #[inline]
+    fn build(self, authority: &AccountId) -> Self::Target {
+        Self::Target {
+            id: self.id,
+            spec: self.spec,
+            mintable: self.mintable,
+            logo: self.logo,
+            metadata: self.metadata,
+            owned_by: authority.clone(),
+            total_quantity: Numeric::ZERO,
+        }
+    }
 }
 
 impl<'world> AssetEntry<'world> {

--- a/crates/iroha_data_model/src/domain.rs
+++ b/crates/iroha_data_model/src/domain.rs
@@ -13,6 +13,7 @@ use serde_with::{DeserializeFromStr, SerializeDisplay};
 pub use self::model::*;
 use crate::{
     ipfs::IpfsPath, metadata::Metadata, prelude::*, HasMetadata, Identifiable, Name, Registered,
+    Registrable,
 };
 
 #[model]
@@ -137,6 +138,20 @@ impl HasMetadata for Domain {
 
 impl Registered for Domain {
     type With = NewDomain;
+}
+
+impl Registrable for NewDomain {
+    type Target = Domain;
+
+    #[inline]
+    fn build(self, authority: &AccountId) -> Self::Target {
+        Self::Target {
+            id: self.id,
+            metadata: self.metadata,
+            logo: self.logo,
+            owned_by: authority.clone(),
+        }
+    }
 }
 
 impl Domain {

--- a/crates/iroha_data_model/src/lib.rs
+++ b/crates/iroha_data_model/src/lib.rs
@@ -429,6 +429,15 @@ pub trait Identifiable: Ord + Eq {
     fn id(&self) -> &Self::Id;
 }
 
+/// Trait for proxy objects used for registration.
+pub trait Registrable {
+    /// Constructed type
+    type Target;
+
+    /// Construct [`Self::Target`] with given authority
+    fn build(self, authority: &crate::account::AccountId) -> Self::Target;
+}
+
 /// Trait that marks the entity as having metadata.
 pub trait HasMetadata {
     // type Metadata = metadata::Metadata;

--- a/crates/iroha_data_model/src/lib.rs
+++ b/crates/iroha_data_model/src/lib.rs
@@ -519,6 +519,6 @@ pub mod prelude {
         executor::prelude::*, isi::prelude::*, metadata::prelude::*, name::prelude::*,
         nft::prelude::*, parameter::prelude::*, peer::prelude::*, permission::prelude::*,
         query::prelude::*, role::prelude::*, transaction::prelude::*, trigger::prelude::*, ChainId,
-        EnumTryAsError, HasMetadata, IdBox, Identifiable, ValidationFail,
+        EnumTryAsError, HasMetadata, IdBox, Identifiable, Registrable, ValidationFail,
     };
 }

--- a/crates/iroha_data_model/src/nft.rs
+++ b/crates/iroha_data_model/src/nft.rs
@@ -8,7 +8,9 @@ use iroha_data_model_derive::model;
 use serde::{Deserialize, Serialize};
 
 pub use self::model::*;
-use crate::{metadata::Metadata, prelude::AccountId, IntoKeyValue, ParseError, Registered};
+use crate::{
+    metadata::Metadata, prelude::AccountId, IntoKeyValue, ParseError, Registered, Registrable,
+};
 
 #[model]
 mod model {
@@ -160,6 +162,19 @@ impl FromStr for NftId {
 
 impl Registered for Nft {
     type With = NewNft;
+}
+
+impl Registrable for NewNft {
+    type Target = Nft;
+
+    #[inline]
+    fn build(self, authority: &AccountId) -> Self::Target {
+        Self::Target {
+            id: self.id,
+            content: self.content,
+            owned_by: authority.clone(),
+        }
+    }
 }
 
 impl<'world> NftEntry<'world> {

--- a/crates/iroha_data_model/src/role.rs
+++ b/crates/iroha_data_model/src/role.rs
@@ -9,7 +9,7 @@ pub use self::model::*;
 use crate::{
     account::AccountId,
     permission::{Permission, Permissions},
-    Identifiable, Name, Registered,
+    Identifiable, Name, Registered, Registrable,
 };
 
 #[model]
@@ -129,6 +129,15 @@ impl NewRole {
 
 impl Registered for Role {
     type With = NewRole;
+}
+
+impl Registrable for NewRole {
+    type Target = Role;
+
+    #[inline]
+    fn build(self, _authority: &AccountId) -> Self::Target {
+        self.inner
+    }
 }
 
 /// The prelude re-exports most commonly used traits, structs and macros from this module.


### PR DESCRIPTION
There are functions such as `Account:new`, which create not `Account`, but `NewAccount`. Sometimes it is not desirable and I, as a user of `iroha_data_model` crate, want to simply create an `Account` itself. The only way to do so without `transparent_api` feature is to use `Registrable` trait (transforming e.g. `NewAccount` to `Account`), which is for some reason defined in `iroha_core`.

This commit moves `Registrable` from `iroha_core` to `iroha_data_model`.
