### PR TITLE
fix(offline): refund redeem back to asset controller, not tx authority

### DIFF
--- a/IrohaSwift/Sources/IrohaSwift/OfflineCashModels.swift
+++ b/IrohaSwift/Sources/IrohaSwift/OfflineCashModels.swift
@@ -658,9 +658,46 @@ public enum ToriiOfflineCashCodec {
         return digest.map { String(format: "%02x", $0) }.joined()
     }
 
+    /// Canonicalizes an amount string to match the Rust `Numeric::Display` format,
+    /// which preserves the input's decimal scale (e.g. "1.00" stays "1.00", not "1").
     public static func canonicalAmountString(_ rawValue: String) throws -> String {
-        let parsed = try parseAmount(rawValue)
-        return NSDecimalNumber(decimal: parsed).stringValue
+        let trimmed = rawValue
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: ",", with: "")
+        guard !trimmed.isEmpty else {
+            throw ToriiOfflineAmountError.invalidAmount(rawValue)
+        }
+        let negative = trimmed.hasPrefix("-")
+        var digits = trimmed
+        if digits.hasPrefix("+") || digits.hasPrefix("-") { digits.removeFirst() }
+        var scale = 0
+        var mantissa: [Character] = []
+        var seenDot = false
+        for ch in digits {
+            if ch == "." {
+                if seenDot { throw ToriiOfflineAmountError.invalidAmount(rawValue) }
+                seenDot = true
+                continue
+            }
+            guard ch.isASCII, ch.isNumber else {
+                throw ToriiOfflineAmountError.invalidAmount(rawValue)
+            }
+            mantissa.append(ch)
+            if seenDot { scale += 1 }
+        }
+        guard scale <= 28 else { throw ToriiOfflineAmountError.invalidAmount(rawValue) }
+        while mantissa.count > 1 && mantissa.first == "0" { mantissa.removeFirst() }
+        if mantissa.isEmpty { mantissa = ["0"] }
+        if scale == 0 {
+            let body = String(mantissa)
+            return negative && body != "0" ? "-" + body : body
+        }
+        while mantissa.count <= scale { mantissa.insert("0", at: 0) }
+        let splitAt = mantissa.count - scale
+        let intPart = String(mantissa[0..<splitAt])
+        let fracPart = String(mantissa[splitAt..<mantissa.count])
+        let body = "\(intPart).\(fracPart)"
+        return negative && !mantissa.allSatisfy({ $0 == "0" }) ? "-" + body : body
     }
 
     public static func addAmounts(_ lhs: String, _ rhs: String) throws -> String {

--- a/IrohaSwift/Sources/IrohaSwift/OfflineSettlementProofs.swift
+++ b/IrohaSwift/Sources/IrohaSwift/OfflineSettlementProofs.swift
@@ -239,6 +239,14 @@ public struct ToriiOfflineMerklePath: Codable, Sendable, Equatable {
         }
     }
 
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(siblings, forKey: .siblings)
+        // Server expects dirs as an array of bytes (Vec<u8>), not base64.
+        let bytes: [UInt8] = Data(base64Encoded: dirs).map { [UInt8]($0) } ?? []
+        try container.encode(bytes, forKey: .dirs)
+    }
+
     private enum CodingKeys: String, CodingKey {
         case dirs, siblings
     }
@@ -548,7 +556,7 @@ public enum ToriiOfflineSettlementProofs {
             prefixedHex(levels[Int(starkDomainLog2) - layer])
         }
         let rootData = roots.compactMap { hex in
-            Data(hexString: String(hex.dropFirst(2)))
+            Data(hexString: hex)
         }
         let queries = (0..<Int(starkQueryCount)).map { queryIndex in
             synthesizeQueryChain(
@@ -784,7 +792,7 @@ public enum ToriiOfflineSettlementProofs {
     }
 
     private static func prefixedHex(_ data: Data) -> String {
-        "0x" + data.hexEncodedString()
+        data.hexEncodedString()
     }
 
     private static func littleEndianData(_ value: UInt16) -> Data {
@@ -810,7 +818,7 @@ public enum ToriiOfflineSettlementProofs {
     }
 
     private static func normalizePrefixedHex(_ value: String, label: String) throws -> String {
-        "0x" + (try normalizePlainHex(value, label: label))
+        try normalizePlainHex(value, label: label)
     }
 
     private struct SettlementCommitmentPayload: Encodable {

--- a/crates/iroha_core/src/smartcontracts/isi/offline.rs
+++ b/crates/iroha_core/src/smartcontracts/isi/offline.rs
@@ -1668,7 +1668,7 @@ pub mod isi {
                 "offline redeem amount must be positive",
             ));
         }
-        refund_allowance_from_escrow(state_transaction, &asset, authority, &amount)
+        refund_allowance_from_escrow(state_transaction, &asset, asset.account(), &amount)
     }
 
     fn register_allowance(


### PR DESCRIPTION
## Summary

- `RedeemOfflineEscrowBalance` was refunding the escrow balance to the transaction `authority` instead of the instruction's target controller. Since the operator submits redeem instructions on behalf of users, funds ended up on the operator's account rather than the user's. Switched to `asset.account()` (the controller already encoded in the instruction), mirroring how `LoadOfflineEscrowBalance` withdraws from `asset.account()` on the reverse path.
- Aligned `IrohaSwift` offline settlement SDK with the server's Norito/JSON wire expectations so the redeem round-trip actually succeeds:
  - `canonicalAmountString` preserves the input scale (e.g. `"1.00"` stays `"1.00"`), matching Rust `Numeric::Display`. Previously `NSDecimalNumber` dropped trailing zeros, producing a mismatched redeem-request commitment hash.
  - STARK envelope roots / comp_root / merkle siblings are serialized as plain hex without the `"0x"` prefix, matching `decode_hex<N>` in Norito.
  - `MerklePath.dirs` is now encoded as a `Vec<u8>` (JSON array of bytes) on the wire instead of a base64 string; the server's generic `Vec<T>` decoder expects an array.

## Test plan

- End-to-end iOS redeem flow (cbdc-ios): Top Up → Redeem restores the online balance to the user's controller account (previously funds landed on the operator).
- Inspected on-chain balances via CLI to confirm the deposit goes to `asset.account()`.