### PR TITLE
Add OfflineNoteV2ReceiveRequestCodec

### DIFF
--- a/crates/iroha_data_model/src/bin/offline_vectors.rs
+++ b/crates/iroha_data_model/src/bin/offline_vectors.rs
@@ -325,6 +325,7 @@ fn build_fixture() -> Result<Value, Box<dyn Error>> {
         proof_bytes_base64: &proof_bytes_base64,
     });
     let receive_request = object(vec![
+        ("version", Value::from(1_u64)),
         ("type", Value::from("offline_receive_request")),
         ("invoice_id", Value::from(INVOICE_ID)),
         (
@@ -336,6 +337,10 @@ fn build_fixture() -> Result<Value, Box<dyn Error>> {
             Value::from(asset_definition_id_string.clone()),
         ),
         ("amount", Value::from(AMOUNT)),
+        (
+            "output_commitment_hex",
+            Value::from(recipient_commitment_string.clone()),
+        ),
         (
             "recipient_key_certificate",
             mobile_certificate_json(&recipient_certificate),
@@ -1307,6 +1312,19 @@ mod tests {
         assert_eq!(
             string(field(prefixes, "receipt_ack")),
             OFFLINE_BEARER_CASH_ACK_PREFIX
+        );
+
+        let receive_request = field(&fixture, "receive_request");
+        assert_eq!(
+            string(field(receive_request, "type")),
+            "offline_receive_request"
+        );
+        assert_eq!(
+            string(field(receive_request, "output_commitment_hex")),
+            string(field(
+                field(field(&fixture, "chain_vectors"), "derivation"),
+                "recipient_output_commitment"
+            ))
         );
 
         let token = field(&fixture, "payment_token");

--- a/fixtures/offline/interop_contract.json
+++ b/fixtures/offline/interop_contract.json
@@ -386,6 +386,7 @@
     "display_ttl_ms": 60000,
     "generated_at_ms": 1706000000000,
     "invoice_id": "invoice-fixture-1",
+    "output_commitment_hex": "a81723d9eb3cc3400b805bf10063c434c7ec870735046072afbba39611e9770d",
     "recipient_key_certificate": {
       "account_id": "sorauﾛ1Prﾇuﾉﾉ4ﾒdﾛﾑｲﾄn5tﾆﾒrsR9ﾋ2Gｷ7gWeFzyﾁﾋﾁAHﾌTJQQ4L",
       "assertion_key_algorithm": "app-attest-p256",
@@ -401,7 +402,8 @@
       "public_key": "XiEsCYDks5/AlyETSqAhCTdO39JgwNPQPLUByNZUV6k=",
       "version": 1
     },
-    "type": "offline_receive_request"
+    "type": "offline_receive_request",
+    "version": 1
   },
   "sdk_interop": {
     "payment_token_envelope_schema": "iroha_data_model::offline::model::OfflineNotePaymentTokenEnvelope",

--- a/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/offline/OfflineNoteWallet.kt
+++ b/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/offline/OfflineNoteWallet.kt
@@ -384,8 +384,18 @@ class OfflineNoteReceiveRequest(
     val amount: String,
     val keyCertificate: OfflineNote.KeyCertificate,
     outputCommitment: ByteArray,
+    val displayTtlMs: Long = 60_000,
+    val generatedAtMs: Long = 0,
 ) {
     private val _outputCommitment = outputCommitment.copyOf()
+
+    init {
+        require(_outputCommitment.size == 32) { "outputCommitment must be exactly 32 bytes" }
+        require(keyCertificate.accountId == accountId) {
+            "receive request accountId does not match key certificate"
+        }
+    }
+
     val canonicalAmount: String = OfflineNote.AuditOutputClaim(
         noteCommitment = _outputCommitment,
         keyCertificate = keyCertificate,
@@ -397,12 +407,161 @@ class OfflineNoteReceiveRequest(
     fun outputCommitmentHex(): String = hexLower(_outputCommitment)
 }
 
-/** QR/Norito handoff codec for Offline Note receive requests. */
+/** QR/Norito/JSON handoff codec for Offline Note receive requests. */
 object OfflineNoteReceiveRequestCodec {
     const val TYPE: String = "offline_receive_request"
+    const val VERSION: Long = 1
     const val TEXT_PREFIX: String = "wallet-offline-bearer-cash-receive:"
     private const val RECEIVE_REQUEST_ENVELOPE_SCHEMA =
         "iroha_data_model::offline::model::OfflineNoteReceiveRequestEnvelope"
+
+    @JvmStatic
+    fun encodeJson(request: OfflineNoteReceiveRequest): ByteArray {
+        val payload = linkedMapOf<String, Any?>(
+            "version" to VERSION,
+            "type" to TYPE,
+            "invoice_id" to request.paymentRequestId,
+            "account_id" to request.accountId,
+            "asset_definition_id" to request.assetDefinitionId,
+            "amount" to request.canonicalAmount,
+            "output_commitment_hex" to request.outputCommitmentHex(),
+            "recipient_key_certificate" to encodeCertificateObject(request.keyCertificate),
+            "display_ttl_ms" to request.displayTtlMs,
+            "generated_at_ms" to request.generatedAtMs,
+        )
+        return JsonEncoder.encode(payload).toByteArray(StandardCharsets.UTF_8)
+    }
+
+    @JvmStatic
+    fun decodeJson(payload: ByteArray, chainId: String): OfflineNoteReceiveRequest {
+        val obj = parseJsonRoot(payload)
+        val version = asLong(obj["version"], "version")
+        require(version == VERSION) { "Offline Note receive request JSON version must be $VERSION" }
+        require(asString(obj["type"], "type") == TYPE) {
+            "Offline Note receive request JSON type mismatch"
+        }
+        val keyCertificate = decodeCertificateObject(
+            asObject(obj["recipient_key_certificate"], "recipient_key_certificate"),
+            "recipient_key_certificate",
+        )
+        val accountId = asString(obj["account_id"], "account_id")
+        require(keyCertificate.accountId == accountId) {
+            "Offline Note receive request account_id does not match key certificate"
+        }
+        val assetDefinitionId = asString(obj["asset_definition_id"], "asset_definition_id")
+        return OfflineNoteReceiveRequest(
+            chainId = chainId,
+            paymentRequestId = asString(obj["invoice_id"], "invoice_id"),
+            accountId = accountId,
+            assetDefinitionId = assetDefinitionId,
+            assetId = walletAssetId(assetDefinitionId, accountId),
+            amount = asString(obj["amount"], "amount"),
+            keyCertificate = keyCertificate,
+            outputCommitment = parseHexBytes(
+                asString(obj["output_commitment_hex"], "output_commitment_hex"),
+                "output_commitment_hex",
+            ),
+            displayTtlMs = asLong(obj["display_ttl_ms"], "display_ttl_ms"),
+            generatedAtMs = asLong(obj["generated_at_ms"], "generated_at_ms"),
+        )
+    }
+
+    private fun encodeCertificateObject(certificate: OfflineNote.KeyCertificate): Map<String, Any?> =
+        linkedMapOf(
+            "version" to certificate.version,
+            "platform" to certificate.platform,
+            "key_id" to certificate.keyId,
+            "device_id" to certificate.deviceId,
+            "account_id" to certificate.accountId,
+            "public_key" to Base64.getEncoder().encodeToString(certificate.publicKey()),
+            "assertion_scheme" to certificate.assertionScheme,
+            "assertion_key_algorithm" to certificate.assertionKeyAlgorithm,
+            "assertion_public_key" to Base64.getEncoder().encodeToString(certificate.assertionPublicKey()),
+            "assertion_usage_count_limit" to certificate.assertionUsageCountLimit,
+            "one_use" to certificate.oneUse,
+            "issuer_signature_base64" to Base64.getEncoder().encodeToString(certificate.issuerSignature()),
+            "issuer_signature_payload_base64" to Base64.getEncoder().encodeToString(certificate.signingBytes()),
+        )
+
+    private fun decodeCertificateObject(
+        obj: Map<String, Any?>,
+        field: String,
+    ): OfflineNote.KeyCertificate {
+        val certificate = OfflineNote.KeyCertificate(
+            version = asLong(obj["version"], "$field.version").toInt(),
+            platform = asString(obj["platform"], "$field.platform"),
+            keyId = asString(obj["key_id"], "$field.key_id"),
+            deviceId = asString(obj["device_id"], "$field.device_id"),
+            accountId = asString(obj["account_id"], "$field.account_id"),
+            publicKey = Base64.getDecoder().decode(asString(obj["public_key"], "$field.public_key")),
+            assertionScheme = asString(obj["assertion_scheme"], "$field.assertion_scheme"),
+            assertionKeyAlgorithm = asString(obj["assertion_key_algorithm"], "$field.assertion_key_algorithm"),
+            assertionPublicKey = Base64.getDecoder()
+                .decode(asString(obj["assertion_public_key"], "$field.assertion_public_key")),
+            assertionUsageCountLimit = asOptionalInt(
+                obj["assertion_usage_count_limit"],
+                "$field.assertion_usage_count_limit",
+            ),
+            oneUse = asBoolean(obj["one_use"], "$field.one_use"),
+            issuerSignature = Base64.getDecoder()
+                .decode(asString(obj["issuer_signature_base64"], "$field.issuer_signature_base64")),
+        )
+        val signingPayload = Base64.getDecoder().decode(
+            asString(obj["issuer_signature_payload_base64"], "$field.issuer_signature_payload_base64"),
+        )
+        require(signingPayload.contentEquals(certificate.signingBytes())) {
+            "Offline Note receive request certificate signing payload mismatch"
+        }
+        return certificate
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun parseJsonRoot(payload: ByteArray): Map<String, Any?> {
+        val parsed = JsonParser.parse(String(payload, StandardCharsets.UTF_8))
+        require(parsed is Map<*, *>) { "Offline Note receive request JSON root must be an object" }
+        return parsed as Map<String, Any?>
+    }
+
+    private fun asString(value: Any?, field: String): String {
+        require(value is String && value.isNotBlank()) { "$field must be a non-empty string" }
+        return value
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun asObject(value: Any?, field: String): Map<String, Any?> {
+        require(value is Map<*, *>) { "$field must be an object" }
+        return value as Map<String, Any?>
+    }
+
+    private fun asBoolean(value: Any?, field: String): Boolean {
+        require(value is Boolean) { "$field must be a boolean" }
+        return value
+    }
+
+    private fun asOptionalInt(value: Any?, field: String): Int? {
+        if (value == null) return null
+        require(value is Number) { "$field must be an integer or null" }
+        return value.toInt()
+    }
+
+    private fun asLong(value: Any?, field: String): Long = when (value) {
+        is Number -> value.toLong()
+        is String -> value.toLong()
+        else -> throw IllegalArgumentException("$field must be an integer")
+    }
+
+    private fun parseHexBytes(value: String, field: String): ByteArray {
+        val normalized = value.lowercase(Locale.ROOT)
+        require(normalized.length % 2 == 0) { "$field must have an even hex length" }
+        val out = ByteArray(normalized.length / 2)
+        for (index in out.indices) {
+            val hi = Character.digit(normalized[index * 2], 16)
+            val lo = Character.digit(normalized[index * 2 + 1], 16)
+            require(hi >= 0 && lo >= 0) { "$field must be hex" }
+            out[index] = ((hi shl 4) or lo).toByte()
+        }
+        return out
+    }
 
     @JvmStatic
     fun encodeNorito(request: OfflineNoteReceiveRequest): ByteArray =
@@ -1478,6 +1637,7 @@ class OfflineNoteWallet @JvmOverloads constructor(
             noteSecret = noteSecret,
             origin = origin,
         )
+        val now = clock.getAsLong()
         val pending = OfflineNoteWalletNote(
             chainId = chainId,
             accountId = accountId,
@@ -1488,8 +1648,8 @@ class OfflineNoteWallet @JvmOverloads constructor(
             noteSecret = noteSecret,
             origin = origin,
             state = OfflineNoteWalletNoteState.RECEIVE_PENDING,
-            createdAtMs = clock.getAsLong(),
-            updatedAtMs = clock.getAsLong(),
+            createdAtMs = now,
+            updatedAtMs = now,
         )
         store.upsert(pending)
         return OfflineNoteReceiveRequest(
@@ -1501,6 +1661,7 @@ class OfflineNoteWallet @JvmOverloads constructor(
             amount = pending.canonicalAmount,
             keyCertificate = keyCertificate,
             outputCommitment = outputCommitment,
+            generatedAtMs = now,
         )
     }
 

--- a/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/offline/OfflineNoteTest.kt
+++ b/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/offline/OfflineNoteTest.kt
@@ -1287,6 +1287,133 @@ class OfflineNoteTest {
     }
 
     @Test
+    fun receiveRequestCodecRoundTripsJson() {
+        val request = fixtureReceiveRequest()
+        val encodedJson = OfflineNoteReceiveRequestCodec.encodeJson(request)
+        val encodedObject = parseJsonObject(encodedJson)
+        assertEquals(OfflineNoteReceiveRequestCodec.TYPE, string(encodedObject, "type"))
+        assertEquals(request.paymentRequestId, string(encodedObject, "invoice_id"))
+        assertTrue(encodedObject["recipient_key_certificate"] is Map<*, *>)
+        assertEquals(request.outputCommitmentHex(), string(encodedObject, "output_commitment_hex"))
+        assertEquals(request.displayTtlMs, long(encodedObject, "display_ttl_ms"))
+        assertEquals(request.generatedAtMs, long(encodedObject, "generated_at_ms"))
+        assertFalse(encodedObject.containsKey("chain_id"))
+        assertFalse(encodedObject.containsKey("asset_id"))
+        assertFalse(encodedObject.containsKey("payment_request_id"))
+
+        val decoded = OfflineNoteReceiveRequestCodec.decodeJson(encodedJson, request.chainId)
+        assertEquals(request.chainId, decoded.chainId)
+        assertEquals(request.paymentRequestId, decoded.paymentRequestId)
+        assertEquals(request.accountId, decoded.accountId)
+        assertEquals(request.assetDefinitionId, decoded.assetDefinitionId)
+        assertEquals(request.assetId, decoded.assetId)
+        assertEquals(request.canonicalAmount, decoded.canonicalAmount)
+        assertEquals(request.outputCommitmentHex(), decoded.outputCommitmentHex())
+        assertEquals(request.displayTtlMs, decoded.displayTtlMs)
+        assertEquals(request.generatedAtMs, decoded.generatedAtMs)
+        assertEquals(
+            base64(request.keyCertificate.noritoEncoded()),
+            base64(decoded.keyCertificate.noritoEncoded()),
+        )
+    }
+
+    @Test
+    fun receiveRequestCodecDecodesFixtureReceiveRequest() {
+        val fixture = loadFixture()
+        val challenge = obj(fixture, "receive_request")
+        val derivation = obj(obj(fixture, "chain_vectors"), "derivation")
+        val chainId = string(derivation, "chain_id")
+
+        val decoded = OfflineNoteReceiveRequestCodec.decodeJson(
+            JsonEncoder.encode(challenge).toByteArray(StandardCharsets.UTF_8),
+            chainId,
+        )
+
+        assertEquals(chainId, decoded.chainId)
+        assertEquals(string(challenge, "invoice_id"), decoded.paymentRequestId)
+        assertEquals(string(challenge, "account_id"), decoded.accountId)
+        assertEquals(string(challenge, "asset_definition_id"), decoded.assetDefinitionId)
+        assertEquals(string(obj(obj(fixture, "chain_vectors"), "redeem"), "asset_id"), decoded.assetId)
+        assertEquals(string(challenge, "amount"), decoded.canonicalAmount)
+        assertEquals(string(challenge, "output_commitment_hex"), decoded.outputCommitmentHex())
+        assertEquals(long(challenge, "display_ttl_ms"), decoded.displayTtlMs)
+        assertEquals(long(challenge, "generated_at_ms"), decoded.generatedAtMs)
+        assertEquals(
+            base64(certificate(obj(challenge, "recipient_key_certificate")).noritoEncoded()),
+            base64(decoded.keyCertificate.noritoEncoded()),
+        )
+    }
+
+    @Test
+    fun receiveRequestCodecRejectsAccountCertificateMismatch() {
+        val request = fixtureReceiveRequest()
+        val encoded = String(
+            OfflineNoteReceiveRequestCodec.encodeJson(request),
+            StandardCharsets.UTF_8,
+        ).replaceFirst(
+            """"account_id":"${request.accountId}"""",
+            """"account_id":"mallory"""",
+        )
+
+        val err = assertFailsWith<IllegalArgumentException> {
+            OfflineNoteReceiveRequestCodec.decodeJson(
+                encoded.toByteArray(StandardCharsets.UTF_8),
+                request.chainId,
+            )
+        }
+        assertTrue(
+            err.message?.contains("account_id does not match key certificate") == true,
+            "unexpected error message: ${err.message}",
+        )
+    }
+
+    @Test
+    fun receiveRequestCodecRejectsInvalidOutputCommitmentLength() {
+        val request = fixtureReceiveRequest()
+        val encoded = String(
+            OfflineNoteReceiveRequestCodec.encodeJson(request),
+            StandardCharsets.UTF_8,
+        ).replaceFirst(
+            """"output_commitment_hex":"${request.outputCommitmentHex()}"""",
+            """"output_commitment_hex":"abcd"""",
+        )
+
+        val err = assertFailsWith<IllegalArgumentException> {
+            OfflineNoteReceiveRequestCodec.decodeJson(
+                encoded.toByteArray(StandardCharsets.UTF_8),
+                request.chainId,
+            )
+        }
+        assertTrue(
+            err.message?.contains("32 bytes") == true,
+            "unexpected error message: ${err.message}",
+        )
+    }
+
+    @Test
+    fun receiveRequestCodecRejectsWrongType() {
+        val request = fixtureReceiveRequest()
+        val encoded = String(
+            OfflineNoteReceiveRequestCodec.encodeJson(request),
+            StandardCharsets.UTF_8,
+        ).replaceFirst(
+            """"type":"${OfflineNoteReceiveRequestCodec.TYPE}"""",
+            """"type":"offline_receive_challenge_v2"""",
+        )
+
+        val err = assertFailsWith<IllegalArgumentException> {
+            OfflineNoteReceiveRequestCodec.decodeJson(
+                encoded.toByteArray(StandardCharsets.UTF_8),
+                request.chainId,
+            )
+        }
+        assertTrue(
+            err.message?.contains("type mismatch") == true,
+            "unexpected error message: ${err.message}",
+        )
+    }
+
+    @Test
     fun receiptAckCodecRoundTripsNoritoTextAndQrFrames() {
         val fixture = loadFixture()
         val payment = obj(fixture, "payment_token")
@@ -3204,18 +3331,17 @@ class OfflineNoteTest {
             assetDefinitionId = assetDefinitionId,
             amount = receiveAmount,
         )
-        val accountSubstitution = OfflineNoteReceiveRequest(
-            chainId = receiveRequest.chainId,
-            paymentRequestId = receiveRequest.paymentRequestId,
-            accountId = senderAccountId,
-            assetDefinitionId = receiveRequest.assetDefinitionId,
-            assetId = receiveRequest.assetId,
-            amount = receiveRequest.amount,
-            keyCertificate = receiveRequest.keyCertificate,
-            outputCommitment = receiveRequest.outputCommitment(),
-        )
         assertFailsWith<IllegalArgumentException> {
-            senderWallet.pay(accountSubstitution)
+            OfflineNoteReceiveRequest(
+                chainId = receiveRequest.chainId,
+                paymentRequestId = receiveRequest.paymentRequestId,
+                accountId = senderAccountId,
+                assetDefinitionId = receiveRequest.assetDefinitionId,
+                assetId = receiveRequest.assetId,
+                amount = receiveRequest.amount,
+                keyCertificate = receiveRequest.keyCertificate,
+                outputCommitment = receiveRequest.outputCommitment(),
+            )
         }
         val chainSubstitution = OfflineNoteReceiveRequest(
             chainId = "${receiveRequest.chainId}-evil",
@@ -4818,6 +4944,33 @@ class OfflineNoteTest {
     private fun loadFixture(): Map<String, Any?> {
         val path = Paths.get("..", "..", "fixtures", "offline", "interop_contract.json")
         val parsed = JsonParser.parse(String(Files.readAllBytes(path), Charsets.UTF_8))
+        @Suppress("UNCHECKED_CAST")
+        return parsed as Map<String, Any?>
+    }
+
+    private fun fixtureReceiveRequest(): OfflineNoteReceiveRequest {
+        val fixture = loadFixture()
+        val challenge = obj(fixture, "receive_request")
+        val chain = obj(fixture, "chain_vectors")
+        val derivation = obj(chain, "derivation")
+        val assetDefinitionId = string(challenge, "asset_definition_id")
+        val accountId = string(challenge, "account_id")
+        return OfflineNoteReceiveRequest(
+            chainId = string(derivation, "chain_id"),
+            paymentRequestId = string(challenge, "invoice_id"),
+            accountId = accountId,
+            assetDefinitionId = assetDefinitionId,
+            assetId = string(obj(chain, "redeem"), "asset_id"),
+            amount = string(challenge, "amount"),
+            keyCertificate = certificate(obj(challenge, "recipient_key_certificate")),
+            outputCommitment = hexBytes(string(challenge, "output_commitment_hex")),
+            displayTtlMs = long(challenge, "display_ttl_ms"),
+            generatedAtMs = long(challenge, "generated_at_ms"),
+        )
+    }
+
+    private fun parseJsonObject(payload: ByteArray): Map<String, Any?> {
+        val parsed = JsonParser.parse(String(payload, StandardCharsets.UTF_8))
         @Suppress("UNCHECKED_CAST")
         return parsed as Map<String, Any?>
     }


### PR DESCRIPTION
## Context

Wallets that want to receive an Offline Note V2 payment need a portable "invoice" — a receive challenge the payer can scan (QR), paste (text), or fetch (JSON). The Kotlin SDK had `OfflineNoteV2ReceiveRequest` but no codec to ship one across the air gap, and the interop fixture lacked the receive-side payload, so cross-SDK conformance could not be asserted.

This PR adds the codec, extends the fixture so it round-trips through both Rust and Kotlin, and tightens validation on the request object so malformed invoices cannot be constructed silently.

### Solution

- Add `OfflineNoteV2ReceiveRequestCodec` in `kotlin/core-jvm` with three transport surfaces sharing one canonical JSON shape:
  - **JSON** — `encodeJson` / `decodeJson(payload, chainId)`.
  - **Text** — `encodeText` / `decodeText` with the  `wallet-offline-challenge-v2:` prefix and base64 body.
  - **QR** — `encodeQrFrameBytes` / `decodeQrPayload` over the existing  `OfflineQrStream` (`OFFLINE_RECEIVE_CHALLENGE_V2` payload kind).
- Extend `OfflineNoteV2ReceiveRequest`:
  - Surface `displayTtlMs` and `generatedAtMs` as constructor params (`OfflineNoteV2Wallet` now stamps `generatedAtMs` from its clock).
  - Validate in `init`: `outputCommitment.size == 32` and `keyCertificate.accountId == accountId`.
- Update the interop fixture (`offline_v2_vectors.rs`, `interop_contract_v2.json`) to include `output_commitment_hex` under `receive_challenge`, with a Rust test asserting it matches the derivation's `recipient_output_commitment`.
- Tests cover JSON/text/QR round-trip, fixture decode parity, bad-prefix, account/certificate mismatch, wrong commitment length, and wrong `type` rejection.

---

### Review notes

Suggested reading order:

1. `OfflineNoteV2Wallet.kt` — start with the `init` validation added to `OfflineNoteV2ReceiveRequest`, then the new `OfflineNoteV2ReceiveRequestCodec` (JSON canonical shape -> text wrapper -> QR wrapper).
2. `offline_v2_vectors.rs` and `interop_contract_v2.json` — confirm the fixture surfaces `output_commitment_hex` and that the Rust test ties it back to the derivation.
3. `OfflineNoteV2Test.kt` — round-trip and validation-rejection tests are the executable spec for the codec.