### PR TITLE
Fix offline escrow self-account handling

### DIFF
--- a/crates/iroha_core/src/smartcontracts/isi/offline.rs
+++ b/crates/iroha_core/src/smartcontracts/isi/offline.rs
@@ -101,6 +101,24 @@ pub(crate) fn is_offline_escrow_source_asset(
     Ok(&derived == source_id.account())
 }
 
+fn ensure_distinct_offline_escrow_account(
+    escrow_account: &AccountId,
+    participant_account: &AccountId,
+    participant_role: &str,
+    definition_id: &AssetDefinitionId,
+) -> Result<(), Error> {
+    if escrow_account == participant_account {
+        return Err(labeled_invariant(
+            "escrow_self_reference",
+            format!(
+                "offline escrow account for asset definition `{definition_id}` must be distinct from {participant_role} account `{participant_account}`",
+            ),
+        )
+        .into());
+    }
+    Ok(())
+}
+
 fn reserve_offline_note_escrow(
     state_transaction: &mut StateTransaction<'_, '_>,
     asset: &AssetId,
@@ -119,6 +137,12 @@ fn reserve_offline_note_escrow(
     if amount.is_zero() {
         return Ok(());
     }
+    ensure_distinct_offline_escrow_account(
+        &escrow_account,
+        asset.account(),
+        "note",
+        asset.definition(),
+    )?;
     let escrow_asset = AssetId::new(asset.definition().clone(), escrow_account);
     state_transaction
         .world
@@ -162,6 +186,12 @@ fn credit_from_offline_note_escrow(
             .world
             .deposit_numeric_asset(&recipient_asset, amount);
     }
+    ensure_distinct_offline_escrow_account(
+        &escrow_account,
+        recipient,
+        "recipient",
+        &definition_id,
+    )?;
     let escrow_asset = AssetId::new(definition_id, escrow_account);
     state_transaction
         .world
@@ -988,8 +1018,24 @@ pub mod isi {
 
     #[cfg(test)]
     mod tests {
+        use std::sync::Arc;
+
         use super::*;
+        use crate::{
+            kura::Kura,
+            query::store::LiveQueryStore,
+            state::{State, World},
+        };
         use iroha_crypto::{KeyPair, Signature};
+        use iroha_data_model::{
+            Registrable,
+            account::Account,
+            asset::{Asset, AssetDefinition},
+            block::BlockHeader,
+            domain::{Domain, DomainId},
+        };
+        use iroha_primitives::numeric::NumericSpec;
+        use nonzero_ext::nonzero;
 
         fn sample_account(seed: u8) -> AccountId {
             let keypair = KeyPair::from_seed(vec![seed; 32], Algorithm::Ed25519);
@@ -1018,6 +1064,91 @@ pub mod isi {
                 one_use: true,
                 issuer_signature: sample_signature(0x44),
             }
+        }
+
+        fn self_escrow_test_state(
+            balance: Numeric,
+        ) -> (State, AssetId, AccountId, AssetDefinitionId) {
+            let account_id = sample_account(0x01);
+            let domain_id: DomainId = DomainId::try_new("offline", "universal").expect("domain id");
+            let definition_id = AssetDefinitionId::new(
+                domain_id.clone(),
+                "xor".parse().expect("asset definition name"),
+            );
+            let asset_id = AssetId::new(definition_id.clone(), account_id.clone());
+            let domain = Domain::new(domain_id).build(&account_id);
+            let account = Account::new(account_id.clone()).build(&account_id);
+            let asset_definition =
+                AssetDefinition::new(definition_id.clone(), NumericSpec::integer())
+                    .with_name("xor".to_owned())
+                    .build(&account_id);
+            let asset = Asset::new(asset_id.clone(), balance);
+            let world = World::with_assets([domain], [account], [asset_definition], [asset], []);
+            let kura = Kura::blank_kura_for_testing();
+            let query = LiveQueryStore::start_test();
+            let mut state = State::new(world, Arc::clone(&kura), query);
+            state.settlement.offline.escrow_required = true;
+            state
+                .settlement
+                .offline
+                .escrow_accounts
+                .insert(definition_id.clone(), account_id.clone());
+
+            (state, asset_id, account_id, definition_id)
+        }
+
+        #[test]
+        fn reserve_offline_note_escrow_rejects_escrow_self_reference() {
+            let (state, asset_id, _account_id, _definition_id) =
+                self_escrow_test_state(Numeric::new(100, 0));
+            let header = BlockHeader::new(nonzero!(1_u64), None, None, None, 0, 0);
+            let mut block = state.block(header);
+            let mut transaction = block.transaction();
+
+            let err =
+                reserve_offline_note_escrow(&mut transaction, &asset_id, &Numeric::new(25, 0))
+                    .expect_err("self-referenced escrow must reject note reservation");
+            assert!(
+                err.to_string().contains("escrow_self_reference"),
+                "unexpected error: {err}"
+            );
+
+            let balance = transaction
+                .world
+                .assets
+                .get(&asset_id)
+                .map(|asset| asset.as_ref().clone())
+                .unwrap_or_else(Numeric::zero);
+            assert_eq!(balance, Numeric::new(100, 0));
+        }
+
+        #[test]
+        fn credit_from_offline_note_escrow_rejects_escrow_self_reference() {
+            let (state, asset_id, account_id, _definition_id) =
+                self_escrow_test_state(Numeric::new(100, 0));
+            let header = BlockHeader::new(nonzero!(1_u64), None, None, None, 0, 0);
+            let mut block = state.block(header);
+            let mut transaction = block.transaction();
+
+            let err = credit_from_offline_note_escrow(
+                &mut transaction,
+                &asset_id,
+                &account_id,
+                &Numeric::new(25, 0),
+            )
+            .expect_err("self-referenced escrow must reject note credit");
+            assert!(
+                err.to_string().contains("escrow_self_reference"),
+                "unexpected error: {err}"
+            );
+
+            let balance = transaction
+                .world
+                .assets
+                .get(&asset_id)
+                .map(|asset| asset.as_ref().clone())
+                .unwrap_or_else(Numeric::zero);
+            assert_eq!(balance, Numeric::new(100, 0));
         }
 
         #[test]

--- a/crates/iroha_kagami/src/localnet.rs
+++ b/crates/iroha_kagami/src/localnet.rs
@@ -26,6 +26,7 @@ use iroha_data_model::{
         verifying_keys,
     },
     nexus::DataSpaceId,
+    offline::OFFLINE_ASSET_ENABLED_METADATA_KEY,
     parameter::system::{
         SumeragiConsensusMode, SumeragiNposParameters, SumeragiParameter, SumeragiParameters,
     },
@@ -2187,11 +2188,7 @@ fn render_peer_config(
     torii.insert("transport".into(), Value::Table(transport));
     root.insert("torii".into(), Value::Table(torii));
 
-    let mut settlement_offline_escrow_accounts = Table::new();
-    settlement_offline_escrow_accounts.insert(
-        localnet_offline_note_asset_literal(),
-        Value::String(localnet_client_account),
-    );
+    let settlement_offline_escrow_accounts = Table::new();
     let mut settlement_offline = Table::new();
     settlement_offline.insert(
         "escrow_accounts".into(),
@@ -2258,9 +2255,18 @@ fn extend_genesis(
         }
         let asset_def = AssetDefinitionId::parse_address_literal(&asset.id)
             .wrap_err("invalid asset definition id")?;
+        let mut metadata = Metadata::default();
+        if asset.id == LOCALNET_OFFLINE_NOTE_ASSET_ID {
+            metadata.insert(
+                OFFLINE_ASSET_ENABLED_METADATA_KEY
+                    .parse()
+                    .expect("offline asset metadata key must parse"),
+                Json::new(true),
+            );
+        }
         let definition = AssetDefinition::new(asset_def.clone(), NumericSpec::default())
             .with_name(asset.name.clone())
-            .with_metadata(Metadata::default());
+            .with_metadata(metadata);
         builder = builder.append_instruction(Register::asset_definition(definition));
         if let Some(alias_literal) = asset.alias.as_deref() {
             let alias = alias_literal
@@ -3210,7 +3216,8 @@ fn write_localnet_readme(
             "## Built-in App API bootstrap\n\n",
             "- Offline-note asset definition: `{offline_note_asset}`\n",
             "- Offline-note alias: `{offline_note_alias}`\n",
-            "- Localnet app authority / escrow account: `{client_account_id}`\n",
+            "- Localnet app authority: `{client_account_id}`\n",
+            "- Offline escrow account: deterministic account derived from the chain id and asset definition\n",
             "- Generated peer configs enable `torii.onboarding` and Offline V2 escrow routing\n\n",
             "- Start script: `{start_script}`\n",
             "- Stop script: `{stop_script}`\n\n",
@@ -3492,6 +3499,9 @@ mod tests {
             usize::from(client_account_id != *ALICE_ID);
         let expected_mint_destination =
             AssetId::new(offline_asset_id.clone(), client_account_id.clone());
+        let offline_enabled_key: iroha_data_model::name::Name = OFFLINE_ASSET_ENABLED_METADATA_KEY
+            .parse()
+            .expect("offline asset metadata key");
 
         let has_definition = manifest.instructions().any(|instruction| {
             instruction
@@ -3502,12 +3512,17 @@ mod tests {
                         register,
                         RegisterBox::AssetDefinition(register)
                             if register.object().id == offline_asset_id
+                                && register
+                                    .object()
+                                    .metadata
+                                    .get(&offline_enabled_key)
+                                    .is_some_and(|value| matches!(value.try_into_any::<bool>(), Ok(true)))
                     )
                 })
         });
         assert!(
             has_definition,
-            "localnet must register the built-in offline-note asset"
+            "localnet must register the built-in offline-note asset with offline.enabled=true"
         );
 
         let has_alias_binding = manifest.instructions().any(|instruction| {
@@ -3736,11 +3751,9 @@ mod tests {
             .get("escrow_accounts")
             .and_then(toml::Value::as_table)
             .expect("settlement.offline.escrow_accounts table");
-        assert_eq!(
-            escrow_accounts
-                .get(LOCALNET_OFFLINE_NOTE_ASSET_ID)
-                .and_then(toml::Value::as_str),
-            Some(client_account_id.as_str())
+        assert!(
+            escrow_accounts.is_empty(),
+            "generated peer config must not map offline-note escrow to the localnet app authority"
         );
     }
 
@@ -5862,6 +5875,13 @@ mod tests {
         let contents = fs::read_to_string(tmp.path().join("README.md")).expect("read readme");
         assert!(contents.contains("- Base seed: `Iroha`"));
         assert!(contents.contains(LOCALNET_OFFLINE_NOTE_ASSET_ALIAS));
+        assert!(contents.contains("- Localnet app authority: `"));
+        assert!(
+            contents.contains(
+                "- Offline escrow account: deterministic account derived from the chain id and asset definition"
+            )
+        );
+        assert!(!contents.contains("Localnet app authority / escrow account"));
     }
 
     #[test]

--- a/status.md
+++ b/status.md
@@ -2,6 +2,17 @@
 
 Last updated: 2026-04-26
 
+## 2026-04-26 Offline escrow self-account guard and localnet note seed fix
+
+- `crates/iroha_core/src/smartcontracts/isi/offline.rs` now rejects non-zero Offline V2 note escrow movements when the resolved escrow account is the same account being debited or credited. The new `escrow_self_reference` invariant is checked before balance mutation on issue/reserve and redeem/credit paths.
+- `crates/iroha_kagami/src/localnet.rs` no longer writes the built-in offline-note asset escrow account as the localnet app authority. Generated peer configs keep an empty `settlement.offline.escrow_accounts` table, and localnet genesis marks the built-in offline-note asset `offline.enabled = true` so the deterministic escrow account path creates the vault.
+- Focused validation for this fix:
+  - `cargo fmt --all`
+  - `cargo test -p iroha_core escrow_self_reference`
+  - `cargo test -p iroha_kagami generated_localnet_bootstraps_builtin_offline_note_asset_and_permissions`
+  - `cargo test -p iroha_kagami generated_peer_config_enables_offline_note_bootstrap_services`
+  - `cargo test -p iroha_kagami localnet_readme_records_base_seed_when_present`
+
 ## 2026-04-26 Torii MCP Sumeragi collector empty-topology fix
 
 - Fixed `/v1/sumeragi/collectors` so the Torii/MCP test harness with no commit topology returns an empty collector snapshot instead of constructing a `Topology` from an empty peer list and panicking.


### PR DESCRIPTION
## Context

In Offline V2, an escrow account is the vault that temporarily holds tokens reserved for an offline note (issue/reserve) and from which they are released on redeem (credit). If that vault account ever resolves to the same account being debited or credited, an escrow movement degenerates into a self-transfer: balances would be mutated against a single account with the escrow invariant silently violated, leaving offline-note accounting in an inconsistent state.

This PR closes that hole and fixes a related localnet misconfiguration that made it easy to hit in practice: the bundled localnet generator was wiring the built-in offline-note asset's escrow account to the localnet app authority — i.e. the same account that holds the minted note balance — instead of letting the deterministic per-asset escrow account be derived.

### Solution

- Add an `ensure_distinct_offline_escrow_account` guard in `crates/iroha_core/src/smartcontracts/isi/offline.rs`. It is invoked at the start of `reserve_offline_note_escrow` (issue path) and `credit_from_offline_note_escrow` (redeem path), before any balance mutation, and returns an `escrow_self_reference` labeled invariant error when the resolved escrow account equals the participant account (note source on reserve, recipient on credit). Zero-amount calls remain a no-op as before.
- Update `crates/iroha_kagami/src/localnet.rs` so generated peer configs no longer pre-populate `settlement.offline.escrow_accounts` with the localnet app authority. Instead, the localnet genesis marks the built-in offline-note asset definition with `offline.enabled = true`, which causes the deterministic escrow account (derived from the chain id and asset definition) to be created on bootstrap. The generated localnet README is updated to reflect that the app authority and the offline escrow account are now distinct.
- Add unit tests covering both guarded paths (`reserve_offline_note_escrow_rejects_escrow_self_reference`, `credit_from_offline_note_escrow_rejects_escrow_self_reference`) and update the localnet generator tests to assert the new bootstrap shape (empty `escrow_accounts` table, `offline.enabled = true` metadata on the offline-note asset definition, refreshed README wording).

### Migration Guide (optional)

Operators with hand-written peer configurations that explicitly mapped the offline-note asset definition to a participant account (e.g. the app authority) under `settlement.offline.escrow_accounts` should remove that entry and instead enable the deterministic escrow account by setting `offline.enabled = true` in the asset definition's metadata at genesis. Any chain that previously relied on a self-referential escrow mapping will now see those issue/redeem instructions fail with an `escrow_self_reference` invariant error until the mapping is corrected.

---

### Review notes (optional)

Suggested review order:

1. `crates/iroha_core/src/smartcontracts/isi/offline.rs` — read the new `ensure_distinct_offline_escrow_account` helper and its two call sites first, then the two new unit tests that exercise the issue and redeem paths against a state where the escrow account and the participant account collide.
2. `crates/iroha_kagami/src/localnet.rs` — three coordinated changes: the generated peer config no longer seeds `escrow_accounts`; genesis now stamps the offline-note asset definition with the `offline.enabled = true` metadata key; and the README/test fixtures are updated to match. The existing `generated_localnet_bootstraps_builtin_offline_note_asset_and_permissions` and `generated_peer_config_enables_offline_note_bootstrap_services` tests are the easiest way to confirm the new shape.
3. `status.md` — narrative summary of the same change for the running status log.

Focused validation run locally:

- `cargo fmt --all`
- `cargo test -p iroha_core escrow_self_reference`
- `cargo test -p iroha_kagami generated_localnet_bootstraps_builtin_offline_note_asset_and_permissions`
- `cargo test -p iroha_kagami generated_peer_config_enables_offline_note_bootstrap_services`
- `cargo test -p iroha_kagami localnet_readme_records_base_seed_when_present`