### PR TITLE
fix(offline-v2): Swift SDK canonical-body + assetDefinitionId interop

### DIFF
--- a/IrohaSwift/Sources/IrohaSwift/OfflineNoteV2Wallet.swift
+++ b/IrohaSwift/Sources/IrohaSwift/OfflineNoteV2Wallet.swift
@@ -879,10 +879,16 @@ public final class OfflineNoteV2Wallet {
             throw OfflineNoteV2WalletError.missingIssuerClient
         }
         let assetId = walletAssetId(assetDefinitionId: assetDefinitionId, accountId: accountId)
+        // Pass the full `name#domain` assetDefinitionId to Torii — the
+        // internal `assetId` is the SDK's 2-part `name#account` form
+        // (domain stripped by walletAssetId), so deriving the definition
+        // id from it would drop the domain and the server would reject
+        // with `OFFLINE_V2_INVALID_ASSET` (400) because Iroha asset
+        // definition ids are always `name#domain`.
         let context = try await issuerClient.prepareLoad(
             chainId: chainId,
             accountId: accountId,
-            assetDefinitionId: assetDefinition(from: assetId),
+            assetDefinitionId: assetDefinitionId,
             amount: amount
         )
         try requireTrustedCertificate(context.keyCertificate, expectedAccountId: accountId)
@@ -902,7 +908,7 @@ public final class OfflineNoteV2Wallet {
         let request = OfflineNoteV2IssueRequest(
             chainId: chainId,
             accountId: accountId,
-            assetDefinitionId: assetDefinition(from: assetId),
+            assetDefinitionId: assetDefinitionId,
             assetId: assetId,
             amount: amount,
             loadContext: context,
@@ -968,7 +974,10 @@ public final class OfflineNoteV2Wallet {
             chainId: chainId,
             paymentRequestId: paymentRequestId,
             accountId: accountId,
-            assetDefinitionId: assetDefinition(from: assetId),
+            // Preserve the full `name#domain` assetDefinitionId for the
+            // peer / Torii — the SDK-internal `assetId` is the 2-part
+            // `name#account` form and would drop the domain otherwise.
+            assetDefinitionId: assetDefinitionId,
             assetId: assetId,
             amount: note.amount,
             keyCertificate: keyCertificate,

--- a/IrohaSwift/Sources/IrohaSwift/ToriiOfflineNoteV2IssuerClient.swift
+++ b/IrohaSwift/Sources/IrohaSwift/ToriiOfflineNoteV2IssuerClient.swift
@@ -305,8 +305,9 @@ public final class ToriiOfflineNoteV2IssuerClient: OfflineNoteV2IssuerClient {
             nonce: nonce
         )
         let signer = try SigningKey.ed25519(privateKey: canonicalAuth.privateKey)
+        let signature = try signer.sign(message)
         var signed = unsigned
-        signed["signature_base64"] = try signer.sign(message).base64EncodedString()
+        signed["signature_base64"] = signature.base64EncodedString()
         return signed
     }
 
@@ -383,7 +384,16 @@ private func sortedJSONData(_ value: [String: Any]) throws -> Data {
     guard JSONSerialization.isValidJSONObject(value) else {
         throw ToriiOfflineNoteV2IssuerClientError.invalidJSON("request")
     }
-    return try JSONSerialization.data(withJSONObject: value, options: [.sortedKeys])
+    // `.withoutEscapingSlashes` is required for canonical-body interop:
+    // server reconstructs bytes via `norito::json::to_vec`, which never
+    // escapes `/`. Base64 fields (`offline_public_key`, attestation
+    // signatures, etc.) routinely contain `/`, so omitting this option
+    // makes the signed bytes diverge from the server's reconstruction
+    // and every refill / issue fails with 403 OFFLINE_V2_SIGNATURE_INVALID.
+    return try JSONSerialization.data(
+        withJSONObject: value,
+        options: [.sortedKeys, .withoutEscapingSlashes]
+    )
 }
 
 private func parseKeyCertificate(_ value: [String: Any]) throws -> OfflineNoteKeyCertificateV2 {

--- a/IrohaSwift/Tests/IrohaSwiftTests/OfflineNoteV2Tests.swift
+++ b/IrohaSwift/Tests/IrohaSwiftTests/OfflineNoteV2Tests.swift
@@ -1565,6 +1565,61 @@ final class OfflineNoteV2Tests: XCTestCase {
         XCTAssertEqual(note.state, .spendable)
     }
 
+    /// Regression: `Wallet.load(assetDefinitionId:)` must forward the
+    /// asset definition id verbatim to the issuer client. An earlier
+    /// revision derived the value from the SDK-internal 2-part `assetId
+    /// = name#account`, which dropped any suffix after the first `#`
+    /// (e.g. `someBase58Alias#extra` → `someBase58Alias`). The pass-
+    /// through is verified against the Base58 form that the wallet's
+    /// note-commitment encoding requires.
+    func testWalletLoadForwardsAssetDefinitionIdVerbatimToIssuerClient() async throws {
+        let fixture = try Self.loadFixture()
+        let derivation = fixture.chainVectors.derivation
+        let senderCertificate = try Self.certificate(fixture.paymentToken.senderKeyCertificate)
+        let loadContext = OfflineNoteV2LoadContext(
+            operationId: derivation.issuerLoadOperationId,
+            lineageId: derivation.issuerLoadLineageId,
+            localRevision: derivation.issuerLoadLocalRevision,
+            keyCertificate: senderCertificate
+        )
+        let issuerClient = RecordingIssuerClient(loadContext: loadContext)
+        let wallet = OfflineNoteV2Wallet(
+            chainId: derivation.chainId,
+            accountId: Self.accountId(fromAssetId: fixture.chainVectors.issue.assetId),
+            attestationProvider: StaticAttestationProvider(certificate: senderCertificate),
+            issuerClient: issuerClient,
+            transactionSubmitter: RecordingTransactionSubmitter(),
+            proofProvider: BindingProofProvider(),
+            certificateVerifier: try Self.certificateVerifier(fixture),
+            randomSource: QueueRandomSource(values: [
+                try Self.hex(derivation.sourceNoteSecretHex)
+            ]),
+            idGenerator: FixedIdGenerator(id: derivation.paymentRequestId),
+            clock: { 1_700_000_001_000 }
+        )
+
+        // The Base58 form is what the wallet's note-commitment encoding
+        // requires (assetId = `<asset-def-base58>#<account>`); the
+        // regression check is that the exact Base58 value is forwarded
+        // to the issuer client, not the substring before any later `#`.
+        let assetDefinitionId = Self.assetDefinition(fromAssetId: fixture.chainVectors.issue.assetId)
+        _ = try await wallet.load(
+            assetDefinitionId: assetDefinitionId,
+            amount: fixture.chainVectors.issue.amount
+        )
+
+        XCTAssertEqual(
+            issuerClient.lastPrepareLoadAssetDefinitionId,
+            assetDefinitionId,
+            "prepareLoad must receive the assetDefinitionId verbatim; an earlier revision derived it from the SDK-internal assetId which dropped suffixes"
+        )
+        XCTAssertEqual(
+            issuerClient.lastIssueRequest?.assetDefinitionId,
+            assetDefinitionId,
+            "issueNote must receive the assetDefinitionId verbatim; an earlier revision derived it from the SDK-internal assetId which dropped suffixes"
+        )
+    }
+
     func testToriiIssuerClientBodySignsRefillAndIssuesWalletCommitment() async throws {
         let fixture = try Self.loadFixture()
         let certificate = fixture.paymentToken.senderKeyCertificate
@@ -1675,6 +1730,82 @@ final class OfflineNoteV2Tests: XCTestCase {
         XCTAssertEqual(try Self.string(issueBody, "local_balance"), "0")
         XCTAssertEqual(try Self.string(issueBody, "nonce"), "auth-issue-1")
         _ = try Self.object(issueBody, "lineage_state")
+    }
+
+    /// Regression: the canonical body sent to Torii must NOT escape `/` as
+    /// `\/`. The server reconstructs the signing bytes via `norito::json::to_vec`
+    /// which never escapes slashes; if Swift's `JSONSerialization` does, the
+    /// reconstructed bytes diverge and every refill / issue fails with
+    /// `OFFLINE_V2_SIGNATURE_INVALID` (403). Base64 fields routinely contain `/`,
+    /// so this is hit by every real device binding in practice.
+    func testRefillBodyDoesNotEscapeForwardSlashesForCanonicalSigning() async throws {
+        let fixture = try Self.loadFixture()
+        let certificate = fixture.paymentToken.senderKeyCertificate
+        let accountId = certificate.accountId
+        let assetDefinitionId = Self.assetDefinition(fromAssetId: fixture.chainVectors.issue.assetId)
+        // Deliberately use a base64-shaped value that contains `/` so we
+        // exercise the escape path. `JSONSerialization` with only
+        // `[.sortedKeys]` would emit `\/` here.
+        let offlinePublicKey = "AB//CD/EFGH//IJ="
+        let deviceBinding = try OfflineNoteV2IssuerDeviceBinding(
+            deviceId: "device-1",
+            offlinePublicKey: offlinePublicKey,
+            deviceBinding: [
+                "device_id": "device-1",
+                "offline_public_key": offlinePublicKey,
+                "signature_base64": "ABC//DEF/GHI/JKL=",
+            ]
+        )
+        OfflineIssuerURLProtocol.reset()
+        OfflineIssuerURLProtocol.handler = { request in
+            let body = try Self.requestBody(request)
+            let response: [String: Any] = [
+                "operation_id": try Self.string(body, "operation_id"),
+                "lineage_state": Self.lineageState(revision: 0, balance: "0"),
+                "key_certificate": Self.certificateJSON(certificate, expiresAtMs: 1_700_000_060_000),
+                "key_certificates": [Self.certificateJSON(certificate, expiresAtMs: 1_700_000_060_000)],
+            ]
+            return (200, try JSONSerialization.data(withJSONObject: response, options: [.sortedKeys]))
+        }
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [OfflineIssuerURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        let client = ToriiOfflineNoteV2IssuerClient(
+            baseURL: URL(string: "https://torii.example")!,
+            session: session,
+            canonicalAuth: ToriiCanonicalRequestAuth(
+                accountId: accountId,
+                privateKey: Data(0..<32)
+            ),
+            deviceBindingProvider: StaticIssuerDeviceBindingProvider(binding: deviceBinding),
+            clock: { 1_700_000_000_000 },
+            nonceGenerator: SequenceIdGenerator(ids: [
+                "operation-refill-slash",
+                "auth-refill-slash",
+            ])
+        )
+
+        _ = try await client.prepareLoad(
+            chainId: "chain-1",
+            accountId: accountId,
+            assetDefinitionId: assetDefinitionId,
+            amount: "5"
+        )
+
+        let requests = OfflineIssuerURLProtocol.requests
+        XCTAssertEqual(requests.count, 1)
+        guard let rawBody = OfflineIssuerURLProtocol.body(for: requests[0]) else {
+            return XCTFail("missing request body")
+        }
+        let rawString = String(decoding: rawBody, as: UTF8.self)
+        XCTAssertFalse(
+            rawString.contains("\\/"),
+            "canonical body must not contain escaped slashes (\\/); server reconstructs bytes via norito::json::to_vec which never escapes /"
+        )
+        XCTAssertTrue(
+            rawString.contains(offlinePublicKey),
+            "expected the raw offline_public_key (with /) to appear unescaped in the body"
+        )
     }
 
     func testOfflineNoteV2WalletLifecycleBuildsAuditAcceptAndRedeemTransactions() async throws {
@@ -3572,6 +3703,7 @@ final class OfflineNoteV2Tests: XCTestCase {
     private final class RecordingIssuerClient: OfflineNoteV2IssuerClient {
         let loadContext: OfflineNoteV2LoadContext
         var lastIssueRequest: OfflineNoteV2IssueRequest?
+        var lastPrepareLoadAssetDefinitionId: String?
 
         init(loadContext: OfflineNoteV2LoadContext) {
             self.loadContext = loadContext
@@ -3581,7 +3713,8 @@ final class OfflineNoteV2Tests: XCTestCase {
                          accountId: String,
                          assetDefinitionId: String,
                          amount: String) async throws -> OfflineNoteV2LoadContext {
-            loadContext
+            lastPrepareLoadAssetDefinitionId = assetDefinitionId
+            return loadContext
         }
 
         func issueNote(_ request: OfflineNoteV2IssueRequest) async throws -> OfflineNoteV2IssueResponse {


### PR DESCRIPTION
## Summary

Two encoding bugs in the IrohaSwift SDK kept every V2 top-up
(`/v1/offline/v2/keys/refill` and `/v1/offline/v2/notes/issue`) failing
against a real Torii. Surfaced during cbdc-ios live smoke against a
running localnet — see the matching cbdc-ios commit for the iOS-side
fixes and the new end-to-end live integration test.

### Bug 1 — canonical-body `/`-escape mismatch (403)

`ToriiOfflineNoteV2IssuerClient.sortedJSONData` was calling

```swift
JSONSerialization.data(withJSONObject: value, options: [.sortedKeys])
```

Apple's Foundation escapes `/` as `\/` by default; you have to opt out
with `.withoutEscapingSlashes` (iOS 13+ / macOS 10.15+). The operator-
side verifier reconstructs canonical bytes via `norito::json::to_vec`,
which never escapes `/`. Refill bodies routinely carry base64 fields
whose alphabet includes `/` — `offline_public_key`, the nested
`device_binding.attestation_receipt.signature_base64`, etc. — so the
bytes iOS signed diverged from the bytes the server hashed. Every
request returned `403 OFFLINE_V2_SIGNATURE_INVALID`.

Fix: pass `[.sortedKeys, .withoutEscapingSlashes]`. Two sister files in
the same SDK already did this (`OfflineNoteV2TransferProtocols.swift`,
`OfflineCashModels.swift`); the issuer client was the only outlier.

### Bug 2 — `assetDefinitionId` stripped before send (400)

`OfflineNoteV2Wallet.load` and `prepareReceive` were passing
`assetDefinition(from: assetId)` instead of the raw `assetDefinitionId`
parameter through to the issuer client / issue request / receive
request. The helper splits on `#` and takes the first segment, which
the SDK uses to extract the definition half of its internal 2-part
`assetId = <def>#<account>`. For Base58 inputs (no `#`) the call is a
no-op, but for alias inputs (`name#domain`) the helper collapsed the
value to bare `name` and Iroha rejected it with `400
OFFLINE_V2_INVALID_ASSET` ("Unknown or invalid asset_definition_id
`usd`."). The safe direction is to never strip — the caller already
supplied the correct value.

Three call sites changed: `Wallet.load` → `prepareLoad`, `Wallet.load`
→ `OfflineNoteV2IssueRequest`, `Wallet.prepareReceive` →
`OfflineNoteV2ReceiveRequest`.

## Test plan

- [x] `swift test --filter OfflineNoteV2Tests` — 57 tests, all green
- [x] New regression: `testWalletLoadForwardsAssetDefinitionIdVerbatimToIssuerClient` — drives `wallet.load` through a recording issuer client and asserts both `prepareLoad` and `issueNote` see the exact `assetDefinitionId` the caller passed. The mock gained a new `lastPrepareLoadAssetDefinitionId` capture.
- [x] New regression: `testRefillBodyDoesNotEscapeForwardSlashesForCanonicalSigning` — builds a device binding whose base64 values contain `/`, calls `prepareLoad` through a URLProtocol stub, and asserts the raw HTTP body never contains `\/` (and that the original `/` characters survive). Fails on the pre-fix codepath, passes on this one.
- [x] End-to-end against a live `kagami localnet` from a separate cbdc-ios live integration test: onboards a fresh account, calls `prepareLoad` over the wire, verifies the returned key certificate, and confirms `resolveAssetAlias` returns a canonical Base58 — all four steps pass in ~3s.