### PR TITLE
fix: inherit trigger authority from entrypoint authority

### DIFF
--- a/crates/iroha_core/src/state.rs
+++ b/crates/iroha_core/src/state.rs
@@ -1466,7 +1466,7 @@ impl<'state> StateBlock<'state> {
                 action.executable(),
                 (*time_event).into(),
             )
-            .and_then(|()| transaction.execute_data_triggers_dfs())?;
+            .and_then(|()| transaction.execute_data_triggers_dfs(action.authority()))?;
         transaction
             .world
             .triggers
@@ -1521,7 +1521,7 @@ impl<'state> StateBlock<'state> {
                 let mut transaction = self.transaction();
                 transaction.apply_executable(tx.instructions(), tx.authority().clone());
                 transaction
-                    .execute_data_triggers_dfs()
+                    .execute_data_triggers_dfs(tx.authority())
                     .expect("should be no errors");
                 transaction.apply();
             }
@@ -1577,7 +1577,10 @@ impl StateTransaction<'_, '_> {
     }
 
     /// Perform a depth-first traversal of the trigger execution path.
-    pub(crate) fn execute_data_triggers_dfs(&mut self) -> Result<(), TransactionRejectionReason> {
+    pub(crate) fn execute_data_triggers_dfs(
+        &mut self,
+        authority: &AccountId,
+    ) -> Result<(), TransactionRejectionReason> {
         let mut stack: Vec<(DataEvent, TriggerId, u8)> = self
             .capture_data_events()
             .into_iter()
@@ -1591,22 +1594,23 @@ impl StateTransaction<'_, '_> {
             if max_depth < depth {
                 return Err(TriggerExecutionFail::MaxDepthExceeded.into());
             }
-            let (authority, executable) = {
+            let executable = {
                 let action = self
                     .world
                     .triggers
                     .data_triggers()
                     .get(&trg_id)
                     .expect("stack should reference existing data trigger IDs");
+
                 assert!(
                     !action.repeats.is_depleted(),
                     "orphaned trigger was not removed"
                 );
 
-                (action.authority().clone(), action.executable().clone())
+                action.executable().clone()
             };
 
-            self.execute_trigger(&trg_id, &authority, &executable, event.clone().into())?;
+            self.execute_trigger(&trg_id, authority, &executable, event.clone().into())?;
             let depleted = self.world.triggers.decrease_repeats([&trg_id].into_iter());
             stack.retain(|(_, trg_id, _)| !depleted.contains(trg_id));
 

--- a/crates/iroha_core/src/tx.rs
+++ b/crates/iroha_core/src/tx.rs
@@ -222,9 +222,9 @@ impl StateBlock<'_> {
         state_transaction: &mut StateTransaction<'_, '_>,
         wasm_cache: &mut WasmCache<'_, '_, '_>,
     ) -> Result<(), TransactionRejectionReason> {
-        let authority = tx.as_ref().authority();
+        let authority = tx.as_ref().authority().clone();
 
-        if state_transaction.world.accounts.get(authority).is_none() {
+        if state_transaction.world.accounts.get(&authority).is_none() {
             return Err(TransactionRejectionReason::AccountDoesNotExist(
                 FindError::Account(authority.clone()),
             ));
@@ -242,7 +242,7 @@ impl StateBlock<'_> {
         }
 
         debug!("Transaction validated successfully; processing data triggers");
-        state_transaction.execute_data_triggers_dfs()?;
+        state_transaction.execute_data_triggers_dfs(&authority)?;
         debug!("Data triggers executed successfully");
 
         Ok(())


### PR DESCRIPTION
## Context

In my latest assessment, the failure of the `domain_owner_trigger_permissions` test after PR #5457 is not because this PR introduced a bug, but because correctly routing trigger execution to the executor revealed a flaw in the previous implementation: by-call triggers should have sourced authority from the execution-time `event.authority` rather than the registration-time `action.authority`. This PR fixes that.

Also make data triggers inherit the [entrypoint](https://github.com/hyperledger-iroha/iroha/pull/5471#issue-3152413250)'s authority, closing #5441.