### PR TITLE
refactor(core, kura): `Kura::blocks_count`; change some Kura signatures & docs

### DIFF
--- a/crates/iroha_core/src/snapshot.rs
+++ b/crates/iroha_core/src/snapshot.rs
@@ -165,8 +165,8 @@ pub fn try_read_snapshot(
         });
     }
     for height in 1..=snapshot_height {
-        let kura_block = NonZeroUsize::new(height)
-            .and_then(|height| kura.get_block(height))
+        let kura_block = kura
+            .get_block(NonZeroUsize::new(height).expect("iterating from 1"))
             .expect("Kura has height at least as large as state height");
         let snapshot_block_hash = state_view.block_hashes[height - 1];
         if kura_block.hash() != snapshot_block_hash {


### PR DESCRIPTION
- Added `Kura::blocks_count` to read the current storage height
- Made Kura accept `impl Into<Arc<SignedBlock>>` instead of `CommittedBlock`. It is not in the domain of Kura to decide what blocks to store (they just must be `SignedBlock`s), while enforcing `CommittedBlock` forces some code in Explorer to do extra conversion
- Chores