### PR TITLE
Fix RegisterBox encoding after linked_domains removal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -300,7 +300,8 @@ members = [
     "tools/soranet-relay",
     "tools/norito_codegen_exporter",
     "tools/soradns-resolver",
-    "tools/telemetry-schema-diff"
+    "tools/telemetry-schema-diff",
+    "tools/kotlin-fixture-gen"
 ]
 exclude = [
     "mochi/fixtures",

--- a/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/core/model/instructions/RegisterAccountWirePayloadEncoder.kt
+++ b/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/core/model/instructions/RegisterAccountWirePayloadEncoder.kt
@@ -66,33 +66,29 @@ object RegisterAccountWirePayloadEncoder {
         }
 
         /**
-         * NewAccount struct (6 fields):
+         * NewAccount struct (5 fields):
          * 1. id: AccountId (transparent → AccountController)
-         * 2. linked_domains: BTreeSet<DomainId> — empty
-         * 3. metadata: Metadata — empty
-         * 4. label: Option<AccountLabel> — None
-         * 5. uaid: Option<UniversalAccountId> — None
-         * 6. opaque_ids: Vec<OpaqueAccountId> — empty
+         * 2. metadata: Metadata — empty
+         * 3. label: Option<AccountAlias> — None
+         * 4. uaid: Option<UniversalAccountId> — None
+         * 5. opaque_ids: Vec<OpaqueAccountId> — empty
          */
         private fun encodeNewAccount(encoder: NoritoEncoder, accountId: String) {
             // Field 1: id — reuse AccountId encoding from TransferWirePayloadEncoder
             val accountIdBytes = TransferWirePayloadEncoder.encodeAccountIdPayload(accountId)
             writeFieldWithLength(encoder, accountIdBytes)
 
-            // Field 2: linked_domains (empty BTreeSet) — count = 0
+            // Field 2: metadata (empty Metadata/BTreeMap) — count = 0
             writeFieldWithLength(encoder, encodeEmptySequence())
 
-            // Field 3: metadata (empty Metadata/BTreeMap) — count = 0
-            writeFieldWithLength(encoder, encodeEmptySequence())
-
-            // Field 4: label (None)
+            // Field 3: label (None)
             val noneBytes = encodeNone()
             writeFieldWithLength(encoder, noneBytes)
 
-            // Field 5: uaid (None)
+            // Field 4: uaid (None)
             writeFieldWithLength(encoder, noneBytes)
 
-            // Field 6: opaque_ids (empty Vec)
+            // Field 5: opaque_ids (empty Vec)
             writeFieldWithLength(encoder, encodeEmptySequence())
         }
 

--- a/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/core/model/instructions/ClaimIdentifierWirePayloadEncoderParityTest.kt
+++ b/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/core/model/instructions/ClaimIdentifierWirePayloadEncoderParityTest.kt
@@ -1,0 +1,69 @@
+package org.hyperledger.iroha.sdk.core.model.instructions
+
+import org.hyperledger.iroha.sdk.client.IdentifierResolutionPayload
+import org.hyperledger.iroha.sdk.client.IdentifierResolutionReceipt
+import org.hyperledger.iroha.sdk.core.model.WirePayload
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+/**
+ * Parity test for [ClaimIdentifierWirePayloadEncoder].
+ *
+ * Runs `kotlin-fixture-gen claim-identifier` which encodes a `ClaimIdentifier`
+ * instruction using the current Rust data model and outputs:
+ * - Line 1: full wire payload hex
+ * - Line 2: account I105
+ * - Line 3: receipt payload bytes hex
+ * - Line 4: signature bytes hex
+ */
+class ClaimIdentifierWirePayloadEncoderParityTest {
+
+    @Test
+    fun `claim identifier encoding matches Rust fixture generator`() {
+        val lines = FixtureGeneratorRunner.run("claim-identifier")
+        val rustHex = lines[0]
+        val accountId = lines[1]
+        val receiptPayloadHex = lines[2]
+        val signatureHex = lines[3]
+
+        val dummyPayload = IdentifierResolutionPayload(
+            policyId = "unused",
+            opaqueId = "unused",
+            receiptHash = "unused",
+            uaid = "unused",
+            accountId = accountId,
+            resolvedAtMs = 0L,
+            expiresAtMs = null,
+        )
+        val receipt = IdentifierResolutionReceipt(
+            policyId = "unused",
+            opaqueId = "unused",
+            receiptHash = "unused",
+            uaid = "unused",
+            accountId = accountId,
+            resolvedAtMs = 0L,
+            expiresAtMs = null,
+            backend = "unused",
+            signature = signatureHex,
+            signaturePayloadHex = receiptPayloadHex,
+            signaturePayload = dummyPayload,
+        )
+
+        val instruction = ClaimIdentifierWirePayloadEncoder.encode(accountId, receipt)
+
+        assertEquals("identity::ClaimIdentifier", instruction.name)
+        val wirePayload = assertIs<WirePayload>(instruction.payload)
+        val kotlinHex = FixtureGeneratorRunner.bytesToHex(wirePayload.payloadBytes)
+
+        assertContentEquals(
+            FixtureGeneratorRunner.hexToBytes(rustHex),
+            wirePayload.payloadBytes,
+            "Kotlin ClaimIdentifier encoding must match Rust. " +
+                "If Rust data model changed, update ClaimIdentifierWirePayloadEncoder.\n" +
+                "  Rust:   $rustHex\n" +
+                "  Kotlin: $kotlinHex",
+        )
+    }
+}

--- a/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/core/model/instructions/FixtureGeneratorRunner.kt
+++ b/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/core/model/instructions/FixtureGeneratorRunner.kt
@@ -1,0 +1,56 @@
+package org.hyperledger.iroha.sdk.core.model.instructions
+
+/**
+ * Runs the Rust `kotlin-fixture-gen` binary and returns its stdout lines.
+ *
+ * The binary lives at `tools/kotlin-fixture-gen/` in the Iroha repo root.
+ * If the binary is not built yet, this helper builds it automatically.
+ */
+internal object FixtureGeneratorRunner {
+
+    fun run(subcommand: String): List<String> {
+        val repoRoot = locateRepoRoot()
+        val binary = java.io.File(repoRoot, "target/debug/kotlin-fixture-gen")
+        if (!binary.exists()) {
+            val build = ProcessBuilder("cargo", "build", "-p", "kotlin-fixture-gen")
+                .directory(repoRoot)
+                .redirectErrorStream(true)
+                .start()
+            val buildExit = build.waitFor()
+            require(buildExit == 0) {
+                "cargo build failed (exit $buildExit): ${build.inputStream.bufferedReader().readText()}"
+            }
+        }
+        val process = ProcessBuilder(binary.absolutePath, subcommand)
+            .directory(repoRoot)
+            .redirectErrorStream(false)
+            .start()
+        val stdout = process.inputStream.bufferedReader().readText().trim()
+        val exitCode = process.waitFor()
+        require(exitCode == 0) { "kotlin-fixture-gen $subcommand failed (exit $exitCode)" }
+        require(stdout.isNotBlank()) { "kotlin-fixture-gen $subcommand produced empty output" }
+        return stdout.lines()
+    }
+
+    private fun locateRepoRoot(): java.io.File {
+        var dir = java.io.File("").absoluteFile
+        while (!java.io.File(dir, "Cargo.toml").exists()) {
+            dir = dir.parentFile
+                ?: error("Could not locate Iroha repo root (Cargo.toml) from CWD")
+        }
+        return dir
+    }
+
+    fun hexToBytes(hex: String): ByteArray {
+        val clean = hex.lowercase()
+        require(clean.length % 2 == 0) { "Hex string must have even length" }
+        return ByteArray(clean.length / 2) { i ->
+            val hi = Character.digit(clean[i * 2], 16)
+            val lo = Character.digit(clean[i * 2 + 1], 16)
+            ((hi shl 4) or lo).toByte()
+        }
+    }
+
+    fun bytesToHex(bytes: ByteArray): String =
+        bytes.joinToString("") { "%02x".format(it) }
+}

--- a/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/core/model/instructions/RegisterAccountWirePayloadEncoderParityTest.kt
+++ b/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/core/model/instructions/RegisterAccountWirePayloadEncoderParityTest.kt
@@ -1,0 +1,46 @@
+package org.hyperledger.iroha.sdk.core.model.instructions
+
+import org.hyperledger.iroha.sdk.address.AccountAddress
+import org.hyperledger.iroha.sdk.core.model.WirePayload
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+/**
+ * Parity test for [RegisterAccountWirePayloadEncoder].
+ *
+ * Runs the Rust `kotlin-fixture-gen register-account` binary that encodes the
+ * same `RegisterBox::Account` instruction using the current Rust data model.
+ * If either side changes the struct layout, this test fails.
+ */
+class RegisterAccountWirePayloadEncoderParityTest {
+
+    private val parityPublicKeyHex =
+        "CE7FA46C9DCE7EA4B125E2E36BDB63EA33073E7590AC92816AE1E861B7048B03"
+
+    @Test
+    fun `register account encoding matches Rust fixture generator`() {
+        val lines = FixtureGeneratorRunner.run("register-account")
+        val rustHex = lines[0]
+
+        val rawPublicKey = FixtureGeneratorRunner.hexToBytes(parityPublicKeyHex)
+        val address = AccountAddress.fromAccount(rawPublicKey, "ed25519")
+        val accountId = address.toI105(AccountAddress.DEFAULT_I105_DISCRIMINANT)
+
+        val instruction = RegisterAccountWirePayloadEncoder.encodeRegisterAccount(accountId)
+
+        assertEquals("iroha.register", instruction.name)
+        val wirePayload = assertIs<WirePayload>(instruction.payload)
+        val kotlinHex = FixtureGeneratorRunner.bytesToHex(wirePayload.payloadBytes)
+
+        assertContentEquals(
+            FixtureGeneratorRunner.hexToBytes(rustHex),
+            wirePayload.payloadBytes,
+            "Kotlin RegisterBox encoding must match Rust. " +
+                "If Rust data model changed, update RegisterAccountWirePayloadEncoder.\n" +
+                "  Rust:   $rustHex\n" +
+                "  Kotlin: $kotlinHex",
+        )
+    }
+}

--- a/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/core/model/instructions/TransferWirePayloadEncoderParityTest.kt
+++ b/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/core/model/instructions/TransferWirePayloadEncoderParityTest.kt
@@ -1,0 +1,48 @@
+package org.hyperledger.iroha.sdk.core.model.instructions
+
+import org.hyperledger.iroha.sdk.core.model.WirePayload
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+/**
+ * Parity test for [TransferWirePayloadEncoder].
+ *
+ * Runs `kotlin-fixture-gen transfer-asset` which encodes a `TransferBox::Asset`
+ * instruction using the current Rust data model and outputs:
+ * - Line 1: wire payload hex
+ * - Line 2: asset ID string (`<base58-def>#<i105-account>`)
+ * - Line 3: amount
+ * - Line 4: destination account I105
+ */
+class TransferWirePayloadEncoderParityTest {
+
+    @Test
+    fun `transfer asset encoding matches Rust fixture generator`() {
+        val lines = FixtureGeneratorRunner.run("transfer-asset")
+        val rustHex = lines[0]
+        val assetId = lines[1]
+        val amount = lines[2]
+        val destinationAccountId = lines[3]
+
+        val instruction = TransferWirePayloadEncoder.encodeAssetTransfer(
+            assetId,
+            amount,
+            destinationAccountId,
+        )
+
+        assertEquals("iroha.transfer", instruction.name)
+        val wirePayload = assertIs<WirePayload>(instruction.payload)
+        val kotlinHex = FixtureGeneratorRunner.bytesToHex(wirePayload.payloadBytes)
+
+        assertContentEquals(
+            FixtureGeneratorRunner.hexToBytes(rustHex),
+            wirePayload.payloadBytes,
+            "Kotlin TransferBox encoding must match Rust. " +
+                "If Rust data model changed, update TransferWirePayloadEncoder.\n" +
+                "  Rust:   $rustHex\n" +
+                "  Kotlin: $kotlinHex",
+        )
+    }
+}

--- a/tools/kotlin-fixture-gen/Cargo.toml
+++ b/tools/kotlin-fixture-gen/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "kotlin-fixture-gen"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+iroha_data_model = { path = "../../crates/iroha_data_model", default-features = false, features = ["json", "transparent_api"] }
+iroha_crypto = { path = "../../crates/iroha_crypto" }
+norito = { path = "../../crates/norito" }
+hex = { version = "0.4.3", default-features = false, features = ["std"] }

--- a/tools/kotlin-fixture-gen/src/main.rs
+++ b/tools/kotlin-fixture-gen/src/main.rs
@@ -1,0 +1,143 @@
+/// Generates Norito-encoded fixtures for Kotlin SDK parity tests.
+///
+/// Each subcommand outputs the wire payload hex on the first line,
+/// followed by input parameters the Kotlin encoder needs.
+///
+/// When the Rust data model changes, this binary produces different
+/// bytes, causing the Kotlin parity tests to fail until the
+/// corresponding encoder is updated.
+use std::env;
+
+use iroha_crypto::PublicKey;
+use iroha_data_model::account::{AccountId, NewAccount, OpaqueAccountId};
+use iroha_data_model::asset::{AssetDefinitionId, AssetId};
+use iroha_data_model::domain::DomainId;
+use iroha_data_model::identifier::{
+    IdentifierPolicyId, IdentifierResolutionReceipt, IdentifierResolutionReceiptPayload,
+};
+use iroha_data_model::isi::identifier::ClaimIdentifier;
+use iroha_data_model::isi::register::{Register, RegisterBox};
+use iroha_data_model::isi::transfer::{Transfer, TransferBox};
+use iroha_data_model::name::Name;
+use iroha_data_model::nexus::UniversalAccountId;
+use iroha_crypto::{RamLfeBackend, RamLfeVerificationMode};
+use iroha_data_model::ram_lfe::{RamLfeExecutionReceiptPayload, RamLfeProgramId};
+use iroha_data_model::prelude::Numeric;
+use norito::codec::Encode;
+
+/// Well-known public key shared with the Kotlin parity tests.
+const PARITY_PUBLIC_KEY: &str =
+    "ed0120CE7FA46C9DCE7EA4B125E2E36BDB63EA33073E7590AC92816AE1E861B7048B03";
+
+fn parity_account_id() -> AccountId {
+    let pk: PublicKey = PARITY_PUBLIC_KEY.parse().expect("parse public key");
+    AccountId::new(pk)
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 2 {
+        eprintln!(
+            "Usage: {} <register-account|transfer-asset|claim-identifier>",
+            args[0]
+        );
+        std::process::exit(1);
+    }
+    match args[1].as_str() {
+        "register-account" => emit_register_account(),
+        "transfer-asset" => emit_transfer_asset(),
+        "claim-identifier" => emit_claim_identifier(),
+        other => {
+            eprintln!("Unknown fixture: {other}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn emit_register_account() {
+    let account_id = parity_account_id();
+    let new_account = NewAccount::new(account_id);
+    let register_box = RegisterBox::Account(Register::account(new_account));
+    let encoded = norito::to_bytes(&register_box).expect("encode RegisterBox");
+    println!("{}", hex::encode(encoded));
+}
+
+fn emit_transfer_asset() {
+    let account_id = parity_account_id();
+    let domain: DomainId = "wonderland".parse().unwrap();
+    let name: Name = "rose".parse().unwrap();
+    let asset_def_id = AssetDefinitionId::new(domain, name);
+    let asset_id = AssetId::new(asset_def_id.clone(), account_id.clone());
+    let amount = Numeric::new(100_i64, 0);
+    let destination = account_id.clone();
+
+    let transfer = Transfer::asset_numeric(asset_id, amount, destination);
+    let transfer_box: TransferBox = transfer.into();
+    let encoded = norito::to_bytes(&transfer_box).expect("encode TransferBox");
+
+    // Line 1: wire payload hex
+    println!("{}", hex::encode(encoded));
+    // Line 2: asset ID string (<base58-def>#<i105-account>)
+    println!("{}#{}", asset_def_id, account_id);
+    // Line 3: amount
+    println!("100");
+    // Line 4: destination account I105
+    println!("{}", account_id);
+}
+
+fn emit_claim_identifier() {
+    let account_id = parity_account_id();
+    let policy_id = IdentifierPolicyId::new(
+        "phone".parse().unwrap(),
+        "e164".parse().unwrap(),
+    );
+    let program_id: RamLfeProgramId = "parity_test".parse().unwrap();
+    let dummy_hash = iroha_crypto::Hash::new([0xAB; 32]);
+    let execution = RamLfeExecutionReceiptPayload {
+        program_id,
+        program_digest: dummy_hash,
+        backend: RamLfeBackend::HkdfSha3_512PrfV1,
+        verification_mode: RamLfeVerificationMode::Signed,
+        output_hash: dummy_hash,
+        associated_data_hash: dummy_hash,
+        executed_at_ms: 1_735_000_000_000,
+        expires_at_ms: None,
+    };
+    let opaque_id = OpaqueAccountId::from_hash(dummy_hash);
+    let uaid = UniversalAccountId::from_hash(dummy_hash);
+
+    let receipt_payload = IdentifierResolutionReceiptPayload {
+        policy_id,
+        execution,
+        opaque_id,
+        receipt_hash: dummy_hash,
+        uaid,
+        account_id: account_id.clone(),
+    };
+    let receipt_payload_bytes = receipt_payload.encode();
+
+    // Deterministic signature bytes (64 bytes of 0xCD).
+    let signature_bytes = [0xCD_u8; 64];
+    let signature = iroha_crypto::Signature::from_bytes(&signature_bytes);
+
+    let receipt = IdentifierResolutionReceipt {
+        payload: receipt_payload,
+        signature: Some(signature),
+        proof: None,
+    };
+
+    let claim = ClaimIdentifier {
+        account: account_id.clone(),
+        receipt,
+    };
+    let encoded = norito::to_bytes(&claim).expect("encode ClaimIdentifier");
+
+    // Line 1: full wire payload hex
+    println!("{}", hex::encode(encoded));
+    // Line 2: account I105
+    println!("{}", account_id);
+    // Line 3: receipt payload bytes hex
+    println!("{}", hex::encode(&receipt_payload_bytes));
+    // Line 4: signature bytes hex
+    println!("{}", hex::encode(signature_bytes));
+}


### PR DESCRIPTION
## Fix wire payload encoder parity with Rust data model

### Summary
- **RegisterAccountWirePayloadEncoder**: Remove stale `linked_domains` field encoding — the Rust `NewAccount` struct dropped this field in 996e8a190, causing `400 Norito length mismatch` on self-registration
- **ClaimIdentifierWirePayloadEncoder**: Fix `Signature` encoding — was using `rawByteVecAdapter` (flat bytes) instead of `byteVecAdapter` (per-element length-prefixed `ConstVec<u8>` layout)
- **Parity test infrastructure**: Add `tools/kotlin-fixture-gen` Rust binary and three Kotlin parity tests covering all hand-coded wire payload encoders

### How parity tests work
A small Rust binary (`tools/kotlin-fixture-gen`) encodes `RegisterBox`, `TransferBox`, and `ClaimIdentifier` using the current Rust data model. Three Kotlin tests run it at test time and compare output byte-for-byte against the Kotlin encoders. When a Rust struct changes, the binary produces different bytes, and the Kotlin test fails with a clear message pointing to the encoder that needs updating.

### Verified coverage
Each parity test was verified to catch real drift by temporarily breaking the corresponding encoder:

| Encoder | Bug caught |
|---------|-----------|
| `RegisterAccountWirePayloadEncoder` | Extra `linked_domains` field (6→5 fields) |
| `TransferWirePayloadEncoder` | Dummy trailing field added |
| `ClaimIdentifierWirePayloadEncoder` | Wrong byte vector adapter for `Signature` |
