### PR TITLE
refactor(data-model, core): extend prelude & re-exports

### DIFF
--- a/crates/iroha_core/src/state.rs
+++ b/crates/iroha_core/src/state.rs
@@ -40,6 +40,7 @@ use serde::{
     de::{DeserializeSeed, MapAccess, Visitor},
     Deserializer, Serialize,
 };
+pub use storage_transactions::TransactionsReadOnly;
 
 #[cfg(feature = "telemetry")]
 use crate::telemetry::StateTelemetry;
@@ -60,9 +61,7 @@ use crate::{
         },
         wasm,
     },
-    state::storage_transactions::{
-        TransactionsBlock, TransactionsReadOnly, TransactionsStorage, TransactionsView,
-    },
+    state::storage_transactions::{TransactionsBlock, TransactionsStorage, TransactionsView},
     Peers,
 };
 

--- a/crates/iroha_core/src/tx.rs
+++ b/crates/iroha_core/src/tx.rs
@@ -10,7 +10,6 @@
 use std::time::{Duration, SystemTime};
 
 use eyre::Result;
-use iroha_crypto::SignatureOf;
 pub use iroha_data_model::prelude::*;
 use iroha_data_model::{
     isi::error::Mismatch,

--- a/crates/iroha_data_model/src/block.rs
+++ b/crates/iroha_data_model/src/block.rs
@@ -506,3 +506,8 @@ pub mod error {
     #[cfg(feature = "std")]
     impl std::error::Error for BlockRejectionReason {}
 }
+
+pub mod prelude {
+    //! For glob-import
+    pub use super::{error::BlockRejectionReason, BlockHeader, BlockSignature, SignedBlock};
+}

--- a/crates/iroha_data_model/src/lib.rs
+++ b/crates/iroha_data_model/src/lib.rs
@@ -508,17 +508,21 @@ mod ffi {
 #[allow(ambiguous_glob_reexports)]
 pub mod prelude {
     //! Prelude: re-export of most commonly used traits, structs and macros in this crate.
-    pub use iroha_crypto::{HashOf, PublicKey};
+    pub use iroha_crypto::{
+        Algorithm, ExposedPrivateKey, Hash, HashOf, KeyPair, MerkleTree, PrivateKey, PublicKey,
+        Signature, SignatureOf,
+    };
     pub use iroha_primitives::{
         json::*,
         numeric::{numeric, Numeric, NumericSpec},
     };
 
     pub use super::{
-        account::prelude::*, asset::prelude::*, domain::prelude::*, events::prelude::*,
-        executor::prelude::*, isi::prelude::*, metadata::prelude::*, name::prelude::*,
-        nft::prelude::*, parameter::prelude::*, peer::prelude::*, permission::prelude::*,
-        query::prelude::*, role::prelude::*, transaction::prelude::*, trigger::prelude::*, ChainId,
-        EnumTryAsError, HasMetadata, IdBox, Identifiable, Registrable, ValidationFail,
+        account::prelude::*, asset::prelude::*, block::prelude::*, domain::prelude::*,
+        events::prelude::*, executor::prelude::*, isi::prelude::*, metadata::prelude::*,
+        name::prelude::*, nft::prelude::*, parameter::prelude::*, peer::prelude::*,
+        permission::prelude::*, query::prelude::*, role::prelude::*, transaction::prelude::*,
+        trigger::prelude::*, ChainId, EnumTryAsError, HasMetadata, IdBox, Identifiable,
+        Registrable, ValidationFail,
     };
 }

--- a/crates/iroha_schema_gen/src/lib.rs
+++ b/crates/iroha_schema_gen/src/lib.rs
@@ -1,7 +1,6 @@
 //! Iroha schema generation support library. Contains the
 //! `build_schemas` `fn`, which is the function which decides which
 //! types are included in the schema.
-use iroha_crypto::MerkleTree;
 use iroha_data_model::{
     block::stream::{BlockMessage, BlockSubscriptionRequest},
     query::{QueryResponse, SignedQuery},


### PR DESCRIPTION
- Include the entire `iroha_crypto` into `iroha_data_model::prelude` - these types are mentioned and returned everywhere
- Include block-related structs into prelude
- Make `trait TransactionsStorage` public (for Explorer)

I've been long facing annoying incompleteness of the prelude, but never ended up fixing it. I probably missed something this time.