### PR TITLE
fix(genesis): register triggers before other instructions

### DIFF
--- a/crates/iroha_genesis/src/lib.rs
+++ b/crates/iroha_genesis/src/lib.rs
@@ -189,10 +189,6 @@ impl GenesisSpec {
             instruction_batches.push(instructions);
         }
 
-        if !self.instructions.is_empty() {
-            instruction_batches.push(self.instructions);
-        }
-
         if !self.wasm_triggers.is_empty() {
             let instructions = self
                 .wasm_triggers
@@ -204,6 +200,10 @@ impl GenesisSpec {
                 .map(InstructionBox::from)
                 .collect();
             instruction_batches.push(instructions);
+        }
+
+        if !self.instructions.is_empty() {
+            instruction_batches.push(self.instructions);
         }
 
         if !self.topology.is_empty() {
@@ -431,6 +431,7 @@ pub struct GenesisWasmTrigger {
 
 /// Human-readable alternative to [`Action`] which has wasm executable
 #[derive(Debug, Clone, Serialize, Deserialize)]
+// TODO: include metadata field
 pub struct GenesisWasmAction {
     executable: WasmPath,
     repeats: Repeats,

--- a/integration_tests/tests/misc.rs
+++ b/integration_tests/tests/misc.rs
@@ -4,6 +4,8 @@ use eyre::Result;
 use iroha::{client, data_model::prelude::*};
 use iroha_telemetry::metrics::Status;
 use iroha_test_network::*;
+use iroha_test_samples::{sample_wasm_path, ALICE_ID};
+use serde_json::json;
 use tokio::task::spawn_blocking;
 
 fn status_eq_excluding_uptime_and_queue(lhs: &Status, rhs: &Status) -> bool {
@@ -64,5 +66,77 @@ async fn get_server_version() -> eyre::Result<()> {
         tokio::task::spawn_blocking(move || client.get_server_version().unwrap()).await?;
     assert!(response.version.starts_with("2.0.0"));
     assert!(!response.git_sha.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn genesis_instructions_can_address_genesis_wasm_triggers() -> eyre::Result<()> {
+    let network = NetworkBuilder::new().build();
+
+    let peer = network.peer();
+    let genesis = network.genesis();
+    let configs = network.config_layers();
+
+    // modifying the genesis
+    let mut genesis_json = serde_json::to_value(genesis)?;
+
+    // putting a trigger into `wasm_triggers`
+    genesis_json
+        .get_mut("wasm_triggers")
+        .unwrap()
+        .as_array_mut()
+        .unwrap()
+        .push(json!({
+            "id": "test_trigger",
+            "action": {
+                "executable": sample_wasm_path("mint_rose_trigger"),
+                "repeats": "Indefinitely",
+                "authority": ALICE_ID.to_owned(),
+                "filter": { "Time": { "Schedule": { "start_ms": 999_999_999_999u128 } } }
+            }
+        }));
+
+    // setting this trigger metadata in `instructions`
+    // NOTE: it is currently not possible to set metadata in `wasm_triggers`, since
+    // `GenesisWasmAction` does not include `metadata`
+    genesis_json
+        .get_mut("instructions")
+        .unwrap()
+        .as_array_mut()
+        .unwrap()
+        .push(json!({
+            "SetKeyValue": {
+                "Trigger": {
+                    "object": "test_trigger",
+                    "key": "test_key",
+                    "value": "test_value"
+                }
+            }
+        }));
+
+    let genesis = serde_json::from_value(genesis_json)?;
+    peer.start_checked(configs, &genesis).await?;
+
+    let client = peer.client();
+    let metadata = spawn_blocking(move || {
+        client
+            .query(FindTriggers)
+            .filter_with(|trigger| trigger.id.eq("test_trigger".parse().unwrap()))
+            .select_with(|trigger| trigger.action.metadata)
+            .execute_single()
+    })
+    .await??;
+
+    expect_test::expect![[r#"
+        Metadata(
+            {
+                "test_key": Json(
+                    "\"test_value\"",
+                ),
+            },
+        )
+    "#]]
+    .assert_debug_eq(&metadata);
+
     Ok(())
 }


### PR DESCRIPTION
Triggers defined in `wasm_triggers` are registered **after** the `instructions` in the genesis. This disallows to put in instructions referencing the triggers.

IMO registering triggers first is the right approach.