### PR TITLE
Fix schema hash offset and remove unused DomainIdAdapter

### DIFF
--- a/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/norito/SchemaHash.kt
+++ b/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/norito/SchemaHash.kt
@@ -6,7 +6,7 @@ package org.hyperledger.iroha.sdk.norito
 import java.nio.ByteBuffer
 import java.util.Locale
 
-private const val OFFSET_BASIS = -0x340AB5673053566BL // 0xCBF29CE484222325L
+private const val OFFSET_BASIS = -0x340D631B7BDDDCDBL // 0xCBF29CE484222325L
 private const val FNV_PRIME = 0x100000001B3L
 
 /** Computes FNV-1a 64-bit schema hashes matching the Rust implementation. */

--- a/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/tx/norito/TransactionPayloadAdapter.kt
+++ b/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/tx/norito/TransactionPayloadAdapter.kt
@@ -269,33 +269,6 @@ internal class TransactionPayloadAdapter : TypeAdapter<TransactionPayload> {
         }
     }
 
-    private class DomainIdAdapter : TypeAdapter<String> {
-        override fun encode(encoder: NoritoEncoder, value: String) {
-            encodeSizedField(encoder, STRING_ADAPTER, value)
-        }
-
-        override fun decode(decoder: NoritoDecoder): String {
-            val payload = decoder.readBytes(decoder.remaining())
-            return decodeDomainPayload(payload, decoder.flags, decoder.flagsHint)
-        }
-
-        companion object {
-            fun decodeDomainPayload(payload: ByteArray, flags: Int, flagsHint: Int): String {
-                try {
-                    val child = NoritoDecoder(payload, flags, flagsHint)
-                    val domain = decodeSizedField(child, STRING_ADAPTER)
-                    require(child.remaining() == 0) { "Trailing bytes after DomainId payload" }
-                    return domain
-                } catch (_: IllegalArgumentException) {
-                    val child = NoritoDecoder(payload, flags, flagsHint)
-                    val domain = STRING_ADAPTER.decode(child)
-                    require(child.remaining() == 0) { "Trailing bytes after DomainId payload" }
-                    return domain
-                }
-            }
-        }
-    }
-
     private class ChainIdAdapter : TypeAdapter<String> {
         override fun encode(encoder: NoritoEncoder, value: String) {
             encodeSizedField(encoder, STRING_ADAPTER, value)
@@ -390,7 +363,6 @@ internal class TransactionPayloadAdapter : TypeAdapter<TransactionPayload> {
 
     companion object {
         private val STRING_ADAPTER: TypeAdapter<String> = NoritoAdapters.stringAdapter()
-        private val DOMAIN_ID_ADAPTER: TypeAdapter<String> = DomainIdAdapter()
         private val ACCOUNT_ID_ADAPTER: TypeAdapter<String> = AccountIdAdapter()
         private val CHAIN_ID_ADAPTER: TypeAdapter<String> = ChainIdAdapter()
         private val JSON_STRING_ADAPTER: TypeAdapter<String> = JsonStringAdapter()

--- a/kotlin/core-jvm/src/main/resources/META-INF/proguard/consumer-proguard-rules.pro
+++ b/kotlin/core-jvm/src/main/resources/META-INF/proguard/consumer-proguard-rules.pro
@@ -1,0 +1,16 @@
+# Iroha SDK core-jvm — consumer ProGuard/R8 rules
+#
+# Bundled in the JAR at META-INF/proguard/ and applied automatically
+# when consuming Android apps enable minification.
+
+# Zstd-JNI — JNI linking requires class names to match native symbols.
+# Renaming any class with native methods breaks native library loading.
+-keep,allowoptimization class com.github.luben.zstd.Zstd { native <methods>; }
+-keep,allowoptimization class com.github.luben.zstd.ZstdCompressCtx { native <methods>; }
+-keep,allowoptimization class com.github.luben.zstd.ZstdDecompressCtx { native <methods>; }
+-keep,allowoptimization class com.github.luben.zstd.ZstdDictCompress { native <methods>; }
+-keep,allowoptimization class com.github.luben.zstd.ZstdDictDecompress { native <methods>; }
+-keep,allowoptimization class com.github.luben.zstd.ZstdInputStreamNoFinalizer { native <methods>; }
+-keep,allowoptimization class com.github.luben.zstd.ZstdOutputStreamNoFinalizer { native <methods>; }
+-keep,allowoptimization class com.github.luben.zstd.util.Native { native <methods>; }
+-dontwarn com.github.luben.zstd.**

--- a/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/address/I105CompatTest.kt
+++ b/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/address/I105CompatTest.kt
@@ -1,0 +1,51 @@
+package org.hyperledger.iroha.sdk.address
+
+import org.hyperledger.iroha.sdk.crypto.SoftwareKeyProvider
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class I105CompatTest {
+
+    @Test
+    fun `fromAccount produces 36 canonical bytes for ed25519`() {
+        // Use SoftwareKeyProvider like the E2E test does
+        val keyProvider = SoftwareKeyProvider(SoftwareKeyProvider.ProviderPolicy.BOUNCY_CASTLE_REQUIRED)
+        val keyPair = keyProvider.generateEphemeral()
+        val spki = keyPair.public.encoded
+        println("SPKI size: ${spki.size}")
+        println("SPKI hex: ${spki.joinToString("") { "%02x".format(it) }}")
+
+        // Extract raw 32-byte key (skip 12-byte SPKI prefix)
+        val prefix = byteArrayOf(
+            0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65,
+            0x70, 0x03, 0x21, 0x00
+        )
+        val rawKey = spki.copyOfRange(prefix.size, spki.size)
+        println("Raw key size: ${rawKey.size}")
+        println("Raw key hex: ${rawKey.joinToString("") { "%02x".format(it) }}")
+
+        val address = AccountAddress.fromAccount(rawKey, "ed25519")
+        val canonical = address.canonicalHex()
+        println("Canonical: $canonical")
+        println("Canonical bytes: ${canonical.length / 2 - 1}") // minus 0x
+
+        val i105 = address.toI105Default()
+        println("I105: $i105")
+        println("I105 length: ${i105.length}")
+
+        // Canonical must be 36 bytes: header(1) + ctrl_tag(1) + curve(1) + keylen(1) + key(32)
+        assertEquals(36, (canonical.length - 2) / 2, "Canonical should be 36 bytes")
+    }
+
+    @Test
+    fun `fromAccount produces same I105 for known key`() {
+        // Alice's key - known to produce correct I105
+        val aliceHex = "CE7FA46C9DCE7EA4B125E2E36BDB63EA33073E7590AC92816AE1E861B7048B03"
+        val aliceKey = aliceHex.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+        val aliceAddr = AccountAddress.fromAccount(aliceKey, "ed25519")
+        val aliceI105 = aliceAddr.toI105Default()
+        println("Alice I105: $aliceI105")
+        println("Alice canonical: ${aliceAddr.canonicalHex()}")
+        assertEquals("6cmzPVPX944pj7vVyADRpma2DCcBUsG1mhz8VrXArhXaGsjvRUcnZaK", aliceI105)
+    }
+}


### PR DESCRIPTION
## Context

The Kotlin SDK's FNV-1a schema hash offset basis had drifted from the current Rust implementation, causing hash mismatches when the SDK encodes transaction payloads. Separately, `DomainIdAdapter` in `TransactionPayloadAdapter` was dead code — unused after domain ID encoding was consolidated into the string adapter path.

### Solution

- **SchemaHash.kt**: Update the FNV-1a `OFFSET_BASIS` constant to match the current Rust schema hash.
- **TransactionPayloadAdapter.kt**: Remove the unused `DomainIdAdapter` inner class and its companion `DOMAIN_ID_ADAPTER` field.
- **I105CompatTest.kt** (new): Add tests verifying `AccountAddress.fromAccount` produces 36-byte canonical addresses for ed25519 keys and matches a known I105 encoding for Alice's key.
- **consumer-proguard-rules.pro** (new): Add ProGuard consumer rules preserving Zstd-JNI native method classes so Android apps using R8 minification don't break JNI linking at runtime.

---

### Review notes

The schema hash and adapter cleanup are independent fixes bundled for convenience. The ProGuard rules are passive — they're picked up automatically by Android consumers via `META-INF/proguard/` and have no effect on non-Android builds.