### PR TITLE
test: add test for transfer with wrong AssetId

### DIFF
--- a/integration_tests/tests/transfer_asset.rs
+++ b/integration_tests/tests/transfer_asset.rs
@@ -88,3 +88,25 @@ fn generate_two_ids() -> (AccountId, AccountId) {
 fn create_mouse(mouse_id: AccountId) -> Register<Account> {
     Register::account(Account::new(mouse_id))
 }
+
+#[test]
+fn should_fail_if_asset_not_found() {
+    let (network, _rt) = NetworkBuilder::new().start_blocking().unwrap();
+    let iroha = network.client();
+
+    let (alice_id, mouse_id) = generate_two_ids();
+    let asset_definition_id: AssetDefinitionId = "camomile#wonderland".parse().unwrap();
+    let create_asset_definition =
+        Register::asset_definition(AssetDefinition::numeric(asset_definition_id.clone()));
+    let asset_id = AssetId::new(asset_definition_id.clone(), alice_id);
+    let transfer_asset = Transfer::asset_numeric(asset_id.clone(), numeric!(20), mouse_id.clone());
+
+    let instructions: [InstructionBox; 2] = [create_asset_definition.into(), transfer_asset.into()];
+    let result = iroha.submit_all_blocking(instructions);
+
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .chain()
+        .any(|e| e.to_string() == format!("Failed to find asset: `{}`", asset_id)));
+}


### PR DESCRIPTION
This PR adds test coverage for transfer operations that use the wrong AssetId. The objective is to ensure comprehensive test coverage for error scenarios in asset transfer functionality, making the codebase more robust and helping prevent regressions.

The change adds a new test case that verifies the system properly handles and reports errors when attempting to transfer assets with incorrect or mismatched asset identifiers.

Closes #4125

### Solution

Added a new test function `should_fail_if_asset_not_found` that:
- Creates an asset definition but does not mint any assets to an account
- Attempts to transfer a non-existent asset from that account
- Verifies that the operation fails with the appropriate error message
- Ensures the error chain contains the expected "Failed to find asset" message

This follows the existing test patterns in the file and provides clear verification that the transfer system correctly rejects invalid asset operations.

---

### Review notes (optional)

This is a straightforward test addition that follows existing patterns in `transfer_asset.rs`. The test can be reviewed independently and focuses solely on error handling verification.

### Checklist

- [x] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [x] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.
- [x] All CI checks pass.