### PR TITLE
feat!: specify height order for block queries

### DIFF
--- a/crates/iroha_core/src/smartcontracts/isi/query.rs
+++ b/crates/iroha_core/src/smartcontracts/isi/query.rs
@@ -450,32 +450,77 @@ mod tests {
     }
 
     #[test]
-    async fn find_all_blocks() -> Result<()> {
+    async fn find_all_blocks_desc() -> Result<()> {
         let num_blocks = 100;
 
         let state = state_with_test_blocks_and_transactions(num_blocks, 1, 1)?;
-        let blocks = ValidQuery::execute(FindBlocks, CompoundPredicate::PASS, &state.view())?
-            .collect::<Vec<_>>();
+        let blocks = ValidQuery::execute(
+            FindBlocks::new(Order::Descending),
+            CompoundPredicate::PASS,
+            &state.view(),
+        )?
+        .collect::<Vec<_>>();
 
         assert_eq!(blocks.len() as u64, num_blocks);
         assert!(blocks
             .windows(2)
-            .all(|wnd| wnd[0].header() >= wnd[1].header()));
+            .all(|wnd| wnd[0].header() > wnd[1].header()));
 
         Ok(())
     }
 
     #[test]
-    async fn find_all_block_headers() -> Result<()> {
+    async fn find_all_blocks_asc() -> Result<()> {
         let num_blocks = 100;
 
         let state = state_with_test_blocks_and_transactions(num_blocks, 1, 1)?;
-        let block_headers =
-            ValidQuery::execute(FindBlockHeaders, CompoundPredicate::PASS, &state.view())?
-                .collect::<Vec<_>>();
+        let blocks = ValidQuery::execute(
+            FindBlocks::new(Order::Ascending),
+            CompoundPredicate::PASS,
+            &state.view(),
+        )?
+        .collect::<Vec<_>>();
+
+        assert_eq!(blocks.len() as u64, num_blocks);
+        assert!(blocks
+            .windows(2)
+            .all(|wnd| wnd[0].header() < wnd[1].header()));
+
+        Ok(())
+    }
+
+    #[test]
+    async fn find_all_block_headers_desc() -> Result<()> {
+        let num_blocks = 100;
+
+        let state = state_with_test_blocks_and_transactions(num_blocks, 1, 1)?;
+        let block_headers = ValidQuery::execute(
+            FindBlockHeaders::new(Order::Descending),
+            CompoundPredicate::PASS,
+            &state.view(),
+        )?
+        .collect::<Vec<_>>();
 
         assert_eq!(block_headers.len() as u64, num_blocks);
-        assert!(block_headers.windows(2).all(|wnd| wnd[0] >= wnd[1]));
+        assert!(block_headers.windows(2).all(|wnd| wnd[0] > wnd[1]));
+
+        Ok(())
+    }
+
+    #[test]
+    async fn find_all_block_headers_asc() -> Result<()> {
+        let num_blocks = 100;
+
+        let state = state_with_test_blocks_and_transactions(num_blocks, 1, 1)?;
+        let block_headers = ValidQuery::execute(
+            FindBlockHeaders::new(Order::Ascending),
+            CompoundPredicate::PASS,
+            &state.view(),
+        )?
+        .collect::<Vec<_>>();
+
+        assert_eq!(block_headers.len() as u64, num_blocks);
+        assert!(block_headers.windows(2).all(|wnd| wnd[0] < wnd[1]));
 
         Ok(())
     }
@@ -490,7 +535,7 @@ mod tests {
             .expect("state is empty");
 
         assert_eq!(
-            FindBlockHeaders::new()
+            FindBlockHeaders::new(Order::Descending)
                 .execute(
                     CompoundPredicate::<BlockHeader>::build(|header| header.hash.eq(block.hash())),
                     &state_view,
@@ -501,7 +546,7 @@ mod tests {
             block.header()
         );
         assert!(
-            FindBlockHeaders::new()
+            FindBlockHeaders::new(Order::Descending)
                 .execute(
                     CompoundPredicate::<BlockHeader>::build(|header| {
                         header

--- a/crates/iroha_data_model/src/query/mod.rs
+++ b/crates/iroha_data_model/src/query/mod.rs
@@ -1071,20 +1071,26 @@ pub mod block {
 
     use derive_more::Display;
 
+    use crate::prelude::Order;
+
     queries! {
-        /// [`FindBlocks`] Iroha Query lists all blocks sorted by
-        /// height in descending order
+        /// [`FindBlocks`] Iroha Query lists all blocks
         #[derive(Copy, Display)]
         #[display(fmt = "Find all blocks")]
         #[ffi_type]
-        pub struct FindBlocks;
+        pub struct FindBlocks {
+            /// Sort blocks by height
+            pub order: Order
+        }
 
         /// [`FindBlockHeaders`] Iroha Query lists all block headers
-        /// sorted by height in descending order
         #[derive(Copy, Display)]
         #[display(fmt = "Find all block headers")]
         #[ffi_type]
-        pub struct FindBlockHeaders;
+        pub struct FindBlockHeaders {
+            /// Sort blocks by height
+            pub order: Order
+        }
     }
 
     /// The prelude re-exports most commonly used traits, structs and macros from this crate.

--- a/crates/iroha_data_model/src/query/parameters.rs
+++ b/crates/iroha_data_model/src/query/parameters.rs
@@ -70,6 +70,7 @@ mod model {
     }
 
     /// Struct for sorting requests
+    // TODO: rename to `QuerySortingParams`?
     #[derive(
         Debug,
         Clone,
@@ -129,6 +130,28 @@ mod model {
         pub sorting: Sorting,
         pub fetch_size: FetchSize,
     }
+
+    /// Specifies sort ordering.
+    #[derive(
+        Debug,
+        Copy,
+        Clone,
+        PartialEq,
+        Eq,
+        PartialOrd,
+        Ord,
+        Deserialize,
+        Serialize,
+        IntoSchema,
+        Encode,
+        Decode,
+    )]
+    pub enum Order {
+        /// Ascending
+        Ascending,
+        /// Descending
+        Descending,
+    }
 }
 
 impl Sorting {
@@ -142,5 +165,5 @@ impl Sorting {
 
 pub mod prelude {
     //! Prelude: re-export most commonly used traits, structs and macros from this module.
-    pub use super::{FetchSize, Pagination, Sorting};
+    pub use super::{FetchSize, Order, Pagination, Sorting};
 }

--- a/crates/iroha_schema_gen/src/lib.rs
+++ b/crates/iroha_schema_gen/src/lib.rs
@@ -392,6 +392,7 @@ types!(
     Option<bool>,
     Option<u32>,
     Option<u64>,
+    Order,
     Pagination,
     Parameter,
     ParameterChanged,

--- a/crates/iroha_torii/src/lib.rs
+++ b/crates/iroha_torii/src/lib.rs
@@ -370,12 +370,12 @@ impl Error {
                 CapacityLimit => StatusCode::TOO_MANY_REQUESTS,
             },
             TooComplex => StatusCode::UNPROCESSABLE_ENTITY,
-            InternalError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            InternalError(error) => {
+                iroha_logger::error!(?error, "Internal error occured while performing a query");
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
             InstructionFailed(error) => {
-                iroha_logger::error!(
-                ?error,
-                "Query validation failed with unexpected error. This means a bug inside Runtime Executor",
-            );
+                iroha_logger::error!(?error, "Query validation failed with unexpected error. This means a bug inside Runtime Executor");
                 StatusCode::INTERNAL_SERVER_ERROR
             }
         }

--- a/docs/source/references/schema.json
+++ b/docs/source/references/schema.json
@@ -2242,8 +2242,22 @@
   "FindActiveTriggerIds": null,
   "FindAssets": null,
   "FindAssetsDefinitions": null,
-  "FindBlockHeaders": null,
-  "FindBlocks": null,
+  "FindBlockHeaders": {
+    "Struct": [
+      {
+        "name": "order",
+        "type": "Order"
+      }
+    ]
+  },
+  "FindBlocks": {
+    "Struct": [
+      {
+        "name": "order",
+        "type": "Order"
+      }
+    ]
+  },
   "FindDomains": null,
   "FindError": {
     "Enum": [
@@ -3597,6 +3611,18 @@
   },
   "Option<u64>": {
     "Option": "u64"
+  },
+  "Order": {
+    "Enum": [
+      {
+        "tag": "Ascending",
+        "discriminant": 0
+      },
+      {
+        "tag": "Descending",
+        "discriminant": 1
+      }
+    ]
   },
   "Pagination": {
     "Struct": [


### PR DESCRIPTION
Closes #5454 

## Changes

This PR adds an `order` field to `FindBlocks` and `FindBlockHeaders` queries, to specify ascending/descending sorting (by block height). Facilitated by a new data model item, `Order`.