### PR TITLE
Add OfflineNoteV2TransactionEncoder

### DIFF
--- a/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/OfflineNote.java
+++ b/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/OfflineNote.java
@@ -21,10 +21,12 @@ import org.hyperledger.iroha.android.address.AssetDefinitionIdEncoder;
 import org.hyperledger.iroha.android.address.PublicKeyCodec;
 import org.hyperledger.iroha.android.crypto.IrohaHash;
 import org.hyperledger.iroha.android.model.InstructionBox;
+import org.hyperledger.iroha.norito.CRC64;
 import org.hyperledger.iroha.norito.NoritoCodec;
 import org.hyperledger.iroha.norito.NoritoDecoder;
 import org.hyperledger.iroha.norito.NoritoEncoder;
 import org.hyperledger.iroha.norito.NoritoHeader;
+import org.hyperledger.iroha.norito.SchemaHash;
 import org.hyperledger.iroha.norito.TypeAdapter;
 
 /** Native Java implementation of Iroha Offline Note canonical Norito encodings. */
@@ -260,8 +262,34 @@ public final class OfflineNote {
     return NoritoCodec.decode(bytes, adapter, schema);
   }
 
-  private static byte[] encodeInstructionWrapper(final String schema, final byte[] modelPayload) {
-    return NoritoCodec.encode(modelPayload, schema, INSTRUCTION_WRAPPER_ADAPTER, 0);
+  private static byte[] encodeInstructionWrapper(final String schema, final byte[] modelFrame) {
+    final byte[] modelBody = NoritoHeader.decode(modelFrame, null).payload();
+    return frameInstruction(schema, modelBody);
+  }
+
+  private static byte[] frameInstruction(final String wireName, final byte[] modelBody) {
+    if (wireName == null || wireName.isBlank()) {
+      throw new IllegalArgumentException("wireName must not be blank");
+    }
+    if (modelBody == null || modelBody.length == 0) {
+      throw new IllegalArgumentException("modelBody must not be empty");
+    }
+    final NoritoEncoder innerEncoder = new NoritoEncoder(NoritoHeader.COMPACT_LEN);
+    innerEncoder.writeLength(modelBody.length, true);
+    innerEncoder.writeBytes(modelBody);
+    final byte[] inner = innerEncoder.toByteArray();
+    final NoritoHeader header =
+        new NoritoHeader(
+            SchemaHash.hash16(wireName),
+            inner.length,
+            CRC64.compute(inner),
+            NoritoHeader.COMPACT_LEN,
+            NoritoHeader.COMPRESSION_NONE);
+    final byte[] headerBytes = header.encode();
+    final byte[] out = new byte[headerBytes.length + inner.length];
+    System.arraycopy(headerBytes, 0, out, 0, headerBytes.length);
+    System.arraycopy(inner, 0, out, headerBytes.length, inner.length);
+    return out;
   }
 
   private static <T> T decodeInstructionModel(
@@ -1766,19 +1794,6 @@ public final class OfflineNote {
           outputAmounts);
     }
   }
-
-  private static final TypeAdapter<byte[]> INSTRUCTION_WRAPPER_ADAPTER =
-      new TypeAdapter<>() {
-        @Override
-        public void encode(final NoritoEncoder encoder, final byte[] value) {
-          writeField(encoder, child -> child.writeBytes(value));
-        }
-
-        @Override
-        public byte[] decode(final NoritoDecoder decoder) {
-          return readField(decoder, child -> child.readBytes(child.remaining()));
-        }
-      };
 
   private record InstructionModelPayload(byte[] bytes, int flags) {}
 

--- a/java/iroha_android/src/test/java/org/hyperledger/iroha/android/offline/OfflineNoteTest.java
+++ b/java/iroha_android/src/test/java/org/hyperledger/iroha/android/offline/OfflineNoteTest.java
@@ -38,8 +38,18 @@ import org.hyperledger.iroha.android.model.InstructionBox;
 import org.hyperledger.iroha.android.model.TransactionPayload;
 import org.hyperledger.iroha.android.norito.NoritoJavaCodecAdapter;
 import org.hyperledger.iroha.android.tx.SignedTransaction;
+import org.hyperledger.iroha.norito.NoritoDecoder;
+import org.hyperledger.iroha.norito.NoritoHeader;
+import org.hyperledger.iroha.norito.SchemaHash;
 
 public final class OfflineNoteTest {
+
+  private static final String MODEL_ISSUE_SCHEMA =
+      "iroha_data_model::offline::model::OfflineNoteIssueV2";
+  private static final String MODEL_REDEEM_SCHEMA =
+      "iroha_data_model::offline::model::OfflineNoteRedeemV2";
+  private static final String MODEL_AUDIT_SCHEMA =
+      "iroha_data_model::offline::model::OfflineNoteAuditBundleV2";
 
   private OfflineNoteTest() {}
 
@@ -49,6 +59,7 @@ public final class OfflineNoteTest {
     offlineNoteModelsMatchRustNoritoVectors();
     publicNoritoDecodersRoundTripFixturePayloads();
     publicNoritoInstructionDecodersReadExplorerEnvelopeBytes();
+    offlineNoteV2InstructionsUseChainFraming();
     walletDerivationsMatchRustVectors();
     publicInputHashesMatchRustVectors();
     proofBindingRejectsMismatch();
@@ -350,6 +361,25 @@ public final class OfflineNoteTest {
                         wirePayloadBytes(OfflineNote.redeemInstruction(redeem))))
                 .noritoEncoded()),
         "decoded redeem instruction");
+  }
+
+  private static void offlineNoteV2InstructionsUseChainFraming() throws Exception {
+    final Map<String, Object> fixture = loadFixture();
+    assertInstructionFraming(
+        OfflineNote.issueInstruction(issue(fixture)),
+        OfflineNote.ISSUE_INSTRUCTION_SCHEMA,
+        MODEL_ISSUE_SCHEMA,
+        modelBodyFromFixture(fixture, "issue", MODEL_ISSUE_SCHEMA));
+    assertInstructionFraming(
+        OfflineNote.redeemInstruction(redeem(fixture)),
+        OfflineNote.REDEEM_INSTRUCTION_SCHEMA,
+        MODEL_REDEEM_SCHEMA,
+        modelBodyFromFixture(fixture, "redeem", MODEL_REDEEM_SCHEMA));
+    assertInstructionFraming(
+        OfflineNote.auditInstruction(audit(fixture)),
+        OfflineNote.AUDIT_INSTRUCTION_SCHEMA,
+        MODEL_AUDIT_SCHEMA,
+        modelBodyFromFixture(fixture, "audit", MODEL_AUDIT_SCHEMA));
   }
 
   private static void walletDerivationsMatchRustVectors() throws Exception {
@@ -5102,6 +5132,49 @@ public final class OfflineNoteTest {
       out.write((int) (remaining & 0xFF));
       remaining >>>= 8;
     }
+  }
+
+  private static void assertInstructionFraming(
+      final InstructionBox box,
+      final String expectedWireName,
+      final String modelSchemaPath,
+      final byte[] expectedModelBody) {
+    if (!(box.payload() instanceof InstructionBox.WirePayload)) {
+      throw new AssertionError("instruction payload must be a WirePayload");
+    }
+    final InstructionBox.WirePayload payload = (InstructionBox.WirePayload) box.payload();
+    assertEquals(expectedWireName, payload.wireName(), "instruction wire name");
+
+    final byte[] instructionSchema = SchemaHash.hash16(expectedWireName);
+    final byte[] modelSchema = SchemaHash.hash16(modelSchemaPath);
+    final NoritoHeader.DecodeResult decoded =
+        NoritoHeader.decode(payload.payloadBytes(), instructionSchema);
+    assertEquals(
+        NoritoHeader.COMPACT_LEN,
+        decoded.header().flags(),
+        "outer instruction frame flags");
+    assertEquals(
+        NoritoHeader.COMPRESSION_NONE,
+        decoded.header().compression(),
+        "outer instruction frame compression");
+    assertTrue(
+        !Arrays.equals(decoded.header().schemaHash(), modelSchema),
+        "frame schema hash must not equal the inner model schema hash");
+
+    final NoritoDecoder innerDecoder =
+        new NoritoDecoder(decoded.payload(), decoded.header().flags(), 0);
+    final long declaredLength = innerDecoder.readLength(true);
+    assertEquals(expectedModelBody.length, declaredLength, "inner field compact length");
+    final byte[] innerField = innerDecoder.readBytes((int) declaredLength);
+    assertEquals(0L, innerDecoder.remaining(), "no trailing bytes after inner field");
+    assertEquals(hex(expectedModelBody), hex(innerField), "inner field bytes");
+  }
+
+  private static byte[] modelBodyFromFixture(
+      final Map<String, Object> fixture, final String chainKey, final String modelSchemaPath) {
+    final byte[] full =
+        base64Bytes(string(obj(obj(fixture, "chain_vectors"), chainKey), "norito_base64"));
+    return NoritoHeader.decode(full, SchemaHash.hash16(modelSchemaPath)).payload();
   }
 
   @SuppressWarnings("unchecked")

--- a/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/offline/OfflineNote.kt
+++ b/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/offline/OfflineNote.kt
@@ -12,10 +12,12 @@ import org.hyperledger.iroha.sdk.address.PublicKeyPayload
 import org.hyperledger.iroha.sdk.address.algorithmForCurveId
 import org.hyperledger.iroha.sdk.core.model.InstructionBox
 import org.hyperledger.iroha.sdk.crypto.IrohaHash
+import org.hyperledger.iroha.sdk.norito.CRC64
 import org.hyperledger.iroha.sdk.norito.NoritoCodec
 import org.hyperledger.iroha.sdk.norito.NoritoDecoder
 import org.hyperledger.iroha.sdk.norito.NoritoEncoder
 import org.hyperledger.iroha.sdk.norito.NoritoHeader
+import org.hyperledger.iroha.sdk.norito.SchemaHash
 import org.hyperledger.iroha.sdk.norito.TypeAdapter
 
 /** Native JVM implementation of Iroha Offline Note canonical Norito encodings. */
@@ -256,8 +258,31 @@ object OfflineNote {
     private fun <T> decodeWithHeader(bytes: ByteArray, schema: String, adapter: TypeAdapter<T>): T =
         NoritoCodec.decode(bytes, adapter, schema)
 
-    private fun encodeInstructionWrapper(schema: String, modelPayload: ByteArray): ByteArray =
-        NoritoCodec.encode(modelPayload, schema, InstructionWrapperAdapter, 0)
+    internal fun encodeInstructionWrapper(schema: String, modelFrame: ByteArray): ByteArray {
+        val modelBody = NoritoHeader.decode(modelFrame, expectedHash = null).payload
+        return frameInstruction(schema, modelBody)
+    }
+
+    internal fun frameInstruction(wireName: String, modelBody: ByteArray): ByteArray {
+        require(wireName.isNotBlank()) { "wireName must not be blank" }
+        require(modelBody.isNotEmpty()) { "modelBody must not be empty" }
+        val inner = NoritoEncoder(NoritoHeader.COMPACT_LEN).apply {
+            writeLength(modelBody.size.toLong(), compact = true)
+            writeBytes(modelBody)
+        }.toByteArray()
+        val header = NoritoHeader(
+            schemaHash = SchemaHash.hash16(wireName),
+            payloadLength = inner.size,
+            checksum = CRC64.compute(inner),
+            flags = NoritoHeader.COMPACT_LEN,
+            compression = NoritoHeader.COMPRESSION_NONE,
+        )
+        val headerBytes = header.encode()
+        val out = ByteArray(headerBytes.size + inner.size)
+        System.arraycopy(headerBytes, 0, out, 0, headerBytes.size)
+        System.arraycopy(inner, 0, out, headerBytes.size, inner.size)
+        return out
+    }
 
     private fun <T> decodeInstructionModel(
         bytes: ByteArray,
@@ -971,15 +996,6 @@ object OfflineNote {
                 outputAmounts,
             )
         }
-    }
-
-    private object InstructionWrapperAdapter : TypeAdapter<ByteArray> {
-        override fun encode(encoder: NoritoEncoder, value: ByteArray) {
-            writeField(encoder) { it.writeBytes(value) }
-        }
-
-        override fun decode(decoder: NoritoDecoder): ByteArray =
-            readField(decoder) { it.readBytes(it.remaining()) }
     }
 
     private class InstructionModelPayload(

--- a/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/offline/OfflineNoteTransactionEncoder.kt
+++ b/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/offline/OfflineNoteTransactionEncoder.kt
@@ -1,0 +1,172 @@
+// Copyright 2024 Hyperledger Iroha Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hyperledger.iroha.sdk.offline
+
+import org.hyperledger.iroha.sdk.core.model.Executable
+import org.hyperledger.iroha.sdk.core.model.InstructionBox
+import org.hyperledger.iroha.sdk.core.model.TransactionPayload
+import org.hyperledger.iroha.sdk.crypto.Signer
+import org.hyperledger.iroha.sdk.tx.SignedTransaction
+import org.hyperledger.iroha.sdk.tx.TransactionBuilder
+
+internal const val INSTRUCTION_ISSUE_WIRE_NAME: String =
+    OfflineNote.ISSUE_INSTRUCTION_SCHEMA
+internal const val INSTRUCTION_REDEEM_WIRE_NAME: String =
+    OfflineNote.REDEEM_INSTRUCTION_SCHEMA
+internal const val INSTRUCTION_AUDIT_WIRE_NAME: String =
+    OfflineNote.AUDIT_INSTRUCTION_SCHEMA
+
+/**
+ * Builds signed transactions carrying the Offline Note chain instructions
+ * (`IssueOfflineNote`, `RedeemOfflineNote`, `AuditOfflineNote`).
+ *
+ * Each instruction is delivered to the chain as the raw model body (the output of
+ * [OfflineNote.encodeIssue] / [OfflineNote.encodeRedeem] / [OfflineNote.encodeAudit] with the
+ * outer model header stripped) wrapped in a canonical Norito frame whose schema hash is the
+ * instruction wire name (e.g. `iroha_data_model::isi::offline::IssueOfflineNote`). The frame uses
+ * the standard v1 `COMPACT_LEN` flag so the body round-trips through the chain's
+ * `frame_bare_with_header_flags` decoder. The wrapped payload
+ * carries one compact field-length prefix before the raw model body.
+ *
+ * The wrapped bytes are bound to the wire name via [InstructionBox.fromWirePayload] and placed in
+ * [Executable.instructions]; the resulting [TransactionPayload] is signed via the supplied
+ * [TransactionBuilder].
+ *
+ * [OfflineNote.redeemInstruction] and [OfflineNote.auditInstruction] call
+ * [OfflineNote.Redeem.validateProofBinding] / [OfflineNote.AuditBundle.validateProofBinding]
+ * internally so proof-binding mismatches surface as `IllegalArgumentException` from the build call
+ * rather than producing a transaction that the ledger will later reject.
+ */
+class OfflineNoteTransactionEncoder(
+    private val transactionBuilder: TransactionBuilder,
+) {
+
+    /** Inputs for [buildIssueOfflineNote]. */
+    data class IssueOfflineNoteRequest(
+        val chainId: String,
+        val authority: String,
+        val issue: OfflineNote.Issue,
+        val ttlMs: Long? = null,
+        val nonce: Int? = null,
+    )
+
+    /** Inputs for [buildRedeemOfflineNote]. */
+    data class RedeemOfflineNoteRequest(
+        val chainId: String,
+        val authority: String,
+        val redemption: OfflineNote.Redeem,
+        val ttlMs: Long? = null,
+        val nonce: Int? = null,
+    )
+
+    /** Inputs for [buildAuditOfflineNote]. */
+    data class AuditOfflineNoteRequest(
+        val chainId: String,
+        val authority: String,
+        val audit: OfflineNote.AuditBundle,
+        val ttlMs: Long? = null,
+        val nonce: Int? = null,
+    )
+
+    /** Builds and signs a transaction that carries a single `IssueOfflineNote` instruction. */
+    fun buildIssueOfflineNote(
+        request: IssueOfflineNoteRequest,
+        signer: Signer,
+        creationTimeMs: Long,
+    ): SignedTransaction {
+        val box = issueInstructionBox(request.issue)
+        return signTransaction(
+            chainId = request.chainId,
+            authority = request.authority,
+            creationTimeMs = creationTimeMs,
+            ttlMs = request.ttlMs,
+            nonce = request.nonce,
+            instruction = box,
+            signer = signer,
+        )
+    }
+
+    /**
+     * Builds and signs a transaction that carries a single `RedeemOfflineNote` instruction.
+     *
+     * Calls [OfflineNote.Redeem.validateProofBinding] (via [OfflineNote.redeemInstruction])
+     * before encoding so a mismatched recursive proof public-inputs hash is rejected up front.
+     */
+    fun buildRedeemOfflineNote(
+        request: RedeemOfflineNoteRequest,
+        signer: Signer,
+        creationTimeMs: Long,
+    ): SignedTransaction {
+        val box = redeemInstructionBox(request.redemption)
+        return signTransaction(
+            chainId = request.chainId,
+            authority = request.authority,
+            creationTimeMs = creationTimeMs,
+            ttlMs = request.ttlMs,
+            nonce = request.nonce,
+            instruction = box,
+            signer = signer,
+        )
+    }
+
+    /**
+     * Builds and signs a transaction that carries a single `AuditOfflineNote` instruction.
+     *
+     * Calls [OfflineNote.AuditBundle.validateProofBinding] (via [OfflineNote.auditInstruction])
+     * before encoding so a mismatched recursive proof public-inputs hash is rejected up front.
+     */
+    fun buildAuditOfflineNote(
+        request: AuditOfflineNoteRequest,
+        signer: Signer,
+        creationTimeMs: Long,
+    ): SignedTransaction {
+        val box = auditInstructionBox(request.audit)
+        return signTransaction(
+            chainId = request.chainId,
+            authority = request.authority,
+            creationTimeMs = creationTimeMs,
+            ttlMs = request.ttlMs,
+            nonce = request.nonce,
+            instruction = box,
+            signer = signer,
+        )
+    }
+
+    private fun signTransaction(
+        chainId: String,
+        authority: String,
+        creationTimeMs: Long,
+        ttlMs: Long?,
+        nonce: Int?,
+        instruction: InstructionBox,
+        signer: Signer,
+    ): SignedTransaction {
+        val payload = TransactionPayload(
+            chainId = chainId,
+            authority = authority,
+            creationTimeMs = creationTimeMs,
+            executable = Executable.instructions(listOf(instruction)),
+            timeToLiveMs = ttlMs,
+            nonce = nonce,
+        )
+        return transactionBuilder.encodeAndSign(payload, signer)
+    }
+
+    companion object {
+        /** Wraps an Offline Note issue model body (header-stripped) as a typed instruction. */
+        @JvmStatic
+        fun issueInstructionBox(issue: OfflineNote.Issue): InstructionBox =
+            OfflineNote.issueInstruction(issue)
+
+        /** Wraps an Offline Note redeem model body (header-stripped) as a typed instruction. */
+        @JvmStatic
+        fun redeemInstructionBox(redemption: OfflineNote.Redeem): InstructionBox =
+            OfflineNote.redeemInstruction(redemption)
+
+        /** Wraps an Offline Note audit model body (header-stripped) as a typed instruction. */
+        @JvmStatic
+        fun auditInstructionBox(audit: OfflineNote.AuditBundle): InstructionBox =
+            OfflineNote.auditInstruction(audit)
+    }
+}

--- a/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/offline/OfflineNoteTransactionEncoderTest.kt
+++ b/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/offline/OfflineNoteTransactionEncoderTest.kt
@@ -1,0 +1,422 @@
+package org.hyperledger.iroha.sdk.offline
+
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.security.MessageDigest
+import java.util.Base64
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import org.hyperledger.iroha.sdk.norito.NoritoDecoder
+import org.hyperledger.iroha.sdk.client.JsonParser
+import org.hyperledger.iroha.sdk.core.model.Executable
+import org.hyperledger.iroha.sdk.core.model.InstructionBox
+import org.hyperledger.iroha.sdk.core.model.WirePayload
+import org.hyperledger.iroha.sdk.crypto.Signer
+import org.hyperledger.iroha.sdk.norito.NoritoHeader
+import org.hyperledger.iroha.sdk.norito.SchemaHash
+import org.hyperledger.iroha.sdk.tx.TransactionBuilder
+import org.hyperledger.iroha.sdk.tx.norito.NoritoJavaCodecAdapter
+
+private const val CHAIN_ID = "00000000"
+private const val CREATION_TIME_MS = 1_745_000_000_000L
+private const val NONCE = 7
+private const val TTL_MS = 60_000L
+private const val SIGNATURE_LENGTH = 64
+
+private const val MODEL_ISSUE_SCHEMA = "iroha_data_model::offline::model::OfflineNoteIssue"
+private const val MODEL_REDEEM_SCHEMA = "iroha_data_model::offline::model::OfflineNoteRedeem"
+private const val MODEL_AUDIT_SCHEMA = "iroha_data_model::offline::model::OfflineNoteAuditBundle"
+
+class OfflineNoteTransactionEncoderTest {
+
+    @Test
+    fun buildIssueOfflineNote_producesCorrectlyFramedInstruction() {
+        val fixture = loadFixture()
+        val expectedModelBody = modelBodyFromFixture(fixture, "issue", MODEL_ISSUE_SCHEMA)
+        val request = OfflineNoteTransactionEncoder.IssueOfflineNoteRequest(
+            chainId = CHAIN_ID,
+            authority = senderAuthority(fixture),
+            issue = issue(fixture),
+            ttlMs = TTL_MS,
+            nonce = NONCE,
+        )
+        val signed = encoder().buildIssueOfflineNote(request, signer(), CREATION_TIME_MS)
+
+        val box = singleInstruction(signed)
+        assertWireFraming(
+            box = box,
+            expectedWireName = INSTRUCTION_ISSUE_WIRE_NAME,
+            modelSchemaPath = MODEL_ISSUE_SCHEMA,
+            expectedModelBody = expectedModelBody,
+        )
+    }
+
+    @Test
+    fun buildRedeemOfflineNote_producesCorrectlyFramedInstruction() {
+        val fixture = loadFixture()
+        val expectedModelBody = modelBodyFromFixture(fixture, "redeem", MODEL_REDEEM_SCHEMA)
+        val request = OfflineNoteTransactionEncoder.RedeemOfflineNoteRequest(
+            chainId = CHAIN_ID,
+            authority = recipientAuthority(fixture),
+            redemption = redeem(fixture),
+            ttlMs = TTL_MS,
+            nonce = NONCE,
+        )
+        val signed = encoder().buildRedeemOfflineNote(request, signer(), CREATION_TIME_MS)
+
+        val box = singleInstruction(signed)
+        assertWireFraming(
+            box = box,
+            expectedWireName = INSTRUCTION_REDEEM_WIRE_NAME,
+            modelSchemaPath = MODEL_REDEEM_SCHEMA,
+            expectedModelBody = expectedModelBody,
+        )
+    }
+
+    @Test
+    fun buildAuditOfflineNote_producesCorrectlyFramedInstruction() {
+        val fixture = loadFixture()
+        val expectedModelBody = modelBodyFromFixture(fixture, "audit", MODEL_AUDIT_SCHEMA)
+        val request = OfflineNoteTransactionEncoder.AuditOfflineNoteRequest(
+            chainId = CHAIN_ID,
+            authority = senderAuthority(fixture),
+            audit = audit(fixture),
+            ttlMs = TTL_MS,
+            nonce = NONCE,
+        )
+        val signed = encoder().buildAuditOfflineNote(request, signer(), CREATION_TIME_MS)
+
+        val box = singleInstruction(signed)
+        assertWireFraming(
+            box = box,
+            expectedWireName = INSTRUCTION_AUDIT_WIRE_NAME,
+            modelSchemaPath = MODEL_AUDIT_SCHEMA,
+            expectedModelBody = expectedModelBody,
+        )
+    }
+
+    @Test
+    fun directOfflineNoteInstructions_produceCorrectlyFramedInstructions() {
+        val fixture = loadFixture()
+
+        assertWireFraming(
+            box = OfflineNote.issueInstruction(issue(fixture)),
+            expectedWireName = INSTRUCTION_ISSUE_WIRE_NAME,
+            modelSchemaPath = MODEL_ISSUE_SCHEMA,
+            expectedModelBody = modelBodyFromFixture(fixture, "issue", MODEL_ISSUE_SCHEMA),
+        )
+        assertWireFraming(
+            box = OfflineNote.redeemInstruction(redeem(fixture)),
+            expectedWireName = INSTRUCTION_REDEEM_WIRE_NAME,
+            modelSchemaPath = MODEL_REDEEM_SCHEMA,
+            expectedModelBody = modelBodyFromFixture(fixture, "redeem", MODEL_REDEEM_SCHEMA),
+        )
+        assertWireFraming(
+            box = OfflineNote.auditInstruction(audit(fixture)),
+            expectedWireName = INSTRUCTION_AUDIT_WIRE_NAME,
+            modelSchemaPath = MODEL_AUDIT_SCHEMA,
+            expectedModelBody = modelBodyFromFixture(fixture, "audit", MODEL_AUDIT_SCHEMA),
+        )
+    }
+
+    @Test
+    fun buildRedeemOfflineNote_rejectsMismatchedProofBinding() {
+        val fixture = loadFixture()
+        val redeem = redeem(fixture)
+        val forged = OfflineNote.Redeem(
+            sourceNoteCommitment = redeem.sourceNoteCommitment(),
+            inputNullifiers = redeem.inputNullifiers(),
+            senderKeyCertificate = redeem.senderKeyCertificate,
+            recipient = redeem.recipient,
+            assetId = redeem.assetId,
+            amount = redeem.amount,
+            recursiveProof = OfflineNote.RecursiveProof(
+                publicInputsHash = OfflineNote.hash("forged-redeem-public-inputs".toByteArray()),
+                proof = OfflineNote.ProofBox(
+                    OfflineNote.RECURSIVE_BACKEND,
+                    "offline-vector-redeem-proof".toByteArray(),
+                ),
+            ),
+        )
+        val request = OfflineNoteTransactionEncoder.RedeemOfflineNoteRequest(
+            chainId = CHAIN_ID,
+            authority = recipientAuthority(fixture),
+            redemption = forged,
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            encoder().buildRedeemOfflineNote(request, signer(), CREATION_TIME_MS)
+        }
+    }
+
+    @Test
+    fun buildAuditOfflineNote_rejectsMismatchedProofBinding() {
+        val fixture = loadFixture()
+        val audit = audit(fixture)
+        val forged = OfflineNote.AuditBundle(
+            tokenId = audit.tokenId(),
+            senderKeyCertificate = audit.senderKeyCertificate,
+            inputNullifiers = audit.inputNullifiers(),
+            inputClaims = audit.inputClaims,
+            outputCommitments = audit.outputCommitments(),
+            outputClaims = audit.outputClaims,
+            recursiveProof = OfflineNote.RecursiveProof(
+                publicInputsHash = OfflineNote.hash("forged-audit-public-inputs".toByteArray()),
+                proof = OfflineNote.ProofBox(
+                    OfflineNote.RECURSIVE_BACKEND,
+                    "offline-vector-audit-proof".toByteArray(),
+                ),
+            ),
+        )
+        val request = OfflineNoteTransactionEncoder.AuditOfflineNoteRequest(
+            chainId = CHAIN_ID,
+            authority = senderAuthority(fixture),
+            audit = forged,
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            encoder().buildAuditOfflineNote(request, signer(), CREATION_TIME_MS)
+        }
+    }
+
+    @Test
+    fun buildIssueOfflineNote_isDeterministic() {
+        val fixture = loadFixture()
+        val request = OfflineNoteTransactionEncoder.IssueOfflineNoteRequest(
+            chainId = CHAIN_ID,
+            authority = senderAuthority(fixture),
+            issue = issue(fixture),
+            ttlMs = TTL_MS,
+            nonce = NONCE,
+        )
+        val first = encoder().buildIssueOfflineNote(request, signer(), CREATION_TIME_MS)
+        val second = encoder().buildIssueOfflineNote(request, signer(), CREATION_TIME_MS)
+
+        assertContentEquals(first.encodedPayload(), second.encodedPayload(), "encoded payload must be deterministic")
+        assertContentEquals(first.signature(), second.signature(), "signature must be deterministic given the same signer")
+        assertContentEquals(first.publicKey(), second.publicKey(), "public key must be stable across builds")
+        assertEquals(first.schemaName(), second.schemaName(), "schema name must be stable")
+    }
+
+    private fun assertWireFraming(
+        box: InstructionBox,
+        expectedWireName: String,
+        modelSchemaPath: String,
+        expectedModelBody: ByteArray,
+    ) {
+        val payload = box.payload
+        assertTrue(payload is WirePayload, "instruction payload must be a WirePayload, got ${payload::class.simpleName}")
+        assertEquals(expectedWireName, payload.wireName, "instruction wire name must match")
+
+        val framed = payload.payloadBytes
+        val instructionSchema = SchemaHash.hash16(expectedWireName)
+        val modelSchema = SchemaHash.hash16(modelSchemaPath)
+        val decoded = NoritoHeader.decode(framed, expectedHash = instructionSchema)
+        assertEquals(
+            NoritoHeader.COMPACT_LEN,
+            decoded.header.flags,
+            "outer instruction frame must use the chain's default v1 flags (COMPACT_LEN)",
+        )
+        assertEquals(NoritoHeader.COMPRESSION_NONE, decoded.header.compression, "outer instruction frame must be uncompressed")
+        assertContentEquals(instructionSchema, decoded.header.schemaHash, "frame schema hash must equal the instruction wire name hash")
+        assertTrue(
+            !decoded.header.schemaHash.contentEquals(modelSchema),
+            "frame schema hash must NOT equal the inner model schema hash ($modelSchemaPath)",
+        )
+
+        // The chain expects the outer ISI single-field newtype wrapper layout:
+        // `[compact-varint(inner.len)][inner_archive_bytes]`. Verify the wallet's
+        // bytes follow that contract — varint then the raw model body verbatim.
+        val innerDecoder = NoritoDecoder(decoded.payload, decoded.header.flags, 0)
+        val declaredLength = innerDecoder.readLength(compact = true)
+        assertEquals(
+            expectedModelBody.size.toLong(),
+            declaredLength,
+            "inner field varint length must equal the raw model body size",
+        )
+        val innerField = innerDecoder.readBytes(declaredLength.toInt())
+        assertEquals(0, innerDecoder.remaining(), "no trailing bytes after inner field")
+        assertContentEquals(
+            expectedModelBody,
+            innerField,
+            "inner field bytes must equal the raw model body extracted from the fixture",
+        )
+    }
+
+    private fun modelBodyFromFixture(
+        fixture: Map<String, Any?>,
+        chainKey: String,
+        modelSchemaPath: String,
+    ): ByteArray {
+        val full = base64Bytes(string(obj(obj(fixture, "chain_vectors"), chainKey), "norito_base64"))
+        return NoritoHeader.decode(full, expectedHash = SchemaHash.hash16(modelSchemaPath)).payload
+    }
+
+    private fun singleInstruction(signed: org.hyperledger.iroha.sdk.tx.SignedTransaction): InstructionBox {
+        val payload = NoritoJavaCodecAdapter().decodeTransaction(signed.encodedPayload())
+        val executable = payload.executable
+        assertTrue(executable is Executable.Instructions, "executable must carry instructions")
+        assertEquals(1, executable.instructions.size, "exactly one instruction must be carried")
+        assertEquals(SIGNATURE_LENGTH, signed.signature().size, "signer must produce a 64-byte signature")
+        return executable.instructions.single()
+    }
+
+    private fun encoder(): OfflineNoteTransactionEncoder =
+        OfflineNoteTransactionEncoder(TransactionBuilder(NoritoJavaCodecAdapter()))
+
+    private fun senderAuthority(fixture: Map<String, Any?>): String =
+        string(obj(fixture, "payment_token"), "sender_account_id")
+
+    private fun recipientAuthority(fixture: Map<String, Any?>): String =
+        string(obj(fixture, "payment_token"), "recipient_account_id")
+
+    private fun signer(): Signer = DeterministicSigner(
+        publicKey = ByteArray(32) { (it + 1).toByte() },
+        signaturePrefix = "offline-note-test",
+    )
+
+    private fun issue(fixture: Map<String, Any?>): OfflineNote.Issue {
+        val chainIssue = obj(obj(fixture, "chain_vectors"), "issue")
+        return OfflineNote.Issue(
+            noteCommitment = hexBytes(string(chainIssue, "note_commitment")),
+            keyCertificate = certificate(obj(obj(fixture, "payment_token"), "sender_key_certificate")),
+            assetId = string(chainIssue, "asset_id"),
+            amount = string(chainIssue, "amount"),
+        )
+    }
+
+    private fun redeem(fixture: Map<String, Any?>): OfflineNote.Redeem {
+        val vector = obj(obj(fixture, "chain_vectors"), "redeem")
+        val payment = obj(fixture, "payment_token")
+        return OfflineNote.Redeem(
+            sourceNoteCommitment = hexBytes(string(vector, "source_note_commitment")),
+            inputNullifiers = list(vector, "input_nullifiers").map { hexBytes(it as String) },
+            senderKeyCertificate = certificate(obj(payment, "recipient_key_certificate")),
+            recipient = string(payment, "recipient_account_id"),
+            assetId = string(vector, "asset_id"),
+            amount = string(vector, "amount"),
+            recursiveProof = OfflineNote.RecursiveProof(
+                publicInputsHash = hexBytes(string(vector, "public_inputs_hash")),
+                proof = OfflineNote.ProofBox(
+                    OfflineNote.RECURSIVE_BACKEND,
+                    "offline-vector-redeem-proof".toByteArray(),
+                ),
+            ),
+        )
+    }
+
+    private fun audit(fixture: Map<String, Any?>): OfflineNote.AuditBundle {
+        val vector = obj(obj(fixture, "chain_vectors"), "audit")
+        val payment = obj(fixture, "payment_token")
+        return OfflineNote.AuditBundle(
+            tokenId = hexBytes(string(vector, "token_id")),
+            senderKeyCertificate = certificate(obj(payment, "sender_key_certificate")),
+            inputNullifiers = list(vector, "input_nullifiers").map { hexBytes(it as String) },
+            inputClaims = list(payment, "input_claims").map { issuedClaim(it as Map<String, Any?>) },
+            outputCommitments = list(vector, "output_commitments").map { hexBytes(it as String) },
+            outputClaims = list(payment, "output_claims").map { auditOutputClaim(it as Map<String, Any?>) },
+            recursiveProof = OfflineNote.RecursiveProof(
+                publicInputsHash = hexBytes(string(vector, "public_inputs_hash")),
+                proof = OfflineNote.ProofBox(
+                    OfflineNote.RECURSIVE_BACKEND,
+                    "offline-vector-audit-proof".toByteArray(),
+                ),
+            ),
+        )
+    }
+
+    private fun certificate(json: Map<String, Any?>): OfflineNote.KeyCertificate =
+        OfflineNote.KeyCertificate(
+            version = int(json, "version"),
+            platform = string(json, "platform"),
+            keyId = string(json, "key_id"),
+            deviceId = string(json, "device_id"),
+            accountId = string(json, "account_id"),
+            publicKey = base64Bytes(string(json, "public_key")),
+            assertionScheme = string(json, "assertion_scheme"),
+            assertionKeyAlgorithm = string(json, "assertion_key_algorithm"),
+            assertionPublicKey = base64Bytes(string(json, "assertion_public_key")),
+            assertionUsageCountLimit = nullableInt(json, "assertion_usage_count_limit"),
+            oneUse = bool(json, "one_use"),
+            issuerSignature = base64Bytes(string(json, "issuer_signature_base64")),
+        )
+
+    private fun issuedClaim(json: Map<String, Any?>): OfflineNote.IssuedClaim =
+        OfflineNote.IssuedClaim(
+            domain = string(json, "domain"),
+            noteCommitment = hexBytes(string(json, "note_commitment")),
+            keyCertificatePayloadHash = hexBytes(string(json, "key_certificate_payload_hash")),
+            assetId = string(json, "asset_id"),
+            amount = string(json, "amount"),
+        )
+
+    private fun auditOutputClaim(json: Map<String, Any?>): OfflineNote.AuditOutputClaim =
+        OfflineNote.AuditOutputClaim(
+            noteCommitment = hexBytes(string(json, "note_commitment")),
+            keyCertificate = certificate(obj(json, "key_certificate")),
+            assetId = "${string(json, "asset_definition_id")}#${string(json, "account_id")}",
+            amount = string(json, "amount"),
+        )
+
+    private fun loadFixture(): Map<String, Any?> {
+        val path = Paths.get("..", "..", "fixtures", "offline", "interop_contract.json")
+        val parsed = JsonParser.parse(String(Files.readAllBytes(path), Charsets.UTF_8))
+        @Suppress("UNCHECKED_CAST")
+        return parsed as Map<String, Any?>
+    }
+
+    private fun obj(map: Map<String, Any?>, key: String): Map<String, Any?> {
+        @Suppress("UNCHECKED_CAST")
+        return map[key] as Map<String, Any?>
+    }
+
+    private fun list(map: Map<String, Any?>, key: String): List<Any?> {
+        @Suppress("UNCHECKED_CAST")
+        return map[key] as List<Any?>
+    }
+
+    private fun string(map: Map<String, Any?>, key: String): String = map[key] as String
+    private fun bool(map: Map<String, Any?>, key: String): Boolean = map[key] as Boolean
+    private fun int(map: Map<String, Any?>, key: String): Int = (map[key] as Number).toInt()
+    private fun nullableInt(map: Map<String, Any?>, key: String): Int? = (map[key] as Number?)?.toInt()
+
+    private fun base64Bytes(value: String): ByteArray = Base64.getDecoder().decode(value)
+
+    private fun hexBytes(value: String): ByteArray {
+        require(value.length % 2 == 0) { "hex length must be even" }
+        val out = ByteArray(value.length / 2)
+        var offset = 0
+        while (offset < value.length) {
+            out[offset / 2] = value.substring(offset, offset + 2).toInt(16).toByte()
+            offset += 2
+        }
+        return out
+    }
+}
+
+private class DeterministicSigner(
+    publicKey: ByteArray,
+    private val signaturePrefix: String,
+) : Signer {
+    private val _publicKey = publicKey.copyOf()
+
+    override fun sign(message: ByteArray): ByteArray {
+        val md = MessageDigest.getInstance("SHA-256")
+        val first = md.digest(message)
+        val tail = ByteArray(signaturePrefix.length + first.size)
+        System.arraycopy(first, 0, tail, 0, first.size)
+        System.arraycopy(signaturePrefix.toByteArray(), 0, tail, first.size, signaturePrefix.length)
+        val second = md.digest(tail)
+        val out = ByteArray(SIGNATURE_LENGTH)
+        System.arraycopy(first, 0, out, 0, first.size)
+        System.arraycopy(second, 0, out, first.size, second.size)
+        return out
+    }
+
+    override fun publicKey(): ByteArray = _publicKey.copyOf()
+
+    override fun algorithm(): String = "Ed25519"
+}


### PR DESCRIPTION
## Context

The Swift SDK ships an `OfflineNoteV2TransactionEncoder` that builders use to submit Offline Note V2 chain instructions (`Issue`, `Redeem`, `Audit`). The Kotlin SDK had no equivalent, so mobile consumers on Android/JVM had to assemble instruction frames by hand — and the bare `OfflineNoteV2.{issue,redeem,audit}Instruction()` helpers wrapped bodies with `flag=0` plus an 8-byte LE length prefix, which the chain's `frame_bare_with_header_flags::<T>` decoder rejects for newtype ISIs.

This PR adds a Kotlin encoder that mirrors the Swift implementation and fixes the framing in the underlying helpers so all instruction-builder paths produce wire-compatible output. The Java SDK helpers get the matching framing fix for multi-platform alignment.

### Solution

- Add `OfflineNoteV2TransactionEncoder` in `kotlin/core-jvm`, mirroring the Swift encoder:
  - Per-instruction body is produced via `noritoEncoded()` with the outer header stripped.
  - The body is wrapped in an outer Norito frame using the `COMPACT_LEN` flag and a single compact-varint field-length prefix.
  - The result is emitted as a two-field `InstructionBox` (wire-name string + sized payload bytes).
  - Proof-binding validation runs up front for `Redeem` and `Audit` so invalid bundles fail fast (matching Swift).
- Move the framing helper into `OfflineNoteV2.kt` and rewrite `encodeInstructionWrapper` to call it, so the bare `*Instruction()`  helpers and the encoder produce the same bytes.

---

### Review notes

Suggested reading order:

1. `OfflineNoteV2TransactionEncoder.kt` — entry points (`issue`,  `redeem`, `audit`) and proof-binding validation.
2. `OfflineNoteV2.kt` — the moved framing helper and rewritten `encodeInstructionWrapper`; compare against the Swift encoder to confirm parity.
3. `OfflineNoteV2.java` — same framing change applied to the Java helpers.
4. Tests — `OfflineNoteV2TransactionEncoderTest.kt` and `OfflineNoteV2Test.java` document the new byte layout.