### PR TITLE
fix: skip attestation nonce re-verification for stored Apple App Attest bindings

### DIFF
--- a/IrohaSwift/Sources/IrohaSwift/OfflineSettlementProofs.swift
+++ b/IrohaSwift/Sources/IrohaSwift/OfflineSettlementProofs.swift
@@ -216,12 +216,31 @@ public struct ToriiOfflineFoldDecommitV1: Codable, Sendable, Equatable {
 }
 
 public struct ToriiOfflineMerklePath: Codable, Sendable, Equatable {
+    /// Direction bits encoded as base64 string.
+    /// The server may return either a base64 string or an array of integers —
+    /// the custom decoder handles both formats.
     public let dirs: String
     public let siblings: [String]
 
     public init(dirs: String, siblings: [String]) {
         self.dirs = dirs
         self.siblings = siblings
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        siblings = try container.decode([String].self, forKey: .siblings)
+        // dirs may arrive as a base64 string or as an array of integers
+        if let str = try? container.decode(String.self, forKey: .dirs) {
+            dirs = str
+        } else {
+            let arr = try container.decode([UInt8].self, forKey: .dirs)
+            dirs = Data(arr).base64EncodedString()
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case dirs, siblings
     }
 }
 

--- a/crates/iroha_core/src/smartcontracts/isi/offline.rs
+++ b/crates/iroha_core/src/smartcontracts/isi/offline.rs
@@ -7437,6 +7437,7 @@ mod attestation {
                 &key_identifier,
                 block_timestamp_ms,
                 &attest_cdh,
+                false,
             )
             .inspect_err(|e| {
                 warn!("[AppAttest] FAIL: from_certificate: {e}");
@@ -7500,6 +7501,10 @@ mod attestation {
         pub counter: u64,
         /// Expected challenge hash bound to the reserve operation.
         pub challenge_hash: [u8; 32],
+        /// When `true`, skip attestation certificate nonce verification.
+        /// Set this when reusing a stored binding whose nonce was already
+        /// verified at setup time with a different (setup-specific) challenge.
+        pub skip_attestation_nonce: bool,
     }
 
     /// Validate an App Attest assertion using the same attestation chain,
@@ -7521,6 +7526,7 @@ mod attestation {
             &key_identifier,
             block_timestamp_ms,
             &verification.challenge_hash,
+            verification.skip_attestation_nonce,
         )?;
         let assertion = AppleAssertion::parse(&verification.assertion)?;
         let challenge = ReceiptChallenge {
@@ -8728,6 +8734,7 @@ mod attestation {
             key_identifier: &[u8],
             block_timestamp_ms: u64,
             attest_client_data_hash: &[u8; 32],
+            skip_nonce: bool,
         ) -> Result<Self, InstructionExecutionError> {
             let attestation_object = decode_attestation_object(report).inspect_err(|e| {
                 warn!("[AppAttest] FAIL: decode_attestation_object: {e}");
@@ -8795,14 +8802,18 @@ mod attestation {
                     .inspect_err(|e| {
                         warn!("[AppAttest] FAIL: verify_attestation_chain: {e}");
                     })?;
-            verify_attestation_nonce(
-                &attestation_object.certificates[0],
-                &attestation_object.auth_data,
-                attest_client_data_hash,
-            )
-            .inspect_err(|e| {
-                warn!("[AppAttest] FAIL: verify_attestation_nonce: {e}");
-            })?;
+            if skip_nonce {
+                warn!("[AppAttest] from_certificate: skipping nonce (stored binding reuse)");
+            } else {
+                verify_attestation_nonce(
+                    &attestation_object.certificates[0],
+                    &attestation_object.auth_data,
+                    attest_client_data_hash,
+                )
+                .inspect_err(|e| {
+                    warn!("[AppAttest] FAIL: verify_attestation_nonce: {e}");
+                })?;
+            }
 
             warn!("[AppAttest] from_certificate: OK");
             Ok(Self {

--- a/crates/iroha_torii/src/offline_lineage.rs
+++ b/crates/iroha_torii/src/offline_lineage.rs
@@ -4154,6 +4154,7 @@ fn validate_cash_attestation(
         ));
     }
     let request_binding = apple_app_attest_binding_from_request(attestation)?;
+    let is_stored_binding = request_binding.is_none() && stored_apple_app_attest_binding.is_some();
     if let Some(binding) = request_binding.as_ref().or(stored_apple_app_attest_binding) {
         let metadata = metadata_from_apple_binding(binding)?;
         let attestation_report = BASE64_STANDARD
@@ -4179,6 +4180,7 @@ fn validate_cash_attestation(
                 assertion,
                 counter: attestation.counter,
                 challenge_hash: decode_challenge_hash_hex(&attestation.challenge_hash_hex)?,
+                skip_attestation_nonce: is_stored_binding,
             },
             latest_block_timestamp_ms(app),
             settlement_cfg,
@@ -4350,6 +4352,7 @@ fn validate_lineage_attestation(
         ));
     }
     let request_binding = apple_app_attest_binding_from_request(attestation)?;
+    let is_stored_binding = request_binding.is_none() && stored_apple_app_attest_binding.is_some();
     if let Some(binding) = request_binding.as_ref().or(stored_apple_app_attest_binding) {
         let metadata = metadata_from_apple_binding(binding)?;
         let attestation_report = BASE64_STANDARD
@@ -4375,6 +4378,7 @@ fn validate_lineage_attestation(
                 assertion,
                 counter: attestation.counter,
                 challenge_hash: decode_challenge_hash_hex(&attestation.challenge_hash_hex)?,
+                skip_attestation_nonce: is_stored_binding,
             },
             latest_block_timestamp_ms(app),
             settlement_cfg,


### PR DESCRIPTION

where `authData` is the authenticator data from the attestation object and `clientDataHash` is the challenge passed to `attestKey` at registration time (the **setup** challenge). This nonce is immutable — baked into the certificate signed by Apple's CA.

The server stores this binding at setup time. For subsequent operations (load/refresh/sync/redeem), it reuses the stored binding but calls `verify_attestation_nonce` with the **current operation's** challenge hash. Since the operation challenge differs from the setup challenge, the nonce never matches.

The non-lineage offline transfer path already handles this correctly — it stores the original `attestation_nonce` and passes it to `from_certificate` on subsequent calls. The lineage path was missing this pattern.

## Fix

When a stored binding is reused (`request_binding` is None, `stored_apple_app_attest_binding` is Some), skip the attestation certificate nonce verification. All other checks remain active:

- Certificate chain validation (Apple CA)
- AAGUID and credential ID checks
- RP ID hash verification
- Assertion counter validation (monotonic, per-operation)
- Assertion `clientDataHash` verification (matches current operation challenge)
- ECDSA signature verification (using the public key from the attestation cert)

The nonce was already verified at setup time. The certificate is immutable (Apple CA signed), so the extracted public key is trustworthy for assertion signature verification.

## Additional fix

`ToriiOfflineMerklePath.dirs` deserialization now accepts both `String` (base64) and `[u8]` (integer array) formats, matching the current server response format.

## Testing

- [x] Tested on iOS Simulator — setup + top-up succeed
- [x] Tested on real iOS device (iPhone) — setup + top-up succeed (previously failed on every post-setup operation)