### PR TITLE
Add account alias resolution for Android and Kotlin SDKs

### DIFF
--- a/java/iroha_android/README.md
+++ b/java/iroha_android/README.md
@@ -763,6 +763,21 @@ response.rejectCode().ifPresent(code -> {
 });
 ```
 
+### Resolving Account Aliases
+
+`HttpClientTransport.resolveAccountAlias(...)` posts to `/v1/aliases/resolve` and
+returns an `Optional<AccountAliasResolution>`. An `Optional.empty()` value
+indicates the node responded with HTTP 404 for an unknown alias; other failures
+complete the future exceptionally.
+
+```java
+Optional<AccountAliasResolution> resolved =
+    client.resolveAccountAlias("some_alias@universal").join();
+resolved.ifPresentOrElse(
+    resolution -> System.out.println("account: " + resolution.accountId()),
+    () -> System.out.println("alias not found"));
+```
+
 ### Key Manager Defaults
 
 `IrohaKeyManager.withDefaultProviders()` constructs a manager that prefers

--- a/java/iroha_android/android/src/test/java/org/hyperledger/iroha/android/client/okhttp/HttpClientTransportOkHttpTests.java
+++ b/java/iroha_android/android/src/test/java/org/hyperledger/iroha/android/client/okhttp/HttpClientTransportOkHttpTests.java
@@ -2,17 +2,23 @@ package org.hyperledger.iroha.android.client.okhttp;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
+import org.hyperledger.iroha.android.client.AccountAliasResolution;
 import org.hyperledger.iroha.android.client.ClientConfig;
 import org.hyperledger.iroha.android.client.ClientObserver;
 import org.hyperledger.iroha.android.client.ClientResponse;
@@ -88,6 +94,97 @@ public final class HttpClientTransportOkHttpTests {
       assertEquals("application/x-norito, application/json", recorded.getHeader("Accept"));
       assertEquals("ok", recorded.getHeader("X-Test"));
       assertArrayEquals(SignedTransactionEncoder.encodeVersioned(tx), recorded.getBody().readByteArray());
+    }
+  }
+
+  @Test
+  public void resolveAccountAliasParsesSuccessResponse() throws Exception {
+    try (MockWebServer server = new MockWebServer()) {
+      server.enqueue(
+          new MockResponse()
+              .setResponseCode(200)
+              .setBody(
+                  "{\"alias\":\"alice@universal\","
+                      + "\"account_id\":\"sorauaccount\","
+                      + "\"index\":3,"
+                      + "\"source\":\"directory\"}"));
+      server.start();
+
+      final ClientConfig config =
+          ClientConfig.builder()
+              .setBaseUri(server.url("/").uri())
+              .setRequestTimeout(Duration.ofSeconds(2))
+              .build();
+      final OkHttpTransportExecutor executor = new OkHttpTransportExecutor(new OkHttpClient());
+      final org.hyperledger.iroha.android.client.HttpClientTransport transport =
+          new org.hyperledger.iroha.android.client.HttpClientTransport(executor, config);
+
+      final Optional<AccountAliasResolution> response =
+          transport.resolveAccountAlias("alice@universal").get(2, TimeUnit.SECONDS);
+      assertTrue("account alias resolution must be present", response.isPresent());
+      final AccountAliasResolution resolution = response.orElseThrow();
+      assertEquals("alice@universal", resolution.alias());
+      assertEquals("sorauaccount", resolution.accountId());
+      assertEquals(Long.valueOf(3L), resolution.index());
+      assertEquals("directory", resolution.source());
+
+      final RecordedRequest recorded = server.takeRequest(1, TimeUnit.SECONDS);
+      assertNotNull(recorded);
+      assertEquals("POST", recorded.getMethod());
+      assertEquals("/v1/aliases/resolve", recorded.getPath());
+      final String body = recorded.getBody().readString(StandardCharsets.UTF_8);
+      assertTrue(
+          "request body must carry the alias literal: " + body,
+          body.contains("\"alias\":\"alice@universal\""));
+    }
+  }
+
+  @Test
+  public void resolveAccountAliasMapsNotFoundToEmptyOptional() throws Exception {
+    try (MockWebServer server = new MockWebServer()) {
+      server.enqueue(new MockResponse().setResponseCode(404));
+      server.start();
+
+      final ClientConfig config =
+          ClientConfig.builder()
+              .setBaseUri(server.url("/").uri())
+              .setRequestTimeout(Duration.ofSeconds(2))
+              .build();
+      final OkHttpTransportExecutor executor = new OkHttpTransportExecutor(new OkHttpClient());
+      final org.hyperledger.iroha.android.client.HttpClientTransport transport =
+          new org.hyperledger.iroha.android.client.HttpClientTransport(executor, config);
+
+      final Optional<AccountAliasResolution> response =
+          transport.resolveAccountAlias("missing@universal").get(2, TimeUnit.SECONDS);
+      assertFalse("404 must map to Optional.empty", response.isPresent());
+
+      final RecordedRequest recorded = server.takeRequest(1, TimeUnit.SECONDS);
+      assertNotNull(recorded);
+      assertEquals("POST", recorded.getMethod());
+      assertEquals("/v1/aliases/resolve", recorded.getPath());
+    }
+  }
+
+  @Test
+  public void resolveAccountAliasFailsOnMalformedJson() throws Exception {
+    try (MockWebServer server = new MockWebServer()) {
+      server.enqueue(new MockResponse().setResponseCode(200).setBody("not json"));
+      server.start();
+
+      final ClientConfig config =
+          ClientConfig.builder()
+              .setBaseUri(server.url("/").uri())
+              .setRequestTimeout(Duration.ofSeconds(2))
+              .build();
+      final OkHttpTransportExecutor executor = new OkHttpTransportExecutor(new OkHttpClient());
+      final org.hyperledger.iroha.android.client.HttpClientTransport transport =
+          new org.hyperledger.iroha.android.client.HttpClientTransport(executor, config);
+
+      final ExecutionException ex =
+          assertThrows(
+              ExecutionException.class,
+              () -> transport.resolveAccountAlias("alice@universal").get(2, TimeUnit.SECONDS));
+      assertNotNull(ex.getCause());
     }
   }
 

--- a/java/iroha_android/src/main/java/org/hyperledger/iroha/android/client/AccountAliasJsonParser.java
+++ b/java/iroha_android/src/main/java/org/hyperledger/iroha/android/client/AccountAliasJsonParser.java
@@ -1,0 +1,71 @@
+package org.hyperledger.iroha.android.client;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/** Minimal JSON parser for Torii account alias resolution responses. */
+public final class AccountAliasJsonParser {
+
+  private AccountAliasJsonParser() {}
+
+  public static AccountAliasResolution parseResolution(final byte[] payload) {
+    final Map<String, Object> root =
+        expectObject(parse(payload, "account alias resolution"), "account alias resolution");
+    return new AccountAliasResolution(
+        requiredString(root.get("alias"), "account alias resolution.alias"),
+        requiredString(root.get("account_id"), "account alias resolution.account_id"),
+        root.containsKey("index")
+            ? asOptionalLong(root.get("index"), "account alias resolution.index")
+            : null,
+        optionalString(root.get("source")));
+  }
+
+  private static Object parse(final byte[] payload, final String context) {
+    if (payload == null || payload.length == 0) {
+      throw new IllegalStateException(context + " returned an empty payload");
+    }
+    final String json = new String(payload, StandardCharsets.UTF_8).trim();
+    if (json.isEmpty()) {
+      throw new IllegalStateException(context + " returned a blank payload");
+    }
+    return JsonParser.parse(json);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> expectObject(final Object value, final String path) {
+    if (!(value instanceof Map<?, ?>)) {
+      throw new IllegalStateException(path + " must be a JSON object");
+    }
+    return (Map<String, Object>) value;
+  }
+
+  private static String requiredString(final Object value, final String path) {
+    final String string = optionalString(value);
+    if (string == null || string.isBlank()) {
+      throw new IllegalStateException(path + " must be a non-empty string");
+    }
+    return string;
+  }
+
+  private static String optionalString(final Object value) {
+    if (value == null) {
+      return null;
+    }
+    final String string = value instanceof String ? (String) value : String.valueOf(value);
+    final String trimmed = string.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+
+  private static Long asOptionalLong(final Object value, final String path) {
+    if (value == null) {
+      return null;
+    }
+    if (!(value instanceof Number number)) {
+      throw new IllegalStateException(path + " must be a number");
+    }
+    if (number instanceof Float || number instanceof Double) {
+      throw new IllegalStateException(path + " must be an integer");
+    }
+    return number.longValue();
+  }
+}

--- a/java/iroha_android/src/main/java/org/hyperledger/iroha/android/client/HttpClientTransport.java
+++ b/java/iroha_android/src/main/java/org/hyperledger/iroha/android/client/HttpClientTransport.java
@@ -446,6 +446,17 @@ public final class HttpClientTransport implements IrohaClient {
         "governance contract");
   }
 
+  /** Resolves an account alias via `POST /v1/aliases/resolve`. */
+  @Override
+  public CompletableFuture<Optional<AccountAliasResolution>> resolveAccountAlias(
+      final String alias) {
+    final String normalizedAlias = normalizeNonBlank(alias, "alias");
+    final byte[] body = encodeJsonBody(Map.of("alias", normalizedAlias));
+    final TransportRequest request = buildJsonPostRequest("/v1/aliases/resolve", body);
+    return fetchJsonAllowingNotFound(
+        request, AccountAliasJsonParser::parseResolution, "account alias resolve");
+  }
+
   /** Creates a transport backed by the platform HTTP executor (OkHttp on Android). */
   public static HttpClientTransport createDefault(final ClientConfig config) {
     return new HttpClientTransport(PlatformHttpTransportExecutor.createDefault(), config);

--- a/java/iroha_android/src/main/java/org/hyperledger/iroha/android/client/IrohaClient.java
+++ b/java/iroha_android/src/main/java/org/hyperledger/iroha/android/client/IrohaClient.java
@@ -1,6 +1,7 @@
 package org.hyperledger.iroha.android.client;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.hyperledger.iroha.android.tx.SignedTransaction;
 
@@ -33,6 +34,21 @@ public interface IrohaClient {
     final CompletableFuture<Map<String, Object>> future = new CompletableFuture<>();
     future.completeExceptionally(
         new UnsupportedOperationException("waitForTransactionStatusStream not supported"));
+    return future;
+  }
+
+  /**
+   * Resolves an account alias literal against the node's alias registry via
+   * `POST /v1/aliases/resolve`.
+   *
+   * <p>The returned future resolves to {@link Optional#empty()} when the node responds with
+   * HTTP 404. Implementations that cannot reach a node should fail the future exceptionally.
+   */
+  default CompletableFuture<Optional<AccountAliasResolution>> resolveAccountAlias(
+      final String alias) {
+    final CompletableFuture<Optional<AccountAliasResolution>> future = new CompletableFuture<>();
+    future.completeExceptionally(
+        new UnsupportedOperationException("resolveAccountAlias not supported by this client"));
     return future;
   }
 }

--- a/java/iroha_android/src/main/java/org/hyperledger/iroha/android/client/transport/UrlConnectionTransportExecutor.java
+++ b/java/iroha_android/src/main/java/org/hyperledger/iroha/android/client/transport/UrlConnectionTransportExecutor.java
@@ -149,7 +149,14 @@ public final class UrlConnectionTransportExecutor
       throws IOException {
     if (status >= 400) {
       final InputStream error = connection.getErrorStream();
-      return error != null ? error : connection.getInputStream();
+      if (error != null) {
+        return error;
+      }
+      try {
+        return connection.getInputStream();
+      } catch (final IOException ignored) {
+        return null;
+      }
     }
     return connection.getInputStream();
   }

--- a/java/iroha_android/src/test/java/org/hyperledger/iroha/android/client/HttpClientTransportTests.java
+++ b/java/iroha_android/src/test/java/org/hyperledger/iroha/android/client/HttpClientTransportTests.java
@@ -97,6 +97,9 @@ public final class HttpClientTransportTests {
     callContractRequestParsesResponse();
     callContractRejectsAmbiguousTarget();
     governanceContractRequestParsesResponse();
+    resolveAccountAliasRequestParsesResponse();
+    resolveAccountAliasAllowsNotFound();
+    resolveAccountAliasFailsOnMalformedJson();
     identifierNormalizationCanonicalizesInputs();
     identifierResolveRequestBuilderCanonicalizesPolicyInput();
     identifierBfvEnvelopeBuilderProducesDeterministicCiphertext();
@@ -1738,6 +1741,86 @@ public final class HttpClientTransportTests {
     assert request.uri().toString().equals("https://torii.example/api/v1/gov/contracts/" + contractAddress)
         : "Governance contract URI mismatch";
     assert "GET".equals(request.method()) : "Governance contract must use GET";
+  }
+
+  private static void resolveAccountAliasRequestParsesResponse() {
+    final String accountId =
+        "sorauロ1Npテユヱヌq11pウリ2ア5ヌヲiCJKjRヤzキNMNニケユPCウルFvオE9LBLB";
+    final String json =
+        "{"
+            + "\"alias\":\"alice@universal\","
+            + "\"account_id\":\""
+            + accountId
+            + "\","
+            + "\"index\":7,"
+            + "\"source\":\"directory\""
+            + "}";
+    final StubResponseExecutor executor =
+        new StubResponseExecutor(200, json.getBytes(StandardCharsets.UTF_8));
+    final HttpClientTransport transport =
+        HttpClientTransport.withExecutor(
+            executor,
+            ClientConfig.builder().setBaseUri(URI.create("https://torii.example/api")).build());
+
+    final Optional<AccountAliasResolution> response =
+        transport.resolveAccountAlias("alice@universal").join();
+
+    assert response.isPresent() : "Account alias resolution should be present";
+    final AccountAliasResolution resolution = response.orElseThrow();
+    assert "alice@universal".equals(resolution.alias()) : "Alias mismatch";
+    assert accountId.equals(resolution.accountId()) : "Account id mismatch";
+    assert Long.valueOf(7L).equals(resolution.index()) : "Index mismatch";
+    assert "directory".equals(resolution.source()) : "Source mismatch";
+
+    final TransportRequest request = executor.lastRequest();
+    assert request != null : "Account alias resolve request must be captured";
+    assert "POST".equals(request.method()) : "Account alias resolve must use POST";
+    assert request.uri().toString().equals("https://torii.example/api/v1/aliases/resolve")
+        : "Account alias resolve URI mismatch";
+    assert request.headers().getOrDefault("Content-Type", List.of()).contains("application/json")
+        : "Account alias resolve must send JSON";
+    assert readBody(request).equals("{\"alias\":\"alice@universal\"}")
+        : "Account alias resolve payload mismatch";
+  }
+
+  private static void resolveAccountAliasAllowsNotFound() {
+    final StubResponseExecutor executor = new StubResponseExecutor(404, new byte[0], "not found");
+    final HttpClientTransport transport =
+        HttpClientTransport.withExecutor(
+            executor,
+            ClientConfig.builder().setBaseUri(URI.create("https://torii.example")).build());
+
+    final Optional<AccountAliasResolution> response =
+        transport.resolveAccountAlias("missing@universal").join();
+    assert response.isEmpty() : "404 account alias resolution should return Optional.empty";
+
+    final TransportRequest request = executor.lastRequest();
+    assert request != null : "Account alias resolve request must be captured";
+    assert request.uri().toString().equals("https://torii.example/v1/aliases/resolve")
+        : "Account alias resolve URI mismatch";
+    assert readBody(request).equals("{\"alias\":\"missing@universal\"}")
+        : "Account alias resolve payload mismatch";
+  }
+
+  private static void resolveAccountAliasFailsOnMalformedJson() {
+    final StubResponseExecutor executor =
+        new StubResponseExecutor(200, "not json".getBytes(StandardCharsets.UTF_8));
+    final HttpClientTransport transport =
+        HttpClientTransport.withExecutor(
+            executor,
+            ClientConfig.builder().setBaseUri(URI.create("https://torii.example")).build());
+
+    final CompletableFuture<Optional<AccountAliasResolution>> future =
+        transport.resolveAccountAlias("alice@universal");
+    boolean threw = false;
+    try {
+      future.join();
+    } catch (final java.util.concurrent.CompletionException ex) {
+      threw = true;
+    }
+    assert threw : "Malformed JSON must complete exceptionally";
+    assert future.isCompletedExceptionally()
+        : "Future must be completed exceptionally for malformed JSON";
   }
 
   private static void identifierNormalizationCanonicalizesInputs() {

--- a/java/iroha_android/src/test/java/org/hyperledger/iroha/android/client/transport/UrlConnectionTransportExecutorTests.java
+++ b/java/iroha_android/src/test/java/org/hyperledger/iroha/android/client/transport/UrlConnectionTransportExecutorTests.java
@@ -1,0 +1,59 @@
+package org.hyperledger.iroha.android.client.transport;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+
+public final class UrlConnectionTransportExecutorTests {
+
+  @Test
+  public void executeReturns404WithEmptyBodyWhenServerSendsNoContent() throws Exception {
+    try (ServerSocket server = new ServerSocket(0)) {
+      final int port = server.getLocalPort();
+      final Thread serverThread =
+          new Thread(
+              () -> {
+                try (Socket socket = server.accept()) {
+                  final InputStream input = socket.getInputStream();
+                  final StringBuilder sb = new StringBuilder();
+                  while (true) {
+                    final int b = input.read();
+                    if (b == -1) break;
+                    sb.append((char) b);
+                    if (sb.toString().endsWith("\r\n\r\n")) break;
+                  }
+                  final OutputStream out = socket.getOutputStream();
+                  out.write(
+                      "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                          .getBytes(StandardCharsets.UTF_8));
+                  out.flush();
+                } catch (final Exception ignored) {
+                }
+              });
+      serverThread.setDaemon(true);
+      serverThread.start();
+
+      final UrlConnectionTransportExecutor executor = new UrlConnectionTransportExecutor();
+      final TransportRequest request =
+          TransportRequest.builder()
+              .setMethod("POST")
+              .setUri(URI.create("http://localhost:" + port + "/v1/aliases/resolve"))
+              .addHeader("Content-Type", "application/json")
+              .setBody("{\"alias\":\"missing@test\"}".getBytes(StandardCharsets.UTF_8))
+              .build();
+
+      final TransportResponse response = executor.execute(request).get();
+
+      assertEquals("Status code should be 404", 404, response.statusCode());
+      assertEquals("Body should be empty for 404 with Content-Length: 0", 0, response.body().length);
+
+      serverThread.join(2000);
+    }
+  }
+}

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -152,6 +152,24 @@ val tunedManager = IrohaKeyManager.withDefaultProviders(
 and is software-only in this SDK pass, so hardware/StrongBox preferences fail
 fast instead of silently downgrading.
 
+## Resolving Account Aliases
+
+`HttpClientTransport.resolveAccountAlias` posts to Torii's `/v1/aliases/resolve`
+endpoint and returns the mapped account id. Unknown aliases surface as
+`Optional.empty()` without throwing:
+
+```kotlin
+val client = HttpClientTransport.createDefault(config)
+
+val resolved = client.resolveAccountAlias("some_alias@universal").join()
+if (resolved.isPresent) {
+    val record = resolved.get()
+    println("account_id=${record.accountId} source=${record.source}")
+} else {
+    println("alias not found")
+}
+```
+
 ## Motivation
 
 `core-jvm` now ships typed builders for the first dedicated RWA instruction

--- a/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/client/AccountAliasJsonParser.kt
+++ b/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/client/AccountAliasJsonParser.kt
@@ -1,0 +1,49 @@
+package org.hyperledger.iroha.sdk.client
+
+import java.nio.charset.StandardCharsets
+
+/** Minimal JSON parser for account alias resolution payloads. */
+object AccountAliasJsonParser {
+
+    @JvmStatic
+    fun parseResolution(payload: ByteArray): AccountAliasResolution {
+        val root = expectObject(parse(payload, "account alias resolution"), "account alias resolution")
+        return AccountAliasResolution(
+            requiredString(root["alias"], "account alias resolution.alias"),
+            requiredString(root["account_id"], "account alias resolution.account_id"),
+            if (root.containsKey("index")) asOptionalLong(root["index"], "account alias resolution.index") else null,
+            optionalString(root["source"]),
+        )
+    }
+
+    private fun parse(payload: ByteArray?, context: String): Any? {
+        check(payload != null && payload.isNotEmpty()) { "$context returned an empty payload" }
+        val json = String(payload, StandardCharsets.UTF_8).trim()
+        check(json.isNotEmpty()) { "$context returned a blank payload" }
+        return JsonParser.parse(json)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun expectObject(value: Any?, path: String): Map<String, Any?> {
+        check(value is Map<*, *>) { "$path must be a JSON object" }
+        return value as Map<String, Any?>
+    }
+
+    private fun requiredString(value: Any?, path: String): String {
+        val string = optionalString(value)
+        check(!string.isNullOrBlank()) { "$path must be a non-empty string" }
+        return string.trim()
+    }
+
+    private fun optionalString(value: Any?): String? {
+        if (value == null) return null
+        return if (value is String) value else value.toString()
+    }
+
+    private fun asOptionalLong(value: Any?, path: String): Long? {
+        if (value == null) return null
+        check(value is Number) { "$path must be a number" }
+        check(value !is Float && value !is Double) { "$path must be an integer" }
+        return value.toLong()
+    }
+}

--- a/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/client/HttpClientTransport.kt
+++ b/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/client/HttpClientTransport.kt
@@ -118,6 +118,12 @@ class HttpClientTransport(
 
     fun resolveIdentifier(policyId: String, input: String?, encryptedInputHex: String?): CompletableFuture<Optional<IdentifierResolutionReceipt>> = resolveIdentifier(buildIdentifierResolveRequest(policyId, input, encryptedInputHex))
 
+    override fun resolveAccountAlias(alias: String): CompletableFuture<Optional<AccountAliasResolution>> {
+        val normalizedAlias = normalizeNonBlank(alias, "alias")
+        val body = encodeJsonBody(linkedMapOf("alias" to normalizedAlias))
+        return fetchJsonAllowingNotFound(buildJsonPostRequest("/v1/aliases/resolve", body), AccountAliasJsonParser::parseResolution, "account alias resolve")
+    }
+
     fun issueIdentifierClaimReceipt(accountId: String, requestBody: IdentifierResolveRequest): CompletableFuture<Optional<IdentifierResolutionReceipt>> {
         val normalizedAccountId = normalizeNonBlank(accountId, "accountId")
         val body = encodeJsonBody(buildIdentifierResolvePayload(requestBody.policyId, requestBody.input, requestBody.encryptedInputHex))

--- a/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/client/IrohaClient.kt
+++ b/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/client/IrohaClient.kt
@@ -1,5 +1,6 @@
 package org.hyperledger.iroha.sdk.client
 
+import java.util.Optional
 import java.util.concurrent.CompletableFuture
 import org.hyperledger.iroha.sdk.tx.SignedTransaction
 
@@ -26,6 +27,20 @@ interface IrohaClient {
         val future = CompletableFuture<Map<String, Any>>()
         future.completeExceptionally(
             UnsupportedOperationException("waitForTransactionStatus not supported")
+        )
+        return future
+    }
+
+    /**
+     * Resolves an account alias to its underlying Iroha account id via Torii's
+     * `/v1/aliases/resolve` endpoint.
+     *
+     * The default implementation reports that the operation is unsupported.
+     */
+    fun resolveAccountAlias(alias: String): CompletableFuture<Optional<AccountAliasResolution>> {
+        val future = CompletableFuture<Optional<AccountAliasResolution>>()
+        future.completeExceptionally(
+            UnsupportedOperationException("resolveAccountAlias not supported by this client")
         )
         return future
     }

--- a/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/client/transport/UrlConnectionTransportExecutor.kt
+++ b/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/client/transport/UrlConnectionTransportExecutor.kt
@@ -107,7 +107,12 @@ class UrlConnectionTransportExecutor(
         private fun responseStream(connection: HttpURLConnection, status: Int): InputStream? {
             if (status >= 400) {
                 val error = connection.errorStream
-                return error ?: connection.inputStream
+                if (error != null) return error
+                return try {
+                    connection.inputStream
+                } catch (_: IOException) {
+                    null
+                }
             }
             return connection.inputStream
         }

--- a/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/client/HttpClientTransportTest.kt
+++ b/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/client/HttpClientTransportTest.kt
@@ -219,6 +219,77 @@ class HttpClientTransportTest {
         assertEquals(0, request.body.size)
     }
 
+    @Test
+    fun resolveAccountAliasParsesSuccessfulResponse() {
+        val executor = StubResponseExecutor(
+            statusCode = 200,
+            body = """
+                {
+                  "alias": "alice@universal",
+                  "account_id": "aid:alice-123",
+                  "index": 42,
+                  "source": "directory"
+                }
+            """.trimIndent().toByteArray(StandardCharsets.UTF_8),
+        )
+        val transport = HttpClientTransport.withExecutor(
+            executor = executor,
+            config = ClientConfig.builder().setBaseUri(URI.create("https://torii.example/api")).build(),
+        )
+
+        val response = transport.resolveAccountAlias("alice@universal").join()
+
+        assertTrue(response.isPresent)
+        val parsed = response.get()
+        assertEquals("alice@universal", parsed.alias)
+        assertEquals("aid:alice-123", parsed.accountId)
+        assertEquals(42L, parsed.index)
+        assertEquals("directory", parsed.source)
+
+        val request = executor.lastRequest
+        assertNotNull(request)
+        assertEquals("POST", request.method)
+        assertEquals("https://torii.example/api/v1/aliases/resolve", request.uri.toString())
+        @Suppress("UNCHECKED_CAST")
+        val payload = JsonParser.parse(readBody(request)) as Map<String, Any?>
+        assertEquals("alice@universal", payload["alias"])
+        assertEquals(1, payload.size)
+    }
+
+    @Test
+    fun resolveAccountAliasReturnsEmptyOnNotFound() {
+        val executor = StubResponseExecutor(
+            statusCode = 404,
+            body = byteArrayOf(),
+        )
+        val transport = HttpClientTransport.withExecutor(
+            executor = executor,
+            config = ClientConfig.builder().setBaseUri(URI.create("https://torii.example/api")).build(),
+        )
+
+        val response = transport.resolveAccountAlias("missing@universal").join()
+
+        assertFalse(response.isPresent)
+        assertNull(response.orElse(null))
+    }
+
+    @Test
+    fun resolveAccountAliasPropagatesMalformedJson() {
+        val executor = StubResponseExecutor(
+            statusCode = 200,
+            body = "not a json object".toByteArray(StandardCharsets.UTF_8),
+        )
+        val transport = HttpClientTransport.withExecutor(
+            executor = executor,
+            config = ClientConfig.builder().setBaseUri(URI.create("https://torii.example/api")).build(),
+        )
+
+        val error = assertFailsWith<java.util.concurrent.ExecutionException> {
+            transport.resolveAccountAlias("alice@universal").get()
+        }
+        assertNotNull(error.cause)
+    }
+
     private fun readBody(request: TransportRequest): String =
         String(request.body, StandardCharsets.UTF_8)
 

--- a/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/client/transport/UrlConnectionTransportExecutorTest.kt
+++ b/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/client/transport/UrlConnectionTransportExecutorTest.kt
@@ -1,0 +1,49 @@
+package org.hyperledger.iroha.sdk.client.transport
+
+import java.net.ServerSocket
+import java.net.URI
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class UrlConnectionTransportExecutorTest {
+
+    @Test
+    fun executeReturns404WithEmptyBodyWhenServerSendsNoContent() {
+        ServerSocket(0).use { server ->
+            val port = server.localPort
+            val serverThread = Thread {
+                server.accept().use { socket ->
+                    val input = socket.getInputStream()
+                    val sb = StringBuilder()
+                    while (true) {
+                        val b = input.read()
+                        if (b == -1) break
+                        sb.append(b.toChar())
+                        if (sb.endsWith("\r\n\r\n")) break
+                    }
+                    val out = socket.getOutputStream()
+                    out.write("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".toByteArray())
+                    out.flush()
+                }
+            }
+            serverThread.isDaemon = true
+            serverThread.start()
+
+            val executor = UrlConnectionTransportExecutor()
+            val request = TransportRequest.builder()
+                .setMethod("POST")
+                .setUri(URI.create("http://localhost:$port/v1/aliases/resolve"))
+                .addHeader("Content-Type", "application/json")
+                .setBody("""{"alias":"missing@test"}""".toByteArray())
+                .build()
+
+            val response = executor.execute(request).get()
+
+            assertEquals(404, response.statusCode, "Status code should be 404")
+            assertTrue(response.body.isEmpty(), "Body should be empty for 404 with Content-Length: 0")
+
+            serverThread.join(2000)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `resolveAccountAlias()` to `HttpClientTransport` and `IrohaClient` in both Java and Kotlin SDKs, calling Torii's `POST /v1/aliases/resolve` endpoint
- Introduce `AccountAliasJsonParser` (Java) and `AccountAliasJsonParser.kt` (Kotlin) to parse alias resolution responses into `AccountAliasResolution` records
- Fix `UrlConnectionTransportExecutor` crash when the server returns HTTP 404 with no response body (null `InputStream`)
- Add tests for success, 404→`Optional.empty()`, and malformed JSON cases across OkHttp, `HttpClientTransport`, and `UrlConnectionTransportExecutor`
- Document usage in both Java and Kotlin READMEs

## Details

The alias resolution API accepts an alias string (e.g. `"alice@universal"`), posts it to `/v1/aliases/resolve`, and returns an `Optional<AccountAliasResolution>`. HTTP 404 maps to `Optional.empty()`; other non-2xx responses complete the future exceptionally.