### PR TITLE
feat(core): add a constructor for `LiveQueryStoreHandle`

### DIFF
--- a/crates/iroha_core/src/query/store.rs
+++ b/crates/iroha_core/src/query/store.rs
@@ -199,6 +199,11 @@ pub struct LiveQueryStoreHandle {
 }
 
 impl LiveQueryStoreHandle {
+    /// Create a new handle for the store
+    pub fn new(store: Arc<LiveQueryStore>) -> Self {
+        Self { store }
+    }
+
     /// Construct a batched response from a post-processed query output.
     ///
     /// # Errors


### PR DESCRIPTION
Add a simple constructor for `LiveQueryStoreHandle`. This makes it possible to construct the handle right from `Arc<LiveQueryStore>`, bypassing the need to invoke `LiveQueryStore::start` or `LiveQueryStore::start_test`.

**Rationale:** `State` requires `LiveQueryStoreHandle` on creation. In Explorer, there is a lifecycle stage of having an uninitialised, "dummy" empty state (until any blocks are received). It simplifies internal implementation if there is no need to spawn any tasks and "just create a dummy state and wait for at least the first block" (the first, genesis block contains the genesis account, which Explorer extracts and creates a new `World` and non-dummy `State` with the given account).

Anyway, this PR is pretty straightforward.