### PR TITLE
Fix permission JSON normalization regressions

### DIFF
--- a/crates/iroha_core/src/state.rs
+++ b/crates/iroha_core/src/state.rs
@@ -23632,15 +23632,20 @@ mod replay_validation_tests {
 
 #[cfg(test)]
 mod permission_cache_tests {
+    use std::collections::BTreeSet;
+
     use iroha_data_model::{
         account::AccountId,
         domain::DomainId,
         isi::{Grant, Revoke},
+        nexus::DataSpaceId,
+        permission::Permission,
         prelude::{Account, Domain},
         role::{Role, RoleId},
         trigger::TriggerId,
     };
     use iroha_executor_data_model::permission::{
+        account::{AccountAliasPermissionScope, CanManageAccountAlias},
         nexus::CanUseFeeSponsor,
         trigger::{CanExecuteTrigger, CanRegisterTrigger},
     };
@@ -23712,8 +23717,6 @@ mod permission_cache_tests {
 
     #[test]
     fn trigger_permission_payload_with_whitespace_decodes() {
-        use std::collections::BTreeSet;
-
         let (registrar, _) = gen_account_in("wonderland");
 
         let domain: Domain = Domain::new(wonderland_domain_id()).build(&registrar);
@@ -23743,6 +23746,33 @@ mod permission_cache_tests {
             "Norito decoder should handle non-canonical JSON payloads"
         );
         assert!(stx.can_execute_trigger_for(&registrar, &trigger_id));
+    }
+
+    #[test]
+    fn permission_deserialized_from_json_matches_canonical_permission() {
+        let stored: Permission = norito::json::from_str(
+            r#"{
+                "name": "CanManageAccountAlias",
+                "payload": { "scope": { "scope": "dataspace", "value": 0 } }
+            }"#,
+        )
+        .expect("deserialize permission");
+        let target = Permission::from(CanManageAccountAlias {
+            scope: AccountAliasPermissionScope::Dataspace(DataSpaceId::GLOBAL),
+        });
+
+        let permissions = BTreeSet::from([stored]);
+
+        assert!(
+            permissions.contains(&target),
+            "deserialized permissions should use canonical JSON payloads: stored={}, target={}",
+            permissions
+                .first()
+                .expect("stored permission")
+                .payload()
+                .get(),
+            target.payload().get(),
+        );
     }
 
     #[test]

--- a/crates/iroha_data_model/src/permission.rs
+++ b/crates/iroha_data_model/src/permission.rs
@@ -22,10 +22,7 @@ mod model {
     #[derive(
         Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Decode, Encode, IntoSchema, Display, Getters,
     )]
-    #[cfg_attr(
-        feature = "json",
-        derive(crate::DeriveJsonSerialize, crate::DeriveJsonDeserialize)
-    )]
+    #[cfg_attr(feature = "json", derive(crate::DeriveJsonSerialize))]
     #[cfg_attr(any(feature = "ffi_export", feature = "ffi_import"), ffi_type)]
     #[display("{name}({payload})")]
     pub struct Permission {
@@ -56,7 +53,152 @@ impl Permission {
     }
 }
 
+#[cfg(feature = "json")]
+fn minify_json_whitespace(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut in_string = false;
+    let mut escaped = false;
+
+    for ch in raw.chars() {
+        if in_string {
+            out.push(ch);
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+
+        match ch {
+            '"' => {
+                in_string = true;
+                out.push(ch);
+            }
+            ' ' | '\n' | '\r' | '\t' => {}
+            _ => out.push(ch),
+        }
+    }
+
+    out
+}
+
+#[cfg(feature = "json")]
+impl norito::json::JsonDeserialize for Permission {
+    fn json_deserialize(
+        parser: &mut norito::json::Parser<'_>,
+    ) -> Result<Self, norito::json::Error> {
+        use norito::json::{MapVisitor, RawValue};
+
+        let mut visitor = MapVisitor::new(parser)?;
+        let mut name: Option<Ident> = None;
+        let mut payload: Option<Json> = None;
+
+        while let Some(key) = visitor.next_key()? {
+            match key.as_str() {
+                "name" => {
+                    if name.is_some() {
+                        return Err(norito::json::Error::duplicate_field("name"));
+                    }
+                    name = Some(visitor.parse_value::<Ident>()?);
+                }
+                "payload" => {
+                    if payload.is_some() {
+                        return Err(norito::json::Error::duplicate_field("payload"));
+                    }
+                    let raw = visitor.parse_value::<RawValue>()?;
+                    payload = Some(Json::from_string_unchecked(minify_json_whitespace(
+                        raw.as_str(),
+                    )));
+                }
+                _ => visitor.skip_value()?,
+            }
+        }
+        visitor.finish()?;
+
+        let name = name.ok_or_else(|| norito::json::Error::missing_field("name"))?;
+        let payload = payload.ok_or_else(|| norito::json::Error::missing_field("payload"))?;
+
+        Ok(Self { name, payload })
+    }
+}
+
 pub mod prelude {
     //! The prelude re-exports most commonly used traits, structs and macros from this crate.
     pub use super::Permission;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use norito::json::JsonDeserialize as _;
+
+    fn deserialize_permission_with_parser(raw: &str) -> Result<Permission, norito::json::Error> {
+        let mut parser = norito::json::Parser::new(raw);
+        let permission = Permission::json_deserialize(&mut parser)?;
+        parser.skip_ws();
+        assert!(
+            parser.eof(),
+            "permission parser should consume the full input"
+        );
+        Ok(permission)
+    }
+
+    #[test]
+    fn permission_deserialization_minifies_payload_whitespace() {
+        let decoded: Permission = norito::json::from_str(
+            r#"{
+                "name": "CanDoThing",
+                "payload": {  "k" : 1 }
+            }"#,
+        )
+        .expect("deserialize permission");
+        let canonical = Permission::new(
+            "CanDoThing".into(),
+            Json::from_string_unchecked("{\"k\":1}".to_owned()),
+        );
+
+        assert_eq!(decoded.payload().get(), "{\"k\":1}");
+        assert_eq!(decoded, canonical);
+    }
+
+    #[test]
+    fn permission_deserialization_keeps_duplicate_payload_keys_distinct() {
+        let stored =
+            deserialize_permission_with_parser(r#"{"name":"CanDoThing","payload":{"k":0,"k":1}}"#)
+                .expect("deserialize permission");
+        let canonical = Permission::new(
+            "CanDoThing".into(),
+            Json::from_string_unchecked("{\"k\":1}".to_owned()),
+        );
+
+        assert_eq!(stored.payload().get(), "{\"k\":0,\"k\":1}");
+        assert_ne!(stored, canonical);
+        assert!(!BTreeSet::from([stored]).contains(&canonical));
+    }
+
+    #[test]
+    fn permission_deserialization_rejects_duplicate_top_level_fields() {
+        let duplicate_name = deserialize_permission_with_parser(
+            r#"{"name":"CanDoThing","name":"OtherThing","payload":null}"#,
+        )
+        .expect_err("duplicate name must fail");
+        let duplicate_payload = deserialize_permission_with_parser(
+            r#"{"name":"CanDoThing","payload":null,"payload":{}}"#,
+        )
+        .expect_err("duplicate payload must fail");
+
+        assert!(
+            duplicate_name
+                .to_string()
+                .contains("duplicate field `name`")
+        );
+        assert!(
+            duplicate_payload
+                .to_string()
+                .contains("duplicate field `payload`")
+        );
+    }
 }

--- a/crates/iroha_executor_data_model/src/permission.rs
+++ b/crates/iroha_executor_data_model/src/permission.rs
@@ -96,21 +96,67 @@ pub mod account {
     use super::*;
 
     /// Scope carried by account-alias permissions.
-    #[derive(
-        Debug,
-        Clone,
-        PartialEq,
-        Eq,
-        crate::json_macros::JsonSerialize,
-        crate::json_macros::JsonDeserialize,
-        iroha_schema::IntoSchema,
-    )]
+    #[derive(Debug, Clone, PartialEq, Eq, iroha_schema::IntoSchema)]
     #[norito(tag = "scope", content = "value", rename_all = "snake_case")]
     pub enum AccountAliasPermissionScope {
         /// Permission scoped to a specific linked domain alias segment.
         Domain(DomainId),
         /// Permission scoped to a dataspace alias segment.
         Dataspace(DataSpaceId),
+    }
+
+    impl norito::json::JsonSerialize for AccountAliasPermissionScope {
+        fn json_serialize(&self, out: &mut String) {
+            out.push_str("{\"scope\":\"");
+            match self {
+                Self::Domain(value) => {
+                    out.push_str("domain\",\"value\":");
+                    norito::json::JsonSerialize::json_serialize(value, out);
+                }
+                Self::Dataspace(value) => {
+                    out.push_str("dataspace\",\"value\":");
+                    norito::json::JsonSerialize::json_serialize(value, out);
+                }
+            }
+            out.push('}');
+        }
+    }
+
+    impl norito::json::JsonDeserialize for AccountAliasPermissionScope {
+        fn json_deserialize(p: &mut norito::json::Parser<'_>) -> Result<Self, norito::json::Error> {
+            let value =
+                <norito::json::Value as norito::json::JsonDeserialize>::json_deserialize(p)?;
+            Self::json_from_value(&value)
+        }
+
+        fn json_from_value(value: &norito::json::Value) -> Result<Self, norito::json::Error> {
+            let object = value.as_object().ok_or_else(|| {
+                norito::json::Error::Message("expected alias permission scope object".into())
+            })?;
+            let scope = object
+                .get("scope")
+                .and_then(norito::json::Value::as_str)
+                .ok_or_else(|| {
+                    norito::json::Error::Message(
+                        "missing alias permission scope discriminator".into(),
+                    )
+                })?;
+            let value = object.get("value").ok_or_else(|| {
+                norito::json::Error::Message("missing alias permission scope value".into())
+            })?;
+
+            match scope {
+                "domain" => Ok(Self::Domain(
+                    <DomainId as norito::json::JsonDeserialize>::json_from_value(value)?,
+                )),
+                "dataspace" => Ok(Self::Dataspace(
+                    <DataSpaceId as norito::json::JsonDeserialize>::json_from_value(value)?,
+                )),
+                other => Err(norito::json::Error::Message(
+                    format!("unknown alias permission scope `{other}`").into(),
+                )),
+            }
+        }
     }
 
     permission! {
@@ -149,6 +195,49 @@ pub mod account {
         pub struct CanManageAccountAlias {
             /// Alias permission scope.
             pub scope: AccountAliasPermissionScope,
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use iroha_schema::{IntoSchema, Metadata};
+
+        #[test]
+        fn alias_scope_serializes_as_snake_case() {
+            let json =
+                norito::json::to_json(&AccountAliasPermissionScope::Dataspace(DataSpaceId::GLOBAL))
+                    .expect("serialize alias scope");
+
+            assert_eq!(json, "{\"scope\":\"dataspace\",\"value\":0}");
+        }
+
+        #[test]
+        fn alias_scope_deserializes_snake_case() {
+            let scope: AccountAliasPermissionScope =
+                norito::json::from_str("{\"scope\":\"dataspace\",\"value\":0}")
+                    .expect("deserialize alias scope");
+
+            assert_eq!(
+                scope,
+                AccountAliasPermissionScope::Dataspace(DataSpaceId::GLOBAL)
+            );
+        }
+
+        #[test]
+        fn alias_scope_schema_uses_snake_case_tags() {
+            let schema = AccountAliasPermissionScope::schema();
+            let Some(Metadata::Enum(meta)) = schema.get::<AccountAliasPermissionScope>() else {
+                panic!("alias scope schema must be an enum");
+            };
+
+            let tags = meta
+                .variants
+                .iter()
+                .map(|variant| variant.tag.as_str())
+                .collect::<Vec<_>>();
+
+            assert_eq!(tags, vec!["domain", "dataspace"]);
         }
     }
 }

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,6 +1,25 @@
 # Roadmap (Open Work Only)
 
-Last updated: 2026-03-25
+Last updated: 2026-03-26
+
+Latest sync (2026-03-26 permission JSON decode-time canonicalization and alias-scope schema alignment):
+`crates/iroha_data_model/src/permission.rs`,
+`crates/iroha_executor_data_model/src/permission.rs`,
+and
+`crates/iroha_core/src/state.rs`
+now keep `Permission` equality/order exact while canonicalizing only
+insignificant payload whitespace during JSON decode, preserving duplicate
+payload keys on the parser path, and publishing `AccountAliasPermissionScope`
+schema tags as `domain` / `dataspace` again.
+
+Validation:
+- `cargo fmt --all`
+- `cargo test -p iroha_data_model permission --lib`
+- `cargo test -p iroha_executor_data_model alias_scope_ --lib`
+- `cargo test -p iroha_core permission_deserialized_from_json_matches_canonical_permission --lib`
+
+Open work for this slice now remains:
+- no additional confirmed work remains in this permission/schema compatibility slice.
 
 Latest sync (2026-03-25 active cargo-deny dependency findings are closed):
 `Cargo.toml`

--- a/status.md
+++ b/status.md
@@ -2,6 +2,26 @@
 
 Last updated: 2026-03-26
 
+## 2026-03-26 Follow-up: permission JSON normalization moved to decode time and alias-scope schema tags are back in sync
+- Hardened `crates/iroha_data_model/src/permission.rs` so `Permission`
+  equality/order semantics are exact again, while JSON decoding now
+  canonicalizes only insignificant payload whitespace, rejects duplicate
+  top-level `name` / `payload` fields on the parser path, and preserves
+  duplicate keys inside the payload instead of reparsing through
+  `norito::json::Value`.
+- Restored the Norito enum metadata on
+  `crates/iroha_executor_data_model/src/permission.rs` so
+  `AccountAliasPermissionScope` publishes the same snake-case schema tags that
+  the manual JSON codec already emits and accepts.
+- Kept the focused end-to-end regression in `crates/iroha_core/src/state.rs`
+  proving that a permission deserialized from JSON still matches the canonical
+  typed alias-management permission in the permission cache path.
+- Validation:
+  - `cargo fmt --all` (pass)
+  - `cargo test -p iroha_data_model permission --lib` (pass)
+  - `cargo test -p iroha_executor_data_model alias_scope_ --lib` (pass)
+  - `cargo test -p iroha_core permission_deserialized_from_json_matches_canonical_permission --lib` (pass)
+
 ## 2026-03-26 Follow-up: address canonicalisation integration assertions now validate canonical account literals instead of a stale `sora` prefix
 - Tightened `integration_tests/tests/address_canonicalisation.rs` so the
   account-listing, asset-holder, and account-transaction response assertions


### PR DESCRIPTION
## Context

This PR fixes a regression in permission matching introduced by JSON payload normalization.

The affected path is `Permission` handling in the data model and executor permission schema for account alias scope. The practical impact was:

- permission equality/order started reparsing payload JSON at comparison time;
- duplicate-key payloads could collapse to a canonical form during comparison instead of remaining distinct;
- generated schema for `AccountAliasPermissionScope` drifted away from the JSON codec and published `Domain` / `Dataspace` tags instead of `domain` / `dataspace`.

That combination could make permission checks behave differently from the stored payload text and could mislead schema-driven clients.

### Solution

The fix keeps permission matching exact and moves the compatibility behavior to JSON decode time only.

- restored derived `PartialEq` / `Eq` / `Ord` for `Permission`;
- replaced the `Permission` JSON deserializer with a manual implementation that:
  - rejects duplicate top-level `name` / `payload` fields;
  - minifies only insignificant whitespace in `payload`;
  - preserves payload key order, duplicate keys, and numeric/string spellings;
  - avoids reparsing payloads through `norito::json::Value`;
- restored Norito enum metadata on `AccountAliasPermissionScope` so schema output matches the manual JSON codec again;
- kept and extended focused regression coverage for:
  - whitespace-only payload normalization on decode;
  - duplicate-key payloads staying distinct from canonical payloads;
  - duplicate top-level `Permission` fields being rejected;
  - alias-scope schema tags remaining snake_case;
  - end-to-end alias permission cache lookup still matching canonical typed permissions.

No migration is required. This is intended to restore correct behavior and schema compatibility without changing the public wire shape.