### PR TITLE
Add offline cash API routes to Torii

### DIFF
--- a/crates/iroha_torii/src/lib.rs
+++ b/crates/iroha_torii/src/lib.rs
@@ -23044,6 +23044,11 @@ impl Torii {
                     "/v1/offline/allowances/query",
                     post(handler_offline_allowances_query),
                 )
+                .route("/v1/offline/cash/setup", post(handler_offline_cash_setup))
+                .route("/v1/offline/cash/load", post(handler_offline_cash_load))
+                .route("/v1/offline/cash/refresh", post(handler_offline_cash_refresh))
+                .route("/v1/offline/cash/sync", post(handler_offline_cash_sync))
+                .route("/v1/offline/cash/redeem", post(handler_offline_cash_redeem))
                 .route("/v1/offline/transfers", get(handler_offline_transfers_list))
                 .route(
                     "/v1/offline/transfers/{bundle_id_hex}",


### PR DESCRIPTION
## Context

The offline cash handlers (`setup`, `load`, `refresh`, `sync`, `redeem`) were implemented under the `app_api` feature flag but never wired into the Torii router. These endpoints are part of the `/v1/offline/cash/` API surface alongside the existing `readiness` route and are needed by clients to manage the offline cash lifecycle.

### Solution

Register the five missing POST routes in the Torii axum router, placed between the existing `/v1/offline/allowances/query` and `/v1/offline/transfers` routes:

- `POST /v1/offline/cash/setup`
- `POST /v1/offline/cash/load`
- `POST /v1/offline/cash/refresh`
- `POST /v1/offline/cash/sync`
- `POST /v1/offline/cash/redeem`

No handler logic or data model changes — this is purely route wiring.

---

### Review notes

Single-hunk change in the router builder. The handlers themselves are already reviewed and merged.