### PR TITLE
feat(connect_norito_bridge): add offline-v2 prover FFI

### DIFF
--- a/crates/connect_norito_bridge/Cargo.toml
+++ b/crates/connect_norito_bridge/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
 norito = { path = "../norito", version = "2.0.0-rc.2.0", default-features = false, features = ["std", "derive", "json", "json-std-io", "columnar", "strict-safe"] }
+iroha_core = { workspace = true, features = ["zk-halo2-ipa"] }
 iroha_torii_shared = { workspace = true }
 fastpq_prover = { workspace = true }
 iroha_crypto = { workspace = true, default-features = false, features = ["std", "bls", "gost", "sm"] }

--- a/crates/connect_norito_bridge/include/connect_norito_bridge.h
+++ b/crates/connect_norito_bridge/include/connect_norito_bridge.h
@@ -20,6 +20,7 @@ extern "C" {
 #define CONNECT_NORITO_ERR_OFFLINE_ASSET -301
 #define CONNECT_NORITO_ERR_OFFLINE_NONCE -303
 #define CONNECT_NORITO_ERR_OFFLINE_SERIALIZE -304
+#define CONNECT_NORITO_ERR_OFFLINE_NOTE_V2_PROVE -310
 
 // ---------------- Bridge ABI ----------------
 uint32_t connect_norito_bridge_abi_version(void);
@@ -61,6 +62,25 @@ int32_t connect_norito_decode_ciphertext_frame(
     const uint8_t* inp, unsigned long inp_len,
     uint8_t* out_sid, uint8_t* out_dir, uint64_t* out_seq,
     uint8_t** out_aead_ptr, unsigned long* out_aead_len);
+
+// ---------------- Offline Note V2 prover helpers ----------------
+// Generate a recursive Halo2/IPA proof for an Offline V2 redemption.
+// Input: Norito-archive bytes of `OfflineNoteRedeemV2` (recursive_proof field is ignored).
+// Output: Norito-archive bytes of `OfflineNoteRecursiveProofV2` (slot back into the redemption).
+int32_t connect_norito_offline_prove_note_v2_redeem(
+    const uint8_t* redeem_norito_ptr,
+    unsigned long redeem_norito_len,
+    uint8_t** out_recursive_proof_ptr,
+    unsigned long* out_recursive_proof_len);
+
+// Generate a recursive Halo2/IPA proof for an Offline V2 audit bundle.
+// Input: Norito-archive bytes of `OfflineNoteAuditBundleV2` (recursive_proof field is ignored).
+// Output: Norito-archive bytes of `OfflineNoteRecursiveProofV2` (slot back into the audit bundle).
+int32_t connect_norito_offline_prove_note_v2_audit(
+    const uint8_t* audit_norito_ptr,
+    unsigned long audit_norito_len,
+    uint8_t** out_recursive_proof_ptr,
+    unsigned long* out_recursive_proof_len);
 
 void connect_norito_free(uint8_t* ptr);
 

--- a/crates/connect_norito_bridge/src/lib.rs
+++ b/crates/connect_norito_bridge/src/lib.rs
@@ -122,6 +122,7 @@ const ERR_FETCH_UNKNOWN_CHUNKER: c_int = -113;
 const ERR_ACCOUNT_ADDRESS: c_int = -200;
 const ERR_ASSET_ID_PARSE: c_int = -301;
 const ERR_JSON_SERIALIZE: c_int = -304;
+const ERR_OFFLINE_NOTE_V2_PROVE: c_int = -310;
 const ERR_DA_PROOF_SUMMARY: c_int = -401;
 const ERR_MULTISIG_SPEC: c_int = -402;
 const ERR_VERIFYING_KEY_ID: c_int = -403;
@@ -151,6 +152,7 @@ enum BridgeError {
     InvalidRootHint,
     AssetId,
     JsonSerialize,
+    OfflineNoteV2Prove,
     UnsupportedAlgorithm,
     MetadataTarget,
     MetadataKey,
@@ -189,6 +191,7 @@ impl BridgeError {
             BridgeError::InvalidRootHint => ERR_INVALID_ROOT_HINT,
             BridgeError::AssetId => ERR_ASSET_ID_PARSE,
             BridgeError::JsonSerialize => ERR_JSON_SERIALIZE,
+            BridgeError::OfflineNoteV2Prove => ERR_OFFLINE_NOTE_V2_PROVE,
             BridgeError::UnsupportedAlgorithm => ERR_UNSUPPORTED_ALGORITHM,
             BridgeError::MetadataTarget => ERR_METADATA_TARGET,
             BridgeError::MetadataKey => ERR_METADATA_KEY,
@@ -3571,12 +3574,352 @@ pub unsafe extern "C" fn connect_norito_decode_ciphertext_frame(
     }
 }
 
+// ---------------- Offline Note V2 prover helpers ----------------
+
+/// Generate a recursive Halo2/IPA proof for an Offline V2 redemption.
+///
+/// The input is Norito-archive bytes of
+/// `iroha_data_model::offline::OfflineNoteRedeemV2`. The existing
+/// `recursive_proof` field is ignored, so callers may pass a stub. The output
+/// is Norito-archive bytes of `OfflineNoteRecursiveProofV2`, ready to slot back
+/// into the redemption before transaction submission.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn connect_norito_offline_prove_note_v2_redeem(
+    redeem_norito_ptr: *const c_uchar,
+    redeem_norito_len: c_ulong,
+    out_recursive_proof_ptr: *mut *mut c_uchar,
+    out_recursive_proof_len: *mut c_ulong,
+) -> c_int {
+    let result = (|| {
+        if redeem_norito_ptr.is_null()
+            || out_recursive_proof_ptr.is_null()
+            || out_recursive_proof_len.is_null()
+        {
+            return Err(BridgeError::NullPtr);
+        }
+        let bytes = unsafe { slice::from_raw_parts(redeem_norito_ptr, redeem_norito_len as usize) };
+        let recursive = prove_offline_note_v2_redeem_recursive(bytes)?;
+        let archive = norito::to_bytes(&recursive).map_err(|_| BridgeError::OfflineNoteV2Prove)?;
+        unsafe { write_bytes_bridge(out_recursive_proof_ptr, out_recursive_proof_len, &archive) }
+    })();
+
+    bridge_result_to_code(result)
+}
+
+/// Generate a recursive Halo2/IPA proof for an Offline V2 audit bundle.
+///
+/// The input is Norito-archive bytes of
+/// `iroha_data_model::offline::OfflineNoteAuditBundleV2`. The existing
+/// `recursive_proof` field is ignored, so callers may pass a stub. The output
+/// is Norito-archive bytes of `OfflineNoteRecursiveProofV2`, ready to slot back
+/// into the audit bundle before transaction submission.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn connect_norito_offline_prove_note_v2_audit(
+    audit_norito_ptr: *const c_uchar,
+    audit_norito_len: c_ulong,
+    out_recursive_proof_ptr: *mut *mut c_uchar,
+    out_recursive_proof_len: *mut c_ulong,
+) -> c_int {
+    let result = (|| {
+        if audit_norito_ptr.is_null()
+            || out_recursive_proof_ptr.is_null()
+            || out_recursive_proof_len.is_null()
+        {
+            return Err(BridgeError::NullPtr);
+        }
+        let bytes = unsafe { slice::from_raw_parts(audit_norito_ptr, audit_norito_len as usize) };
+        let recursive = prove_offline_note_v2_audit_recursive(bytes)?;
+        let archive = norito::to_bytes(&recursive).map_err(|_| BridgeError::OfflineNoteV2Prove)?;
+        unsafe { write_bytes_bridge(out_recursive_proof_ptr, out_recursive_proof_len, &archive) }
+    })();
+
+    bridge_result_to_code(result)
+}
+
+fn prove_offline_note_v2_redeem_recursive(
+    redeem_archive: &[u8],
+) -> BridgeResult<iroha_data_model::offline::OfflineNoteRecursiveProofV2> {
+    use iroha_core::zk::{
+        OFFLINE_NOTE_V2_RECURSIVE_V1_CIRCUIT_ID, offline_note_v2_recursive_vk_box,
+        prove_offline_note_v2_redeem,
+    };
+    use iroha_data_model::{
+        offline::{OfflineNoteRecursiveProofV2, OfflineNoteRedeemV2},
+        proof::VerifyingKeyId,
+    };
+
+    let redemption: OfflineNoteRedeemV2 =
+        norito::decode_from_bytes(redeem_archive).map_err(|_| BridgeError::OfflineNoteV2Prove)?;
+    let vk_box = offline_note_v2_recursive_vk_box().map_err(|_| BridgeError::OfflineNoteV2Prove)?;
+    let proof_box = prove_offline_note_v2_redeem(
+        OFFLINE_NOTE_V2_RECURSIVE_V1_CIRCUIT_ID,
+        &vk_box,
+        &redemption,
+        None,
+    )
+    .map_err(|_| BridgeError::OfflineNoteV2Prove)?;
+    let public_inputs_hash = redemption
+        .public_inputs_hash()
+        .map_err(|_| BridgeError::OfflineNoteV2Prove)?;
+
+    Ok(OfflineNoteRecursiveProofV2 {
+        verifier_key_id: VerifyingKeyId::new(
+            vk_box.backend.clone(),
+            OFFLINE_NOTE_V2_RECURSIVE_V1_CIRCUIT_ID,
+        ),
+        public_inputs_hash,
+        proof: proof_box,
+    })
+}
+
+fn prove_offline_note_v2_audit_recursive(
+    audit_archive: &[u8],
+) -> BridgeResult<iroha_data_model::offline::OfflineNoteRecursiveProofV2> {
+    use iroha_core::zk::{
+        OFFLINE_NOTE_V2_RECURSIVE_V1_CIRCUIT_ID, offline_note_v2_recursive_vk_box,
+        prove_offline_note_v2_audit,
+    };
+    use iroha_data_model::{
+        offline::{OfflineNoteAuditBundleV2, OfflineNoteRecursiveProofV2},
+        proof::VerifyingKeyId,
+    };
+
+    let audit: OfflineNoteAuditBundleV2 =
+        norito::decode_from_bytes(audit_archive).map_err(|_| BridgeError::OfflineNoteV2Prove)?;
+    let vk_box = offline_note_v2_recursive_vk_box().map_err(|_| BridgeError::OfflineNoteV2Prove)?;
+    let proof_box = prove_offline_note_v2_audit(
+        OFFLINE_NOTE_V2_RECURSIVE_V1_CIRCUIT_ID,
+        &vk_box,
+        &audit,
+        None,
+    )
+    .map_err(|_| BridgeError::OfflineNoteV2Prove)?;
+    let public_inputs_hash = audit
+        .public_inputs_hash()
+        .map_err(|_| BridgeError::OfflineNoteV2Prove)?;
+
+    Ok(OfflineNoteRecursiveProofV2 {
+        verifier_key_id: VerifyingKeyId::new(
+            vk_box.backend.clone(),
+            OFFLINE_NOTE_V2_RECURSIVE_V1_CIRCUIT_ID,
+        ),
+        public_inputs_hash,
+        proof: proof_box,
+    })
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn connect_norito_free(ptr_: *mut c_uchar) {
     if !ptr_.is_null() {
         unsafe {
             free(ptr_ as *mut _);
         }
+    }
+}
+
+#[cfg(test)]
+mod offline_note_v2_prover_tests {
+    use iroha_core::zk::{
+        OFFLINE_NOTE_V2_RECURSIVE_V1_CIRCUIT_ID, ZK_BACKEND_HALO2_IPA,
+        offline_note_v2_recursive_vk_box, verify_backend,
+    };
+    use iroha_data_model::{
+        offline::{
+            OfflineNoteAuditBundleV2, OfflineNoteAuditOutputClaimV2, OfflineNoteIssueV2,
+            OfflineNoteIssuedClaimV2, OfflineNoteKeyCertificateV2, OfflineNoteRecursiveProofV2,
+            OfflineNoteRedeemV2,
+        },
+        proof::VerifyingKeyId,
+    };
+
+    use super::*;
+
+    fn sample_signature(seed: u8) -> Signature {
+        let mut bytes = [0u8; 64];
+        for (index, byte) in bytes.iter_mut().enumerate() {
+            *byte = seed.wrapping_add(u8::try_from(index).expect("signature index fits"));
+        }
+        Signature::from_bytes(&bytes)
+    }
+
+    fn sample_account(seed: u8) -> AccountId {
+        let keypair = KeyPair::from_seed(vec![seed; 32], Algorithm::Ed25519);
+        AccountId::new(keypair.public_key().clone())
+    }
+
+    fn sample_asset(account: AccountId) -> AssetId {
+        let definition = AssetDefinitionId::new(
+            DomainId::try_new("offline", "universal").expect("domain id"),
+            "xor".parse().expect("asset definition name"),
+        );
+        AssetId::new(definition, account)
+    }
+
+    fn sample_certificate(account: &AccountId, seed: u8) -> OfflineNoteKeyCertificateV2 {
+        let note_keypair = KeyPair::from_seed(vec![seed; 32], Algorithm::Ed25519);
+        let (_algorithm, public_key) = note_keypair.public_key().to_bytes();
+        OfflineNoteKeyCertificateV2 {
+            version: 2,
+            platform: "ios-appattest".to_owned(),
+            key_id: format!("one-use-key-{seed}"),
+            device_id: "device-1".to_owned(),
+            account_id: account.clone(),
+            public_key: public_key.to_vec(),
+            assertion_scheme: "apple-appattest-counter-v1".to_owned(),
+            assertion_key_algorithm: "app-attest-p256".to_owned(),
+            assertion_public_key: vec![0x04; 65],
+            assertion_usage_count_limit: None,
+            one_use: true,
+            issuer_signature: sample_signature(seed.wrapping_add(1)),
+        }
+    }
+
+    fn placeholder_recursive_proof() -> OfflineNoteRecursiveProofV2 {
+        OfflineNoteRecursiveProofV2 {
+            verifier_key_id: VerifyingKeyId::new(
+                ZK_BACKEND_HALO2_IPA,
+                OFFLINE_NOTE_V2_RECURSIVE_V1_CIRCUIT_ID,
+            ),
+            public_inputs_hash: Hash::new(b"placeholder-offline-note-v2-public-inputs"),
+            proof: ProofBox::new(ZK_BACKEND_HALO2_IPA.to_owned(), Vec::new()),
+        }
+    }
+
+    fn sample_redemption() -> OfflineNoteRedeemV2 {
+        let account = sample_account(0xA1);
+        let asset = sample_asset(account.clone());
+        OfflineNoteRedeemV2 {
+            source_note_commitment: Hash::new(b"offline-note-v2-source-note"),
+            input_nullifiers: vec![Hash::new(b"offline-note-v2-redeem-nullifier")],
+            sender_key_certificate: sample_certificate(&account, 0xB1),
+            recipient: account,
+            asset,
+            amount: Numeric::new(10, 0),
+            recursive_proof: placeholder_recursive_proof(),
+        }
+    }
+
+    fn sample_audit() -> OfflineNoteAuditBundleV2 {
+        let account = sample_account(0xC1);
+        let asset = sample_asset(account.clone());
+        let certificate = sample_certificate(&account, 0xD1);
+        let issue = OfflineNoteIssueV2 {
+            note_commitment: Hash::new(b"offline-note-v2-audit-input-note"),
+            key_certificate: certificate.clone(),
+            asset: asset.clone(),
+            amount: Numeric::new(10, 0),
+        };
+        OfflineNoteAuditBundleV2 {
+            token_id: Hash::new(b"offline-note-v2-audit-token"),
+            sender_key_certificate: certificate.clone(),
+            input_nullifiers: vec![Hash::new(b"offline-note-v2-audit-nullifier")],
+            input_claims: vec![OfflineNoteIssuedClaimV2::from_issue(&issue).expect("input claim")],
+            output_commitments: vec![Hash::new(b"offline-note-v2-audit-output-note")],
+            output_claims: vec![OfflineNoteAuditOutputClaimV2 {
+                note_commitment: Hash::new(b"offline-note-v2-audit-output-note"),
+                key_certificate: certificate,
+                asset,
+                amount: Numeric::new(10, 0),
+            }],
+            recursive_proof: placeholder_recursive_proof(),
+        }
+    }
+
+    fn decode_recursive_proof(
+        out_ptr: *mut c_uchar,
+        out_len: c_ulong,
+    ) -> OfflineNoteRecursiveProofV2 {
+        assert!(!out_ptr.is_null(), "prover output pointer must be set");
+        let out = unsafe { slice::from_raw_parts(out_ptr, out_len as usize).to_vec() };
+        connect_norito_free(out_ptr);
+        norito::decode_from_bytes(&out).expect("decode recursive proof")
+    }
+
+    fn assert_recursive_proof_verifies(
+        recursive: &OfflineNoteRecursiveProofV2,
+        expected_public_inputs_hash: Hash,
+    ) {
+        let vk_box = offline_note_v2_recursive_vk_box().expect("offline note v2 verifying key");
+        assert_eq!(
+            recursive.verifier_key_id,
+            VerifyingKeyId::new(
+                ZK_BACKEND_HALO2_IPA,
+                OFFLINE_NOTE_V2_RECURSIVE_V1_CIRCUIT_ID
+            )
+        );
+        assert_eq!(recursive.public_inputs_hash, expected_public_inputs_hash);
+        assert!(
+            verify_backend(ZK_BACKEND_HALO2_IPA, &recursive.proof, Some(&vk_box)),
+            "bridge output must verify against the canonical Offline V2 verifier"
+        );
+    }
+
+    #[test]
+    fn offline_note_v2_redeem_ffi_returns_verifying_recursive_proof() {
+        let redemption = sample_redemption();
+        let archive = norito::to_bytes(&redemption).expect("encode redemption");
+        let mut out_ptr: *mut c_uchar = ptr::null_mut();
+        let mut out_len: c_ulong = 0;
+
+        let status = unsafe {
+            connect_norito_offline_prove_note_v2_redeem(
+                archive.as_ptr(),
+                archive.len() as c_ulong,
+                &mut out_ptr,
+                &mut out_len,
+            )
+        };
+
+        assert_eq!(status, 0);
+        let recursive = decode_recursive_proof(out_ptr, out_len);
+        assert_recursive_proof_verifies(
+            &recursive,
+            redemption.public_inputs_hash().expect("public input hash"),
+        );
+    }
+
+    #[test]
+    fn offline_note_v2_audit_ffi_returns_verifying_recursive_proof() {
+        let audit = sample_audit();
+        let archive = norito::to_bytes(&audit).expect("encode audit bundle");
+        let mut out_ptr: *mut c_uchar = ptr::null_mut();
+        let mut out_len: c_ulong = 0;
+
+        let status = unsafe {
+            connect_norito_offline_prove_note_v2_audit(
+                archive.as_ptr(),
+                archive.len() as c_ulong,
+                &mut out_ptr,
+                &mut out_len,
+            )
+        };
+
+        assert_eq!(status, 0);
+        let recursive = decode_recursive_proof(out_ptr, out_len);
+        assert_recursive_proof_verifies(
+            &recursive,
+            audit.public_inputs_hash().expect("public input hash"),
+        );
+    }
+
+    #[test]
+    fn offline_note_v2_prover_ffi_rejects_invalid_archive() {
+        let bad_archive = b"not a norito archive";
+        let mut out_ptr: *mut c_uchar = ptr::null_mut();
+        let mut out_len: c_ulong = 0;
+
+        let status = unsafe {
+            connect_norito_offline_prove_note_v2_redeem(
+                bad_archive.as_ptr(),
+                bad_archive.len() as c_ulong,
+                &mut out_ptr,
+                &mut out_len,
+            )
+        };
+
+        assert_eq!(status, ERR_OFFLINE_NOTE_V2_PROVE);
+        assert!(out_ptr.is_null());
+        assert_eq!(out_len, 0);
     }
 }
 

--- a/crates/iroha_data_model/src/block/consensus.rs
+++ b/crates/iroha_data_model/src/block/consensus.rs
@@ -1785,7 +1785,7 @@ pub struct SumeragiNposTimeoutsStatus {
     pub witness_ms: u64,
 }
 
-/// Observational NPoS repair fanout stake-coverage snapshot.
+/// Observational `NPoS` repair fanout stake-coverage snapshot.
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, Default)]
 #[cfg_attr(
     feature = "json",
@@ -2079,7 +2079,7 @@ pub struct SumeragiStatusWire {
     /// DELIVER-to-next-proposal gap snapshot.
     #[norito(default)]
     pub round_gap: SumeragiRoundGapStatus,
-    /// Observational NPoS repair fanout coverage, present only when locally recorded.
+    /// Observational `NPoS` repair fanout coverage, present only when locally recorded.
     #[norito(skip_serializing_if = "Option::is_none")]
     #[norito(default)]
     pub npos_repair_coverage: Option<SumeragiNposRepairCoverageStatus>,

--- a/crates/iroha_data_model/src/events/mod.rs
+++ b/crates/iroha_data_model/src/events/mod.rs
@@ -489,10 +489,10 @@ impl IntoSchema for SharedDataEvent {
 
     fn update_schema_map(metamap: &mut MetaMap) {
         data::DataEvent::update_schema_map(metamap);
-        if !metamap.contains_key::<Self>() {
-            if let Some(metadata) = metamap.get::<data::DataEvent>() {
-                metamap.insert::<Self>(metadata.clone());
-            }
+        if !metamap.contains_key::<Self>()
+            && let Some(metadata) = metamap.get::<data::DataEvent>()
+        {
+            metamap.insert::<Self>(metadata.clone());
         }
     }
 }

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,13 +1,13 @@
 # Roadmap (Open Work Only)
 
-Last updated: 2026-04-29
+Last updated: 2026-04-30
 
 Completed history lives in `status.md`. This file should only track unfinished work.
 
 ## Validation corridor
 
 - Carry Offline V2 real-proof support through the remaining release corridor.
-  - Fold the new prover slice into a broader `cargo test -p iroha_core --lib`, SDK test, and workspace clippy corridor when validation budget allows.
+  - The native bridge prover FFI focused corridor is green as of 2026-04-30. Fold it into a broader `cargo test -p iroha_core --lib`, SDK test, and workspace clippy corridor when validation budget allows.
 - Carry native asset escrow through the remaining Aitai application corridor.
   - Wire the Sora Aitai application UI/backend onto the native numeric escrow ISIs and proof-carrying anonymous escrow helper surfaces, then subscribe through the numeric and anonymous escrow query/event APIs.
   - Add app-facing lifecycle events for transparent and shielded offer state changes, and keep any remaining Kotodama wrapper work scoped to app calls that still need contract compatibility.

--- a/status.md
+++ b/status.md
@@ -1,6 +1,29 @@
 # Status
 
-Last updated: 2026-04-29
+Last updated: 2026-04-30
+
+## 2026-04-30 Offline V2 native bridge prover FFI
+
+- Rebased PR #5578 onto the current `i23-features` branch and narrowed it to
+  the shared `connect_norito_bridge` C-FFI prover surface. Swift keeps using
+  its native `Halo2OfflineNoteV2Prover` path, while the bridge now exposes
+  Rust-backed redeem/audit proof generation for other native consumers.
+- Added `connect_norito_offline_prove_note_v2_redeem` and
+  `connect_norito_offline_prove_note_v2_audit`, returning Norito-archive
+  `OfflineNoteRecursiveProofV2` payloads with canonical verifier-key id,
+  public-input hash, and Halo2/IPA proof bytes.
+- Added bridge tests that decode the FFI output, check the proof binding, and
+  verify the returned proof against the canonical Offline V2 verifier. Invalid
+  archives now fail through `CONNECT_NORITO_ERR_OFFLINE_NOTE_V2_PROVE`.
+- Fixed three current `iroha_data_model` clippy findings surfaced by the
+  bridge clippy pass: two `NPoS` doc-markdown warnings and one collapsible
+  schema-map branch.
+- Focused validation for this slice:
+  - `cargo fmt --all`
+  - `cargo fmt --all --check`
+  - `cargo test -p connect_norito_bridge offline_note_v2_ -- --nocapture`
+  - `cargo test -p connect_norito_bridge`
+  - `cargo clippy -p connect_norito_bridge --all-targets -- -D warnings`
 
 ## 2026-04-29 NPoS PRF seed recovery repair
 


### PR DESCRIPTION
## Summary

Expose the Rust-backed Offline Note V2 Halo2/IPA prover as C-FFI entrypoints in `connect_norito_bridge` for native consumers that need to generate the recursive proofs accepted by `RedeemOfflineNoteV2` and `AuditOfflineNoteV2`.

The current `i23-features` branch already has the Swift-native `Halo2OfflineNoteV2Prover`, so this PR is now narrowed to the shared bridge surface instead of adding Swift `NativeBridge` wrappers or rebuilding the Swift xcframework hash manifest.

## Changes

### `connect_norito_bridge`
- Adds an `iroha_core` dependency with the `zk-halo2-ipa` prover surface enabled.
- Adds `CONNECT_NORITO_ERR_OFFLINE_NOTE_V2_PROVE` / `BridgeError::OfflineNoteV2Prove` (`-310`).
- Adds C-FFI exports:
  - `connect_norito_offline_prove_note_v2_redeem(redeem_norito_ptr, len, out_ptr, out_len)`
  - `connect_norito_offline_prove_note_v2_audit(audit_norito_ptr, len, out_ptr, out_len)`

  **Input:** Norito-archive bytes of `OfflineNoteRedeemV2` / `OfflineNoteAuditBundleV2`; the existing `recursive_proof` field is ignored, so callers may pass a stub.

  **Output:** Norito-archive bytes of an assembled `OfflineNoteRecursiveProofV2` carrying the canonical verifier-key id, recomputed `public_inputs_hash`, and generated `ProofBox`. Callers decode it, slot it back into the redemption/audit payload, and submit the V2 ISI.

### Tests and cleanup
- Adds bridge tests that call the FFI, decode the returned recursive proof, assert the verifier-key id and public-input hash binding, and verify the proof against the canonical Offline V2 verifier.
- Adds invalid-archive coverage for `CONNECT_NORITO_ERR_OFFLINE_NOTE_V2_PROVE`.
- Fixes three current `iroha_data_model` clippy findings surfaced by the bridge clippy pass: two `NPoS` doc-markdown warnings and one collapsible schema-map branch.
- Updates `status.md` / `roadmap.md` with the rebased scope and validation status.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo fmt --all --check`
- [x] `cargo test -p connect_norito_bridge offline_note_v2_ -- --nocapture`
- [x] `cargo test -p connect_norito_bridge`
- [x] `cargo clippy -p connect_norito_bridge --all-targets -- -D warnings`

## Notes

- The bridge calls `prove_offline_note_v2_*(.., proving_key_bytes: None)`, so the proving key is derived per call. A follow-up can add a cached proving-key path if native clients need lower latency.
- Swift consumers should continue using the current `Halo2OfflineNoteV2Prover` path on `i23-features`; this PR intentionally does not add Swift `NativeBridge` wrappers.
