### PR TITLE
Allow injecting executor into HTTP transport

### DIFF
--- a/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/client/HttpClientTransport.kt
+++ b/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/client/HttpClientTransport.kt
@@ -13,6 +13,7 @@ import java.util.Optional
 import java.util.Base64
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
+import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
@@ -442,6 +443,20 @@ class HttpClientTransport(
         @JvmStatic fun createDefault(config: ClientConfig): HttpClientTransport = HttpClientTransport(PlatformHttpTransportExecutor.createDefault(), config)
         @JvmStatic fun withExecutor(executor: HttpTransportExecutor, config: ClientConfig): HttpClientTransport = HttpClientTransport(executor, config)
         @JvmStatic fun withDefaultExecutor(config: ClientConfig): HttpClientTransport = HttpClientTransport(PlatformHttpTransportExecutor.createDefault(), config)
+        /**
+         * Builds a transport whose underlying [UrlConnectionTransportExecutor] runs the synchronous
+         * HTTP work on [asyncExecutor]; pass `null` for behavior equivalent to [withDefaultExecutor].
+         * See [UrlConnectionTransportExecutor] for the full rationale (Android `StrictMode` /
+         * `TrafficStats` interaction).
+         */
+        @JvmStatic fun withDefaultExecutor(config: ClientConfig, asyncExecutor: Executor?): HttpClientTransport =
+            HttpClientTransport(
+                org.hyperledger.iroha.sdk.client.transport.UrlConnectionTransportExecutor(
+                    config.requestTimeout(),
+                    asyncExecutor,
+                ),
+                config,
+            )
         @JvmStatic fun withOfflineJournalQueue(config: ClientConfig, journalPath: Path, key: OfflineJournalKey): ClientConfig = config.toBuilder().enableOfflineJournalQueue(journalPath, key).build()
         @JvmStatic fun withOfflineJournalQueue(config: ClientConfig, journalPath: Path, seed: ByteArray): ClientConfig = config.toBuilder().enableOfflineJournalQueue(journalPath, seed).build()
         @JvmStatic fun withOfflineJournalQueue(config: ClientConfig, journalPath: Path, passphrase: CharArray): ClientConfig = config.toBuilder().enableOfflineJournalQueue(journalPath, passphrase).build()

--- a/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/client/transport/UrlConnectionTransportExecutor.kt
+++ b/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/client/transport/UrlConnectionTransportExecutor.kt
@@ -7,26 +7,59 @@ import java.io.InputStream
 import java.net.HttpURLConnection
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
 
 /**
  * `HttpTransportExecutor` implementation backed by `HttpURLConnection`.
  *
  * This executor avoids `java.net.http` so it can serve JVM and Android targets with the same
  * canonical implementation.
+ *
+ * @param asyncExecutor optional [Executor] used to run the synchronous HTTP work for
+ *   [execute] and [openStream]. When `null`, falls back to `ForkJoinPool.commonPool()`
+ *   via [CompletableFuture.supplyAsync].
+ *
+ *   Why this parameter exists (it is not gratuitous):
+ *   - On Android, sockets opened on threads with no traffic-stats tag (default `0`) trip
+ *     `StrictMode.VmPolicy.detectUntaggedSockets`. With `penaltyDeath` the process is killed.
+ *   - `ForkJoinPool.commonPool()` worker threads cannot be retagged externally — the consumer
+ *     has no hook to influence what tag commonPool's threads carry.
+ *   - Supplying [asyncExecutor] lets the consumer provide its own pool whose `ThreadFactory`
+ *     pre-tags each worker via `TrafficStats.setThreadStatsTag(...)` before any socket is
+ *     created on that thread.
+ *   - Pure-JVM consumers can ignore the parameter (default `null` → `commonPool()`); the
+ *     parameter keeps `core-jvm` free of Android-only APIs while still giving Android callers
+ *     a clean injection point. The same hook also works for any other thread-local context
+ *     (auth MDC, tracing) the consumer wants set per request.
  */
 class UrlConnectionTransportExecutor(
     private val connectTimeout: Duration? = null,
     private val readTimeout: Duration? = null,
+    private val asyncExecutor: Executor? = null,
 ) : HttpTransportExecutor, StreamingTransportExecutor {
 
     /** Creates an executor that applies the same timeout to connect and read operations. */
-    constructor(timeout: Duration?) : this(timeout, timeout)
+    constructor(timeout: Duration?) : this(timeout, timeout, null)
+
+    /**
+     * Creates an executor with a uniform timeout and a caller-supplied async executor;
+     * see the primary constructor for why [asyncExecutor] exists.
+     */
+    constructor(timeout: Duration?, asyncExecutor: Executor?) : this(timeout, timeout, asyncExecutor)
 
     override fun execute(request: TransportRequest): CompletableFuture<TransportResponse> =
-        CompletableFuture.supplyAsync { executeSync(request) }
+        if (asyncExecutor != null) {
+            CompletableFuture.supplyAsync({ executeSync(request) }, asyncExecutor)
+        } else {
+            CompletableFuture.supplyAsync { executeSync(request) }
+        }
 
     override fun openStream(request: TransportRequest): CompletableFuture<TransportStreamResponse> =
-        CompletableFuture.supplyAsync { openStreamSync(request) }
+        if (asyncExecutor != null) {
+            CompletableFuture.supplyAsync({ openStreamSync(request) }, asyncExecutor)
+        } else {
+            CompletableFuture.supplyAsync { openStreamSync(request) }
+        }
 
     private fun executeSync(request: TransportRequest): TransportResponse {
         var connection: HttpURLConnection? = null

--- a/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/client/transport/UrlConnectionTransportExecutorTest.kt
+++ b/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/client/transport/UrlConnectionTransportExecutorTest.kt
@@ -2,11 +2,69 @@ package org.hyperledger.iroha.sdk.client.transport
 
 import java.net.ServerSocket
 import java.net.URI
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class UrlConnectionTransportExecutorTest {
+
+    @Test
+    fun executeRunsOnSuppliedAsyncExecutor() {
+        val capturedThreadName = AtomicReference<String?>(null)
+        val pool = Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "url-connection-test-pool-1").apply { isDaemon = true }
+        }
+        try {
+            ServerSocket(0).use { server ->
+                val port = server.localPort
+                val serverThread = Thread {
+                    server.accept().use { socket ->
+                        val input = socket.getInputStream()
+                        val sb = StringBuilder()
+                        while (true) {
+                            val b = input.read()
+                            if (b == -1) break
+                            sb.append(b.toChar())
+                            if (sb.endsWith("\r\n\r\n")) break
+                        }
+                        val out = socket.getOutputStream()
+                        out.write("HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".toByteArray())
+                        out.flush()
+                    }
+                }
+                serverThread.isDaemon = true
+                serverThread.start()
+
+                val executor = UrlConnectionTransportExecutor(
+                    connectTimeout = null,
+                    readTimeout = null,
+                    asyncExecutor = { runnable ->
+                        pool.execute {
+                            capturedThreadName.set(Thread.currentThread().name)
+                            runnable.run()
+                        }
+                    },
+                )
+                val request = TransportRequest.builder()
+                    .setMethod("GET")
+                    .setUri(URI.create("http://localhost:$port/health"))
+                    .build()
+
+                val response = executor.execute(request).get()
+
+                assertEquals(200, response.statusCode, "Status code should be 200")
+                val name = assertNotNull(capturedThreadName.get(), "Async executor should have been invoked")
+                assertEquals("url-connection-test-pool-1", name, "Executor must run on the supplied pool, not commonPool")
+
+                serverThread.join(2000)
+            }
+        } finally {
+            pool.shutdownNow()
+        }
+    }
 
     @Test
     fun executeReturns404WithEmptyBodyWhenServerSendsNoContent() {


### PR DESCRIPTION
## Context

On Android, `StrictMode.VmPolicy.detectUntaggedSockets` flags any socket opened
on a thread that has not called `TrafficStats.setThreadStatsTag(...)`. With
`penaltyDeath` enabled this kills the process. The SDK's HTTP transport runs
its synchronous work via `CompletableFuture.supplyAsync { ... }`, which
defaults to `ForkJoinPool.commonPool()` — a pool whose worker threads cannot
be retagged from the outside, so every request opens an untagged socket.

This PR gives Android (and any other) consumers a hook to control the pool
that runs the blocking HTTP work, so they can pre-tag worker threads in their
own `ThreadFactory` before sockets are created. Pure-JVM consumers are
unaffected: the new parameter is optional and defaults to the previous
`commonPool()` behavior.

### Solution

- `UrlConnectionTransportExecutor` gains an optional `asyncExecutor: Executor?`
  parameter. When supplied, both `execute()` and `openStream()` route their
  `supplyAsync` call through it instead of `commonPool()`. When `null`, the
  behavior is identical to before.
- `HttpClientTransport` exposes a new `withDefaultExecutor(config, asyncExecutor)`
  factory so callers can inject the pool without constructing the executor
  themselves.
- Added a unit test that spins up a `ServerSocket`, drives a real GET through
  the executor with a single-threaded pool, and asserts the request ran on the
  caller-supplied thread (not on `commonPool`).

### Review notes (optional)

Suggested reading order:
1. `UrlConnectionTransportExecutor.kt` — the core change and the KDoc that
   explains why the parameter exists (Android `StrictMode` / `TrafficStats`).
2. `HttpClientTransport.kt` — thin factory exposing the injection point.
3. `UrlConnectionTransportExecutorTest.kt` — verifies the executor is actually
   used; the rest of the file is unchanged.