### PR TITLE
feat(swift): on-chain offline-note tx encoders (redeem/audit/issue/defund) via bridge

### DIFF
--- a/IrohaSwift/Sources/IrohaSwift/Halo2OfflineNoteProver.swift
+++ b/IrohaSwift/Sources/IrohaSwift/Halo2OfflineNoteProver.swift
@@ -15,7 +15,7 @@ public enum Halo2OfflineNoteProver {
     public static let ipaK: UInt32 = 7
     public static let maxEnvelopeBytes = 20 * 1024
 
-    public static let canonicalVKHash = Data(hexString: "ad4d2ce680df32288d382c8b6403108d7174ca0ba9e558bd93a693f9d770b256")!
+    public static let canonicalVKHash = Data(hexString: "3493ea067302cab2180cef8f5dc60e0e6751ab9bb0c850286e2aaace2f863c25")!
     private static let canonicalTranscriptRepresentation = Data(hexString: "7db2235914292d4e825d6d51e1a880da77f107eb2c7853e3ec9c9d0dccc59813")!
     private static let proofDegree = 6
     private static let blindingFactors = 5

--- a/IrohaSwift/Sources/IrohaSwift/NativeBridge.swift
+++ b/IrohaSwift/Sources/IrohaSwift/NativeBridge.swift
@@ -1611,6 +1611,38 @@ public final class NoritoNativeBridge: @unchecked Sendable {
         UnsafePointer<UInt8>?, CUnsignedLong,
         UnsafeMutablePointer<UnsafeMutablePointer<UInt8>?>?, UnsafeMutablePointer<CUnsignedLong>?
     ) -> Int32
+    private typealias EncodeOfflineNoteTxFn = @convention(c) (
+        UnsafePointer<CChar>?, UInt,
+        UnsafePointer<CChar>?, UInt,
+        UInt64,
+        UInt64,
+        UInt8,
+        UInt32,
+        UInt8,
+        UnsafePointer<UInt8>?, UInt,
+        UnsafePointer<UInt8>?, UInt,
+        UnsafeMutablePointer<UnsafeMutablePointer<UInt8>?>?,
+        UnsafeMutablePointer<UInt>?,
+        UnsafeMutablePointer<UInt8>?,
+        UInt
+    ) -> Int32
+    private typealias EncodeDefundOfflineNoteTxFn = @convention(c) (
+        UnsafePointer<CChar>?, UInt,
+        UnsafePointer<CChar>?, UInt,
+        UInt64,
+        UInt64,
+        UInt8,
+        UInt32,
+        UInt8,
+        UnsafePointer<UInt8>?, UInt,
+        UInt32,
+        UnsafePointer<UInt8>?, UInt,
+        UnsafePointer<UInt8>?, UInt,
+        UnsafeMutablePointer<UnsafeMutablePointer<UInt8>?>?,
+        UnsafeMutablePointer<UInt>?,
+        UnsafeMutablePointer<UInt8>?,
+        UInt
+    ) -> Int32
     private typealias PublicKeyFromPrivateFn = @convention(c) (
         UInt8,
         UnsafePointer<UInt8>?, CUnsignedLong,
@@ -1749,6 +1781,10 @@ public final class NoritoNativeBridge: @unchecked Sendable {
     private var kagemushaRecursiveSpendAppendFn: KagemushaRecursiveSpendArchiveFn? = nil
     private var kagemushaRecursiveSpendVerifyFn: KagemushaRecursiveSpendArchiveFn? = nil
     private var kagemushaRecursiveSpendRedeemFn: KagemushaRecursiveSpendArchiveFn? = nil
+    private var encodeIssueOfflineNoteFn: EncodeOfflineNoteTxFn? = nil
+    private var encodeRedeemOfflineNoteFn: EncodeOfflineNoteTxFn? = nil
+    private var encodeAuditOfflineNoteFn: EncodeOfflineNoteTxFn? = nil
+    private var encodeDefundOfflineNoteFn: EncodeDefundOfflineNoteTxFn? = nil
 #else
     private let bridgeHandle: Any? = nil
     private let encodeTransferFn: Any? = nil
@@ -1858,13 +1894,17 @@ public final class NoritoNativeBridge: @unchecked Sendable {
     private let kagemushaRecursiveSpendAppendFn: Any? = nil
     private let kagemushaRecursiveSpendVerifyFn: Any? = nil
     private let kagemushaRecursiveSpendRedeemFn: Any? = nil
+    private let encodeIssueOfflineNoteFn: Any? = nil
+    private let encodeRedeemOfflineNoteFn: Any? = nil
+    private let encodeAuditOfflineNoteFn: Any? = nil
+    private let encodeDefundOfflineNoteFn: Any? = nil
 #endif
 
 #if canImport(Darwin)
 #endif
 
     #if canImport(Darwin)
-    private func installStaticallyLinkedTransferBridgeIfAvailable() {
+    private func installStaticallyLinkedBridgeIfAvailable() {
         #if IROHASWIFT_BRIDGE_PRESENT
         let abiVersion = connect_norito_bridge_abi_version()
         guard abiVersion == NoritoBridgeLoader.expectedBridgeAbiVersion else {
@@ -1881,10 +1921,33 @@ public final class NoritoNativeBridge: @unchecked Sendable {
         self.encodeTransferWithAlgFn = connect_norito_encode_transfer_signed_transaction_alg
         self.encodeTransferWithFeeSponsorWithAlgFn =
             connect_norito_encode_transfer_signed_transaction_with_fee_sponsor_alg
+        self.encodeMintFn = connect_norito_encode_mint_signed_transaction
+        self.encodeMintWithAlgFn = connect_norito_encode_mint_signed_transaction_alg
+        let staticHandle = dlopen(nil, RTLD_NOW | RTLD_GLOBAL)
+        if let issueNoteSymbol = staticHandle.flatMap({ dlsym($0, "connect_norito_encode_issue_offline_note_signed_transaction") }) {
+            self.encodeIssueOfflineNoteFn = unsafeBitCast(issueNoteSymbol, to: EncodeOfflineNoteTxFn.self)
+        }
+        if let redeemNoteSymbol = staticHandle.flatMap({ dlsym($0, "connect_norito_encode_redeem_offline_note_signed_transaction") }) {
+            self.encodeRedeemOfflineNoteFn = unsafeBitCast(redeemNoteSymbol, to: EncodeOfflineNoteTxFn.self)
+        }
+        if let auditNoteSymbol = staticHandle.flatMap({ dlsym($0, "connect_norito_encode_audit_offline_note_signed_transaction") }) {
+            self.encodeAuditOfflineNoteFn = unsafeBitCast(auditNoteSymbol, to: EncodeOfflineNoteTxFn.self)
+        }
+        if let defundNoteSymbol = staticHandle.flatMap({ dlsym($0, "connect_norito_encode_defund_offline_note_signed_transaction") }) {
+            self.encodeDefundOfflineNoteFn = unsafeBitCast(defundNoteSymbol, to: EncodeDefundOfflineNoteTxFn.self)
+        }
+        self.kagemushaProveVerifiedCompactPaymentTokenWithRecordsFn =
+            connect_norito_kagemusha_prove_verified_compact_payment_token_with_records
+        self.kagemushaProveVerifiedRecursiveAggregationProofBundleWithRecordsAndPallasOpenEnvelopesFn =
+            connect_norito_kagemusha_prove_verified_recursive_aggregation_proof_bundle_with_records_and_pallas_open_envelopes
+        self.kagemushaRecursiveSpendInitFn = connect_norito_kagemusha_recursive_spend_init
+        self.kagemushaRecursiveSpendAppendFn = connect_norito_kagemusha_recursive_spend_append
+        self.kagemushaRecursiveSpendVerifyFn = connect_norito_kagemusha_recursive_spend_verify
+        self.kagemushaRecursiveSpendRedeemFn = connect_norito_kagemusha_recursive_spend_redeem
         self.freeFn = connect_norito_free
         self.setChainDiscriminantFn = connect_norito_set_chain_discriminant
         self.bridgeStatus = .valid(path: "static", identifier: NoritoBridgeLoader.currentIdentifier())
-        NSLog("[NoritoNativeBridge] using statically linked Norito transfer bridge")
+        NSLog("[NoritoNativeBridge] using statically linked Norito bridge")
         #endif
     }
 
@@ -1993,6 +2056,26 @@ public final class NoritoNativeBridge: @unchecked Sendable {
                 self.encodeMintWithAlgFn = unsafeBitCast(mintAlgSymbol, to: EncodeMintWithAlgFn.self)
             } else {
                 self.encodeMintWithAlgFn = nil
+            }
+            if let issueNoteSymbol = dlsym(handle, "connect_norito_encode_issue_offline_note_signed_transaction") {
+                self.encodeIssueOfflineNoteFn = unsafeBitCast(issueNoteSymbol, to: EncodeOfflineNoteTxFn.self)
+            } else {
+                self.encodeIssueOfflineNoteFn = nil
+            }
+            if let redeemNoteSymbol = dlsym(handle, "connect_norito_encode_redeem_offline_note_signed_transaction") {
+                self.encodeRedeemOfflineNoteFn = unsafeBitCast(redeemNoteSymbol, to: EncodeOfflineNoteTxFn.self)
+            } else {
+                self.encodeRedeemOfflineNoteFn = nil
+            }
+            if let auditNoteSymbol = dlsym(handle, "connect_norito_encode_audit_offline_note_signed_transaction") {
+                self.encodeAuditOfflineNoteFn = unsafeBitCast(auditNoteSymbol, to: EncodeOfflineNoteTxFn.self)
+            } else {
+                self.encodeAuditOfflineNoteFn = nil
+            }
+            if let defundNoteSymbol = dlsym(handle, "connect_norito_encode_defund_offline_note_signed_transaction") {
+                self.encodeDefundOfflineNoteFn = unsafeBitCast(defundNoteSymbol, to: EncodeDefundOfflineNoteTxFn.self)
+            } else {
+                self.encodeDefundOfflineNoteFn = nil
             }
             if let shieldSymbol = dlsym(handle, "connect_norito_encode_shield_signed_transaction") {
                 self.encodeShieldFn = unsafeBitCast(shieldSymbol, to: EncodeShieldFn.self)
@@ -2557,6 +2640,10 @@ public final class NoritoNativeBridge: @unchecked Sendable {
             self.encodeTransferWithFeeSponsorWithAlgFn = nil
             self.encodeMintFn = nil
             self.encodeMintWithAlgFn = nil
+            self.encodeIssueOfflineNoteFn = nil
+            self.encodeRedeemOfflineNoteFn = nil
+            self.encodeAuditOfflineNoteFn = nil
+            self.encodeDefundOfflineNoteFn = nil
             self.encodeShieldFn = nil
             self.encodeShieldWithAlgFn = nil
             self.encodeUnshieldFn = nil
@@ -2662,7 +2749,7 @@ public final class NoritoNativeBridge: @unchecked Sendable {
         }
 
         if self.encodeTransferFn == nil || self.freeFn == nil {
-            installStaticallyLinkedTransferBridgeIfAvailable()
+            installStaticallyLinkedBridgeIfAvailable()
         }
 
         if let setAccelerationConfigFn {
@@ -3162,6 +3249,233 @@ public final class NoritoNativeBridge: @unchecked Sendable {
             return nil
         }
         return takeData(pointer: outPtr, length: UInt(outLen))
+        #else
+        return nil
+        #endif
+    }
+
+    private enum OfflineNoteTxKind {
+        case issue
+        case redeem
+        case audit
+    }
+
+    private func encodeOfflineNoteTransaction(
+        kind: OfflineNoteTxKind,
+        chainId: String,
+        authority: String,
+        creationTimeMs: UInt64,
+        ttlMs: UInt64?,
+        nonce: UInt32?,
+        modelBytes: Data,
+        privateKey: Data
+    ) throws -> NativeSignedTransaction? {
+        #if canImport(Darwin)
+        guard let freeFn else { return nil }
+        let encodeFn: EncodeOfflineNoteTxFn?
+        switch kind {
+        case .issue: encodeFn = encodeIssueOfflineNoteFn
+        case .redeem: encodeFn = encodeRedeemOfflineNoteFn
+        case .audit: encodeFn = encodeAuditOfflineNoteFn
+        }
+        guard let encodeFn else { return nil }
+
+        let ttlValue = ttlMs ?? 0
+        let ttlFlag: UInt8 = ttlMs == nil ? 0 : 1
+        let nonceValue = nonce ?? 0
+        let nonceFlag: UInt8 = nonce == nil ? 0 : 1
+
+        var signedPtr: UnsafeMutablePointer<UInt8>? = nil
+        var signedLen: UInt = 0
+        var hashBytes = [UInt8](repeating: 0, count: 32)
+        let hashLength = UInt(hashBytes.count)
+
+        let status = try withAuthorityChainDiscriminant(authority: authority) {
+            chainId.withCString { chainPtr in
+            authority.withCString { authorityPtr in
+                modelBytes.withUnsafeBytes { modelBuffer -> Int32 in
+                    privateKey.withUnsafeBytes { keyBuffer -> Int32 in
+                        hashBytes.withUnsafeMutableBufferPointer { hashBuffer -> Int32 in
+                            guard let hashPtr = hashBuffer.baseAddress else { return -1 }
+                            return self.withSignedOutputs(signedPtr: &signedPtr, signedLen: &signedLen) { signedPtrPtr, signedLenPtr in
+                                encodeFn(
+                                    chainPtr, UInt(chainId.utf8.count),
+                                    authorityPtr, UInt(authority.utf8.count),
+                                    creationTimeMs,
+                                    ttlValue,
+                                    ttlFlag,
+                                    nonceValue,
+                                    nonceFlag,
+                                    modelBuffer.bindMemory(to: UInt8.self).baseAddress, UInt(modelBytes.count),
+                                    keyBuffer.bindMemory(to: UInt8.self).baseAddress, UInt(privateKey.count),
+                                    signedPtrPtr,
+                                    signedLenPtr,
+                                    hashPtr,
+                                    hashLength
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+            }
+        }
+
+        if status != 0 {
+            if let signedPtr { freeFn(signedPtr) }
+            try throwOnStatus(status)
+            return nil
+        }
+        guard let signedPtr else { return nil }
+
+        let signedData = Data(bytes: signedPtr, count: Int(signedLen))
+        freeFn(signedPtr)
+        let hashData = Data(hashBytes)
+        return NativeSignedTransaction(signedBytes: signedData, hash: hashData)
+        #else
+        return nil
+        #endif
+    }
+
+    func encodeIssueOfflineNote(
+        chainId: String,
+        authority: String,
+        creationTimeMs: UInt64,
+        ttlMs: UInt64?,
+        nonce: UInt32? = nil,
+        issueModel: Data,
+        privateKey: Data
+    ) throws -> NativeSignedTransaction? {
+        try encodeOfflineNoteTransaction(
+            kind: .issue,
+            chainId: chainId,
+            authority: authority,
+            creationTimeMs: creationTimeMs,
+            ttlMs: ttlMs,
+            nonce: nonce,
+            modelBytes: issueModel,
+            privateKey: privateKey
+        )
+    }
+
+    func encodeRedeemOfflineNote(
+        chainId: String,
+        authority: String,
+        creationTimeMs: UInt64,
+        ttlMs: UInt64?,
+        nonce: UInt32? = nil,
+        redemptionModel: Data,
+        privateKey: Data
+    ) throws -> NativeSignedTransaction? {
+        try encodeOfflineNoteTransaction(
+            kind: .redeem,
+            chainId: chainId,
+            authority: authority,
+            creationTimeMs: creationTimeMs,
+            ttlMs: ttlMs,
+            nonce: nonce,
+            modelBytes: redemptionModel,
+            privateKey: privateKey
+        )
+    }
+
+    func encodeAuditOfflineNote(
+        chainId: String,
+        authority: String,
+        creationTimeMs: UInt64,
+        ttlMs: UInt64?,
+        nonce: UInt32? = nil,
+        auditModel: Data,
+        privateKey: Data
+    ) throws -> NativeSignedTransaction? {
+        try encodeOfflineNoteTransaction(
+            kind: .audit,
+            chainId: chainId,
+            authority: authority,
+            creationTimeMs: creationTimeMs,
+            ttlMs: ttlMs,
+            nonce: nonce,
+            modelBytes: auditModel,
+            privateKey: privateKey
+        )
+    }
+
+    func encodeDefundOfflineNote(
+        chainId: String,
+        authority: String,
+        creationTimeMs: UInt64,
+        ttlMs: UInt64?,
+        nonce: UInt32? = nil,
+        bearerAuditTrail: [Data],
+        redemptionModel: Data,
+        privateKey: Data
+    ) throws -> NativeSignedTransaction? {
+        #if canImport(Darwin)
+        guard let freeFn, let encodeFn = encodeDefundOfflineNoteFn else { return nil }
+
+        var trail = Data()
+        for audit in bearerAuditTrail {
+            var len = UInt64(audit.count).littleEndian
+            withUnsafeBytes(of: &len) { trail.append(contentsOf: $0) }
+            trail.append(audit)
+        }
+        let auditCount = UInt32(bearerAuditTrail.count)
+
+        let ttlValue = ttlMs ?? 0
+        let ttlFlag: UInt8 = ttlMs == nil ? 0 : 1
+        let nonceValue = nonce ?? 0
+        let nonceFlag: UInt8 = nonce == nil ? 0 : 1
+
+        var signedPtr: UnsafeMutablePointer<UInt8>? = nil
+        var signedLen: UInt = 0
+        var hashBytes = [UInt8](repeating: 0, count: 32)
+        let hashLength = UInt(hashBytes.count)
+
+        let status = try withAuthorityChainDiscriminant(authority: authority) {
+            chainId.withCString { chainPtr in
+            authority.withCString { authorityPtr in
+                trail.withUnsafeBytes { trailBuffer -> Int32 in
+                    redemptionModel.withUnsafeBytes { redeemBuffer -> Int32 in
+                        privateKey.withUnsafeBytes { keyBuffer -> Int32 in
+                            hashBytes.withUnsafeMutableBufferPointer { hashBuffer -> Int32 in
+                                guard let hashPtr = hashBuffer.baseAddress else { return -1 }
+                                return self.withSignedOutputs(signedPtr: &signedPtr, signedLen: &signedLen) { signedPtrPtr, signedLenPtr in
+                                    encodeFn(
+                                        chainPtr, UInt(chainId.utf8.count),
+                                        authorityPtr, UInt(authority.utf8.count),
+                                        creationTimeMs,
+                                        ttlValue,
+                                        ttlFlag,
+                                        nonceValue,
+                                        nonceFlag,
+                                        trailBuffer.bindMemory(to: UInt8.self).baseAddress, UInt(trail.count), auditCount,
+                                        redeemBuffer.bindMemory(to: UInt8.self).baseAddress, UInt(redemptionModel.count),
+                                        keyBuffer.bindMemory(to: UInt8.self).baseAddress, UInt(privateKey.count),
+                                        signedPtrPtr,
+                                        signedLenPtr,
+                                        hashPtr,
+                                        hashLength
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            }
+        }
+
+        if status != 0 {
+            if let signedPtr { freeFn(signedPtr) }
+            try throwOnStatus(status)
+            return nil
+        }
+        guard let signedPtr else { return nil }
+
+        let signedData = Data(bytes: signedPtr, count: Int(signedLen))
+        freeFn(signedPtr)
+        let hashData = Data(hashBytes)
+        return NativeSignedTransaction(signedBytes: signedData, hash: hashData)
         #else
         return nil
         #endif

--- a/IrohaSwift/Sources/IrohaSwift/OfflineNoteTransactionEncoder.swift
+++ b/IrohaSwift/Sources/IrohaSwift/OfflineNoteTransactionEncoder.swift
@@ -1,216 +1,5 @@
 import Foundation
 
-private enum OfflineNoteSwiftNoritoEncoder {
-    private static let signedTransactionWireVersion: UInt8 = 1
-
-    static func encodeIssue(chainId: String,
-                            authority: String,
-                            creationTimeMs: UInt64,
-                            ttlMs: UInt64?,
-                            nonce: UInt32?,
-                            issue: OfflineNoteIssue,
-                            signingKey: SigningKey) throws -> SignedTransactionEnvelope {
-        let instruction = try encodeInstruction(
-            wireName: OfflineNoteTypeNames.issueInstruction,
-            typeName: OfflineNoteTypeNames.issueInstruction,
-            modelPayload: OfflineNoteEncoding.encodeIssue(issue)
-        )
-        return try encodeTransaction(
-            chainId: chainId,
-            authority: authority,
-            creationTimeMs: creationTimeMs,
-            ttlMs: ttlMs,
-            nonce: nonce,
-            instructionPayloads: [instruction],
-            signingKey: signingKey
-        )
-    }
-
-    static func encodeRedeem(chainId: String,
-                             authority: String,
-                             creationTimeMs: UInt64,
-                             ttlMs: UInt64?,
-                             nonce: UInt32?,
-                             redemption: OfflineNoteRedeem,
-                             signingKey: SigningKey) throws -> SignedTransactionEnvelope {
-        try redemption.validateProofBinding()
-        let instruction = try encodeInstruction(
-            wireName: OfflineNoteTypeNames.redeemInstruction,
-            typeName: OfflineNoteTypeNames.redeemInstruction,
-            modelPayload: OfflineNoteEncoding.encodeRedeem(redemption)
-        )
-        return try encodeTransaction(
-            chainId: chainId,
-            authority: authority,
-            creationTimeMs: creationTimeMs,
-            ttlMs: ttlMs,
-            nonce: nonce,
-            instructionPayloads: [instruction],
-            signingKey: signingKey
-        )
-    }
-
-    static func encodeDefund(chainId: String,
-                             authority: String,
-                             creationTimeMs: UInt64,
-                             ttlMs: UInt64?,
-                             nonce: UInt32?,
-                             bearerAuditTrail: [OfflineNoteAuditBundle],
-                             redemption: OfflineNoteRedeem,
-                             signingKey: SigningKey) throws -> SignedTransactionEnvelope {
-        var instructions: [Data] = []
-        instructions.reserveCapacity(bearerAuditTrail.count + 1)
-        for audit in bearerAuditTrail {
-            try audit.validateProofBinding()
-            instructions.append(try encodeInstruction(
-                wireName: OfflineNoteTypeNames.auditInstruction,
-                typeName: OfflineNoteTypeNames.auditInstruction,
-                modelPayload: OfflineNoteEncoding.encodeAudit(audit)
-            ))
-        }
-        try redemption.validateProofBinding()
-        instructions.append(try encodeInstruction(
-            wireName: OfflineNoteTypeNames.redeemInstruction,
-            typeName: OfflineNoteTypeNames.redeemInstruction,
-            modelPayload: OfflineNoteEncoding.encodeRedeem(redemption)
-        ))
-        return try encodeTransaction(
-            chainId: chainId,
-            authority: authority,
-            creationTimeMs: creationTimeMs,
-            ttlMs: ttlMs,
-            nonce: nonce,
-            instructionPayloads: instructions,
-            signingKey: signingKey
-        )
-    }
-
-    static func encodeAudit(chainId: String,
-                            authority: String,
-                            creationTimeMs: UInt64,
-                            ttlMs: UInt64?,
-                            nonce: UInt32?,
-                            audit: OfflineNoteAuditBundle,
-                            signingKey: SigningKey) throws -> SignedTransactionEnvelope {
-        try audit.validateProofBinding()
-        let instruction = try encodeInstruction(
-            wireName: OfflineNoteTypeNames.auditInstruction,
-            typeName: OfflineNoteTypeNames.auditInstruction,
-            modelPayload: OfflineNoteEncoding.encodeAudit(audit)
-        )
-        return try encodeTransaction(
-            chainId: chainId,
-            authority: authority,
-            creationTimeMs: creationTimeMs,
-            ttlMs: ttlMs,
-            nonce: nonce,
-            instructionPayloads: [instruction],
-            signingKey: signingKey
-        )
-    }
-
-    private static func encodeInstruction(wireName: String,
-                                          typeName: String,
-                                          modelPayload: Data) -> Data {
-        var concreteInstruction = OfflineNoritoWriter()
-        concreteInstruction.writeField(modelPayload)
-        let framedInstruction = noritoEncode(
-            typeName: typeName,
-            payload: concreteInstruction.data,
-            flags: 0
-        )
-
-        var instructionBox = OfflineNoritoWriter()
-        instructionBox.writeField(OfflineNorito.encodeString(wireName))
-        instructionBox.writeField(OfflineNorito.encodeBytesVec(framedInstruction))
-        return instructionBox.data
-    }
-
-    private static func encodeTransaction(chainId: String,
-                                          authority: String,
-                                          creationTimeMs: UInt64,
-                                          ttlMs: UInt64?,
-                                          nonce: UInt32?,
-                                          instructionPayloads: [Data],
-                                          signingKey: SigningKey) throws -> SignedTransactionEnvelope {
-        let transactionPayload = try encodeTransactionPayload(
-            chainId: chainId,
-            authority: authority,
-            creationTimeMs: creationTimeMs,
-            ttlMs: ttlMs,
-            nonce: nonce,
-            instructionPayloads: instructionPayloads
-        )
-        let signature = try signingKey.sign(IrohaHash.hash(transactionPayload))
-        let signedTransaction = encodeSignedTransaction(
-            signature: signature,
-            transactionPayload: transactionPayload
-        )
-        let transactionHash = IrohaHash.hash(encodeTransactionEntrypoint(signedTransaction))
-        var norito = Data([signedTransactionWireVersion])
-        norito.append(signedTransaction)
-        return SignedTransactionEnvelope(
-            norito: norito,
-            signedTransaction: signedTransaction,
-            payload: nil,
-            transactionHash: transactionHash
-        )
-    }
-
-    private static func encodeTransactionPayload(chainId: String,
-                                                 authority: String,
-                                                 creationTimeMs: UInt64,
-                                                 ttlMs: UInt64?,
-                                                 nonce: UInt32?,
-                                                 instructionPayloads: [Data]) throws -> Data {
-        var transactionPayload = OfflineNoritoWriter()
-        transactionPayload.writeField(OfflineNorito.encodeString(chainId))
-        transactionPayload.writeField(OfflineNorito.encodeString(authority))
-        transactionPayload.writeField(OfflineNorito.encodeUInt64(creationTimeMs))
-        transactionPayload.writeField(encodeExecutable(instructionPayloads: instructionPayloads))
-        transactionPayload.writeField(try OfflineNorito.encodeOption(ttlMs, encode: OfflineNorito.encodeUInt64))
-        transactionPayload.writeField(try OfflineNorito.encodeOption(nonce, encode: OfflineNorito.encodeUInt32))
-        transactionPayload.writeField(encodeEmptyMetadata())
-        return transactionPayload.data
-    }
-
-    private static func encodeExecutable(instructionPayloads: [Data]) -> Data {
-        var instructions = OfflineNoritoWriter()
-        instructions.writeLength(UInt64(instructionPayloads.count))
-        for instructionPayload in instructionPayloads {
-            instructions.writeField(instructionPayload)
-        }
-
-        var executable = OfflineNoritoWriter()
-        executable.writeUInt32LE(0)
-        executable.writeField(instructions.data)
-        return executable.data
-    }
-
-    private static func encodeSignedTransaction(signature: Data,
-                                                transactionPayload: Data) -> Data {
-        var signedTransaction = OfflineNoritoWriter()
-        signedTransaction.writeField(OfflineNorito.encodeConstVec(signature))
-        signedTransaction.writeField(transactionPayload)
-        signedTransaction.writeField(Data([0]))
-        signedTransaction.writeField(Data([0]))
-        return signedTransaction.data
-    }
-
-    private static func encodeTransactionEntrypoint(_ signedTransaction: Data) -> Data {
-        var entrypoint = OfflineNoritoWriter()
-        entrypoint.writeUInt32LE(0)
-        entrypoint.writeField(signedTransaction)
-        return entrypoint.data
-    }
-
-    private static func encodeEmptyMetadata() -> Data {
-        var metadata = OfflineNoritoWriter()
-        metadata.writeLength(0)
-        return metadata.data
-    }
-}
-
 extension SwiftTransactionEncoder {
     static func encodeIssueOfflineNote(request: IssueOfflineNoteRequest,
                                          keypair: Keypair,
@@ -230,15 +19,20 @@ extension SwiftTransactionEncoder {
             chainId: request.chainId,
             authorityId: request.authority
         )
-        return try OfflineNoteSwiftNoritoEncoder.encodeIssue(
-            chainId: ids.chainId,
-            authority: ids.authorityId,
-            creationTimeMs: creationTimeMs,
-            ttlMs: request.ttlMs,
-            nonce: request.nonce,
-            issue: request.issue,
-            signingKey: signingKey
-        )
+        let privateKey = try privateKeyBytes(from: signingKey)
+        let issueModel = try request.issue.noritoEncoded()
+        let native = try bridgeOrThrow {
+            try NoritoNativeBridge.shared.encodeIssueOfflineNote(
+                chainId: ids.chainId,
+                authority: ids.authorityId,
+                creationTimeMs: creationTimeMs,
+                ttlMs: request.ttlMs,
+                nonce: request.nonce,
+                issueModel: issueModel,
+                privateKey: privateKey
+            )
+        }
+        return try wrap(native: native)
     }
 
     static func encodeRedeemOfflineNote(request: RedeemOfflineNoteRequest,
@@ -259,15 +53,21 @@ extension SwiftTransactionEncoder {
             chainId: request.chainId,
             authorityId: request.authority
         )
-        return try OfflineNoteSwiftNoritoEncoder.encodeRedeem(
-            chainId: ids.chainId,
-            authority: ids.authorityId,
-            creationTimeMs: creationTimeMs,
-            ttlMs: request.ttlMs,
-            nonce: request.nonce,
-            redemption: request.redemption,
-            signingKey: signingKey
-        )
+        try request.redemption.validateProofBinding()
+        let privateKey = try privateKeyBytes(from: signingKey)
+        let redemptionModel = try request.redemption.noritoEncoded()
+        let native = try bridgeOrThrow {
+            try NoritoNativeBridge.shared.encodeRedeemOfflineNote(
+                chainId: ids.chainId,
+                authority: ids.authorityId,
+                creationTimeMs: creationTimeMs,
+                ttlMs: request.ttlMs,
+                nonce: request.nonce,
+                redemptionModel: redemptionModel,
+                privateKey: privateKey
+            )
+        }
+        return try wrap(native: native)
     }
 
     static func encodeDefundOfflineNote(request: DefundOfflineNoteRequest,
@@ -288,16 +88,26 @@ extension SwiftTransactionEncoder {
             chainId: request.chainId,
             authorityId: request.authority
         )
-        return try OfflineNoteSwiftNoritoEncoder.encodeDefund(
-            chainId: ids.chainId,
-            authority: ids.authorityId,
-            creationTimeMs: creationTimeMs,
-            ttlMs: request.ttlMs,
-            nonce: request.nonce,
-            bearerAuditTrail: request.bearerAuditTrail,
-            redemption: request.redemption,
-            signingKey: signingKey
-        )
+        for audit in request.bearerAuditTrail {
+            try audit.validateProofBinding()
+        }
+        try request.redemption.validateProofBinding()
+        let privateKey = try privateKeyBytes(from: signingKey)
+        let bearerAuditTrail = try request.bearerAuditTrail.map { try $0.noritoEncoded() }
+        let redemptionModel = try request.redemption.noritoEncoded()
+        let native = try bridgeOrThrow {
+            try NoritoNativeBridge.shared.encodeDefundOfflineNote(
+                chainId: ids.chainId,
+                authority: ids.authorityId,
+                creationTimeMs: creationTimeMs,
+                ttlMs: request.ttlMs,
+                nonce: request.nonce,
+                bearerAuditTrail: bearerAuditTrail,
+                redemptionModel: redemptionModel,
+                privateKey: privateKey
+            )
+        }
+        return try wrap(native: native)
     }
 
     static func encodeAuditOfflineNote(request: AuditOfflineNoteRequest,
@@ -318,15 +128,21 @@ extension SwiftTransactionEncoder {
             chainId: request.chainId,
             authorityId: request.authority
         )
-        return try OfflineNoteSwiftNoritoEncoder.encodeAudit(
-            chainId: ids.chainId,
-            authority: ids.authorityId,
-            creationTimeMs: creationTimeMs,
-            ttlMs: request.ttlMs,
-            nonce: request.nonce,
-            audit: request.audit,
-            signingKey: signingKey
-        )
+        try request.audit.validateProofBinding()
+        let privateKey = try privateKeyBytes(from: signingKey)
+        let auditModel = try request.audit.noritoEncoded()
+        let native = try bridgeOrThrow {
+            try NoritoNativeBridge.shared.encodeAuditOfflineNote(
+                chainId: ids.chainId,
+                authority: ids.authorityId,
+                creationTimeMs: creationTimeMs,
+                ttlMs: request.ttlMs,
+                nonce: request.nonce,
+                auditModel: auditModel,
+                privateKey: privateKey
+            )
+        }
+        return try wrap(native: native)
     }
 }
 

--- a/IrohaSwift/Sources/IrohaSwift/OfflineNoteWallet.swift
+++ b/IrohaSwift/Sources/IrohaSwift/OfflineNoteWallet.swift
@@ -231,6 +231,36 @@ public final class InMemoryOfflineNoteStore: OfflineNoteStore {
     }
 }
 
+final class AccountScopedOfflineNoteStore: OfflineNoteStore {
+    private let wrapped: OfflineNoteStore
+    private let chainId: String
+    private let accountId: String
+
+    init(wrapping wrapped: OfflineNoteStore, chainId: String, accountId: String) {
+        self.wrapped = wrapped
+        self.chainId = chainId
+        self.accountId = accountId
+    }
+
+    func mutateNotes<T>(_ body: (inout [String: OfflineNoteWalletNote]) throws -> T) throws -> T {
+        try wrapped.mutateNotes { all in
+            var scoped = all.filter { owns($0.value) }
+            let result = try body(&scoped)
+            for key in Array(all.keys) where all[key].map({ owns($0) }) == true {
+                all.removeValue(forKey: key)
+            }
+            for (key, note) in scoped {
+                all[key] = note
+            }
+            return result
+        }
+    }
+
+    private func owns(_ note: OfflineNoteWalletNote) -> Bool {
+        note.chainId == chainId && note.accountId == accountId
+    }
+}
+
 public protocol OfflineNoteAttestationProvider {
     func currentKeyCertificate() throws -> OfflineNoteKeyCertificate
 }
@@ -1420,7 +1450,7 @@ public final class OfflineNoteWallet {
         self.chainId = chainId
         self.accountId = accountId
         self.attestationProvider = attestationProvider
-        self.store = store
+        self.store = AccountScopedOfflineNoteStore(wrapping: store, chainId: chainId, accountId: accountId)
         self.issuerClient = issuerClient
         self.transactionSubmitter = transactionSubmitter
         self.syncResolver = syncResolver

--- a/IrohaSwift/Sources/IrohaSwift/TransactionEncoder.swift
+++ b/IrohaSwift/Sources/IrohaSwift/TransactionEncoder.swift
@@ -540,7 +540,7 @@ private enum SetPrimaryAccountAliasSwiftNoritoEncoder {
 }
 
 struct SwiftTransactionEncoder {
-    private static func bridgeOrThrow(_ body: () throws -> NativeSignedTransaction?) throws -> NativeSignedTransaction {
+    static func bridgeOrThrow(_ body: () throws -> NativeSignedTransaction?) throws -> NativeSignedTransaction {
         guard NoritoNativeBridge.shared.isAvailable else {
             throw SwiftTransactionEncoderError.nativeBridgeUnavailable
         }
@@ -554,7 +554,7 @@ struct SwiftTransactionEncoder {
         }
     }
 
-    private static func wrap(native: NativeSignedTransaction) throws -> SignedTransactionEnvelope {
+    static func wrap(native: NativeSignedTransaction) throws -> SignedTransactionEnvelope {
         guard native.signedBytes.first == signedTransactionWireVersion else {
             throw SwiftTransactionEncoderError.invalidNativeSignedTransaction(
                 "missing version byte \(signedTransactionWireVersion)"
@@ -1343,7 +1343,7 @@ struct SwiftTransactionEncoder {
         return try wrap(native: native)
     }
 
-    private static func privateKeyBytes(from signingKey: SigningKey) throws -> Data {
+    static func privateKeyBytes(from signingKey: SigningKey) throws -> Data {
         if signingKey.algorithm != .ed25519 {
             guard NoritoNativeBridge.shared.supportsTransactions(using: signingKey.algorithm) else {
                 throw SwiftTransactionEncoderError.unsupportedSigningAlgorithm(signingKey.algorithm)

--- a/IrohaSwift/Tests/IrohaSwiftTests/OfflineNoteTests.swift
+++ b/IrohaSwift/Tests/IrohaSwiftTests/OfflineNoteTests.swift
@@ -1321,6 +1321,67 @@ final class OfflineNoteTests: XCTestCase {
         )
     }
 
+    func testOfflineNoteWalletScopesSharedStoreByChainAndAccount() throws {
+        let fixture = try Self.loadFixture()
+        let derivation = fixture.chainVectors.derivation
+        let senderCertificate = try Self.certificate(fixture.paymentToken.senderKeyCertificate)
+        let sharedStore = InMemoryOfflineNoteStore()
+        let ownedNote = try Self.sourceWalletNote(fixture, certificate: senderCertificate)
+        let otherAccountNote = try Self.noteVariant(
+            ownedNote,
+            xorFirstByte: 0x01,
+            accountId: fixture.paymentToken.recipientAccountId
+        )
+        let otherChainNote = try Self.noteVariant(
+            ownedNote,
+            xorFirstByte: 0x02,
+            chainId: "00000043"
+        )
+        try sharedStore.upsert(ownedNote)
+        try sharedStore.upsert(otherAccountNote)
+        try sharedStore.upsert(otherChainNote)
+
+        let wallet = OfflineNoteWallet(
+            chainId: derivation.chainId,
+            accountId: ownedNote.accountId,
+            attestationProvider: StaticAttestationProvider(certificate: senderCertificate),
+            store: sharedStore,
+            transactionSubmitter: RecordingTransactionSubmitter(),
+            proofProvider: BindingProofProvider(),
+            proofVerifier: BindingProofVerifier(),
+            certificateVerifier: try Self.certificateVerifier(fixture),
+            randomSource: QueueRandomSource(values: [
+                try Self.hex(derivation.recipientNoteSecretHex)
+            ]),
+            idGenerator: FixedIdGenerator(id: derivation.paymentRequestId),
+            clock: { 1_700_000_001_200 }
+        )
+
+        XCTAssertEqual(
+            Set(try wallet.listNotes().map(\.noteCommitmentHex)),
+            [ownedNote.noteCommitmentHex]
+        )
+
+        let receiveRequest = try wallet.prepareReceive(
+            assetDefinitionId: Self.assetDefinition(fromAssetId: fixture.chainVectors.issue.assetId),
+            amount: fixture.chainVectors.redeem.amount
+        )
+
+        XCTAssertEqual(
+            Set(try wallet.listNotes().map(\.noteCommitmentHex)),
+            [ownedNote.noteCommitmentHex, receiveRequest.outputCommitmentHex]
+        )
+        XCTAssertEqual(
+            Set(try sharedStore.listNotes().map(\.noteCommitmentHex)),
+            [
+                ownedNote.noteCommitmentHex,
+                receiveRequest.outputCommitmentHex,
+                otherAccountNote.noteCommitmentHex,
+                otherChainNote.noteCommitmentHex
+            ]
+        )
+    }
+
     func testOfflineNoteWalletRejectsBearerCashCustodyPolicyOverflow() throws {
         let fixture = try Self.loadFixture()
         let derivation = fixture.chainVectors.derivation
@@ -4535,6 +4596,31 @@ final class OfflineNoteTests: XCTestCase {
             state: .spendable,
             createdAtMs: 1_700_000_000_000,
             updatedAtMs: 1_700_000_000_000
+        )
+    }
+
+    private static func noteVariant(
+        _ note: OfflineNoteWalletNote,
+        xorFirstByte: UInt8,
+        chainId: String? = nil,
+        accountId: String? = nil
+    ) throws -> OfflineNoteWalletNote {
+        var commitment = [UInt8](note.noteCommitment)
+        commitment[0] ^= xorFirstByte
+        return try OfflineNoteWalletNote(
+            chainId: chainId ?? note.chainId,
+            accountId: accountId ?? note.accountId,
+            assetId: note.assetId,
+            amount: note.amount,
+            keyCertificate: note.keyCertificate,
+            noteCommitment: Data(commitment),
+            noteSecret: note.noteSecret,
+            origin: note.origin,
+            bearerAuditTrail: note.bearerAuditTrail,
+            spentPaymentRequestId: note.spentPaymentRequestId,
+            state: note.state,
+            createdAtMs: note.createdAtMs,
+            updatedAtMs: note.updatedAtMs
         )
     }
 

--- a/crates/connect_norito_bridge/include/connect_norito_bridge.h
+++ b/crates/connect_norito_bridge/include/connect_norito_bridge.h
@@ -83,6 +83,72 @@ int32_t connect_norito_offline_prove_note_audit(
     uint8_t** out_recursive_proof_ptr,
     unsigned long* out_recursive_proof_len);
 
+// Encode and sign a `RedeemOfflineNote` on-chain transaction.
+// `redeem_norito` is the Norito archive of `OfflineNoteRedeem` with the
+// recursive proof already embedded. Output is canonical versioned
+// SignedTransaction bytes matching the transfer/mint encoders below.
+int32_t connect_norito_encode_redeem_offline_note_signed_transaction(
+    const char* chain_id, unsigned long chain_len,
+    const char* authority, unsigned long authority_len,
+    uint64_t creation_time_ms,
+    uint64_t ttl_ms,
+    uint8_t ttl_present,
+    uint32_t nonce,
+    uint8_t nonce_present,
+    const uint8_t* redeem_norito_ptr, unsigned long redeem_norito_len,
+    const uint8_t* private_key, unsigned long private_key_len,
+    uint8_t** out_signed_ptr, unsigned long* out_signed_len,
+    uint8_t* out_hash_ptr, unsigned long out_hash_len);
+
+// Encode and sign an `AuditOfflineNote` on-chain transaction.
+// `audit_norito` is the Norito archive of `OfflineNoteAuditBundle` with the
+// recursive proof already embedded.
+int32_t connect_norito_encode_audit_offline_note_signed_transaction(
+    const char* chain_id, unsigned long chain_len,
+    const char* authority, unsigned long authority_len,
+    uint64_t creation_time_ms,
+    uint64_t ttl_ms,
+    uint8_t ttl_present,
+    uint32_t nonce,
+    uint8_t nonce_present,
+    const uint8_t* audit_norito_ptr, unsigned long audit_norito_len,
+    const uint8_t* private_key, unsigned long private_key_len,
+    uint8_t** out_signed_ptr, unsigned long* out_signed_len,
+    uint8_t* out_hash_ptr, unsigned long out_hash_len);
+
+// Encode and sign an `IssueOfflineNote` on-chain transaction.
+// `issue_norito` is the Norito archive of `OfflineNoteIssue`.
+int32_t connect_norito_encode_issue_offline_note_signed_transaction(
+    const char* chain_id, unsigned long chain_len,
+    const char* authority, unsigned long authority_len,
+    uint64_t creation_time_ms,
+    uint64_t ttl_ms,
+    uint8_t ttl_present,
+    uint32_t nonce,
+    uint8_t nonce_present,
+    const uint8_t* issue_norito_ptr, unsigned long issue_norito_len,
+    const uint8_t* private_key, unsigned long private_key_len,
+    uint8_t** out_signed_ptr, unsigned long* out_signed_len,
+    uint8_t* out_hash_ptr, unsigned long out_hash_len);
+
+// Encode and sign a defund transaction: bearer audit trail followed by the
+// redemption, atomically in one signed transaction. `audit_trail` is a
+// count-prefixed concatenation. Each entry is an 8-byte little-endian length
+// followed by that many bytes of an `OfflineNoteAuditBundle` archive.
+int32_t connect_norito_encode_defund_offline_note_signed_transaction(
+    const char* chain_id, unsigned long chain_len,
+    const char* authority, unsigned long authority_len,
+    uint64_t creation_time_ms,
+    uint64_t ttl_ms,
+    uint8_t ttl_present,
+    uint32_t nonce,
+    uint8_t nonce_present,
+    const uint8_t* audit_trail_ptr, unsigned long audit_trail_len, uint32_t audit_trail_count,
+    const uint8_t* redeem_norito_ptr, unsigned long redeem_norito_len,
+    const uint8_t* private_key, unsigned long private_key_len,
+    uint8_t** out_signed_ptr, unsigned long* out_signed_len,
+    uint8_t* out_hash_ptr, unsigned long out_hash_len);
+
 // Legacy unanchored Kagemusha compact-token prover retained for ABI compatibility only.
 // Production callers must use `connect_norito_kagemusha_prove_verified_compact_payment_token_with_records`.
 // Valid `KagemushaVerifiedFoldBundle` input returns ERR_KAGEMUSHA_PROVE and no output bytes.

--- a/crates/connect_norito_bridge/src/lib.rs
+++ b/crates/connect_norito_bridge/src/lib.rs
@@ -3822,6 +3822,301 @@ pub unsafe extern "C" fn connect_norito_offline_prove_note_audit(
     bridge_result_to_code(result)
 }
 
+/// Encode and sign a `RedeemOfflineNote` on-chain transaction.
+///
+/// `redeem_norito` is the Norito archive of `OfflineNoteRedeem` with the
+/// recursive proof already embedded. The output is canonical versioned
+/// `SignedTransaction` bytes matching the transfer/mint encoders.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn connect_norito_encode_redeem_offline_note_signed_transaction(
+    chain_ptr: *const c_char,
+    chain_len: c_ulong,
+    authority_ptr: *const c_char,
+    authority_len: c_ulong,
+    creation_time_ms: u64,
+    ttl_ms: u64,
+    ttl_present: c_uchar,
+    nonce: u32,
+    nonce_present: c_uchar,
+    redeem_norito_ptr: *const c_uchar,
+    redeem_norito_len: c_ulong,
+    private_key_ptr: *const c_uchar,
+    private_key_len: c_ulong,
+    out_signed_ptr: *mut *mut c_uchar,
+    out_signed_len: *mut c_ulong,
+    out_hash_ptr: *mut c_uchar,
+    out_hash_len: c_ulong,
+) -> c_int {
+    let result = (|| {
+        if redeem_norito_ptr.is_null()
+            || private_key_ptr.is_null()
+            || out_signed_ptr.is_null()
+            || out_signed_len.is_null()
+            || out_hash_ptr.is_null()
+        {
+            return Err(BridgeError::NullPtr);
+        }
+        let chain_id: ChainId = unsafe { read_string_bridge(chain_ptr, chain_len) }?
+            .parse()
+            .map_err(|_| BridgeError::ChainId)?;
+        let authority =
+            parse_account_id(unsafe { read_string_bridge(authority_ptr, authority_len) }?)?;
+        let key_slice = unsafe { slice::from_raw_parts(private_key_ptr, private_key_len as usize) };
+        let private_key = parse_private_key(key_slice)?;
+        let ttl = parse_ttl(ttl_ms, ttl_present != 0)?;
+        let nonce = parse_nonce(nonce, nonce_present != 0)?;
+        let redeem_bytes =
+            unsafe { slice::from_raw_parts(redeem_norito_ptr, redeem_norito_len as usize) };
+        let redemption: iroha_data_model::offline::OfflineNoteRedeem =
+            norito::decode_from_bytes(redeem_bytes).map_err(|_| BridgeError::OfflineNoteProve)?;
+        let instruction = InstructionBox::from(
+            iroha_data_model::isi::offline::RedeemOfflineNote::new(redemption),
+        );
+        let (signed_bytes, hash_bytes) = encode_asset_transaction_with_nonce(
+            chain_id,
+            authority,
+            creation_time_ms,
+            ttl,
+            nonce,
+            private_key,
+            move || Executable::from([instruction]),
+        );
+        write_hash(out_hash_ptr, out_hash_len, &hash_bytes)?;
+        unsafe { write_bytes_bridge(out_signed_ptr, out_signed_len, &signed_bytes) }?;
+        Ok(())
+    })();
+
+    bridge_result_to_code(result)
+}
+
+/// Encode and sign an `AuditOfflineNote` on-chain transaction.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn connect_norito_encode_audit_offline_note_signed_transaction(
+    chain_ptr: *const c_char,
+    chain_len: c_ulong,
+    authority_ptr: *const c_char,
+    authority_len: c_ulong,
+    creation_time_ms: u64,
+    ttl_ms: u64,
+    ttl_present: c_uchar,
+    nonce: u32,
+    nonce_present: c_uchar,
+    audit_norito_ptr: *const c_uchar,
+    audit_norito_len: c_ulong,
+    private_key_ptr: *const c_uchar,
+    private_key_len: c_ulong,
+    out_signed_ptr: *mut *mut c_uchar,
+    out_signed_len: *mut c_ulong,
+    out_hash_ptr: *mut c_uchar,
+    out_hash_len: c_ulong,
+) -> c_int {
+    let result = (|| {
+        if audit_norito_ptr.is_null()
+            || private_key_ptr.is_null()
+            || out_signed_ptr.is_null()
+            || out_signed_len.is_null()
+            || out_hash_ptr.is_null()
+        {
+            return Err(BridgeError::NullPtr);
+        }
+        let chain_id: ChainId = unsafe { read_string_bridge(chain_ptr, chain_len) }?
+            .parse()
+            .map_err(|_| BridgeError::ChainId)?;
+        let authority =
+            parse_account_id(unsafe { read_string_bridge(authority_ptr, authority_len) }?)?;
+        let key_slice = unsafe { slice::from_raw_parts(private_key_ptr, private_key_len as usize) };
+        let private_key = parse_private_key(key_slice)?;
+        let ttl = parse_ttl(ttl_ms, ttl_present != 0)?;
+        let nonce = parse_nonce(nonce, nonce_present != 0)?;
+        let audit_bytes =
+            unsafe { slice::from_raw_parts(audit_norito_ptr, audit_norito_len as usize) };
+        let audit: iroha_data_model::offline::OfflineNoteAuditBundle =
+            norito::decode_from_bytes(audit_bytes).map_err(|_| BridgeError::OfflineNoteProve)?;
+        let instruction =
+            InstructionBox::from(iroha_data_model::isi::offline::AuditOfflineNote::new(audit));
+        let (signed_bytes, hash_bytes) = encode_asset_transaction_with_nonce(
+            chain_id,
+            authority,
+            creation_time_ms,
+            ttl,
+            nonce,
+            private_key,
+            move || Executable::from([instruction]),
+        );
+        write_hash(out_hash_ptr, out_hash_len, &hash_bytes)?;
+        unsafe { write_bytes_bridge(out_signed_ptr, out_signed_len, &signed_bytes) }?;
+        Ok(())
+    })();
+
+    bridge_result_to_code(result)
+}
+
+/// Encode and sign an `IssueOfflineNote` on-chain transaction.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn connect_norito_encode_issue_offline_note_signed_transaction(
+    chain_ptr: *const c_char,
+    chain_len: c_ulong,
+    authority_ptr: *const c_char,
+    authority_len: c_ulong,
+    creation_time_ms: u64,
+    ttl_ms: u64,
+    ttl_present: c_uchar,
+    nonce: u32,
+    nonce_present: c_uchar,
+    issue_norito_ptr: *const c_uchar,
+    issue_norito_len: c_ulong,
+    private_key_ptr: *const c_uchar,
+    private_key_len: c_ulong,
+    out_signed_ptr: *mut *mut c_uchar,
+    out_signed_len: *mut c_ulong,
+    out_hash_ptr: *mut c_uchar,
+    out_hash_len: c_ulong,
+) -> c_int {
+    let result = (|| {
+        if issue_norito_ptr.is_null()
+            || private_key_ptr.is_null()
+            || out_signed_ptr.is_null()
+            || out_signed_len.is_null()
+            || out_hash_ptr.is_null()
+        {
+            return Err(BridgeError::NullPtr);
+        }
+        let chain_id: ChainId = unsafe { read_string_bridge(chain_ptr, chain_len) }?
+            .parse()
+            .map_err(|_| BridgeError::ChainId)?;
+        let authority =
+            parse_account_id(unsafe { read_string_bridge(authority_ptr, authority_len) }?)?;
+        let key_slice = unsafe { slice::from_raw_parts(private_key_ptr, private_key_len as usize) };
+        let private_key = parse_private_key(key_slice)?;
+        let ttl = parse_ttl(ttl_ms, ttl_present != 0)?;
+        let nonce = parse_nonce(nonce, nonce_present != 0)?;
+        let issue_bytes =
+            unsafe { slice::from_raw_parts(issue_norito_ptr, issue_norito_len as usize) };
+        let issue: iroha_data_model::offline::OfflineNoteIssue =
+            norito::decode_from_bytes(issue_bytes).map_err(|_| BridgeError::OfflineNoteProve)?;
+        let instruction =
+            InstructionBox::from(iroha_data_model::isi::offline::IssueOfflineNote::new(issue));
+        let (signed_bytes, hash_bytes) = encode_asset_transaction_with_nonce(
+            chain_id,
+            authority,
+            creation_time_ms,
+            ttl,
+            nonce,
+            private_key,
+            move || Executable::from([instruction]),
+        );
+        write_hash(out_hash_ptr, out_hash_len, &hash_bytes)?;
+        unsafe { write_bytes_bridge(out_signed_ptr, out_signed_len, &signed_bytes) }?;
+        Ok(())
+    })();
+
+    bridge_result_to_code(result)
+}
+
+/// Encode and sign a defund transaction: bearer audits followed by redemption.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn connect_norito_encode_defund_offline_note_signed_transaction(
+    chain_ptr: *const c_char,
+    chain_len: c_ulong,
+    authority_ptr: *const c_char,
+    authority_len: c_ulong,
+    creation_time_ms: u64,
+    ttl_ms: u64,
+    ttl_present: c_uchar,
+    nonce: u32,
+    nonce_present: c_uchar,
+    audit_trail_ptr: *const c_uchar,
+    audit_trail_len: c_ulong,
+    audit_trail_count: u32,
+    redeem_norito_ptr: *const c_uchar,
+    redeem_norito_len: c_ulong,
+    private_key_ptr: *const c_uchar,
+    private_key_len: c_ulong,
+    out_signed_ptr: *mut *mut c_uchar,
+    out_signed_len: *mut c_ulong,
+    out_hash_ptr: *mut c_uchar,
+    out_hash_len: c_ulong,
+) -> c_int {
+    let result = (|| {
+        if redeem_norito_ptr.is_null()
+            || private_key_ptr.is_null()
+            || out_signed_ptr.is_null()
+            || out_signed_len.is_null()
+            || out_hash_ptr.is_null()
+        {
+            return Err(BridgeError::NullPtr);
+        }
+        let chain_id: ChainId = unsafe { read_string_bridge(chain_ptr, chain_len) }?
+            .parse()
+            .map_err(|_| BridgeError::ChainId)?;
+        let authority =
+            parse_account_id(unsafe { read_string_bridge(authority_ptr, authority_len) }?)?;
+        let key_slice = unsafe { slice::from_raw_parts(private_key_ptr, private_key_len as usize) };
+        let private_key = parse_private_key(key_slice)?;
+        let ttl = parse_ttl(ttl_ms, ttl_present != 0)?;
+        let nonce = parse_nonce(nonce, nonce_present != 0)?;
+
+        let trail: &[u8] = if audit_trail_count > 0 {
+            if audit_trail_ptr.is_null() {
+                return Err(BridgeError::NullPtr);
+            }
+            unsafe { slice::from_raw_parts(audit_trail_ptr, audit_trail_len as usize) }
+        } else {
+            &[]
+        };
+        let mut instructions: Vec<InstructionBox> =
+            Vec::with_capacity(audit_trail_count as usize + 1);
+        let mut cursor: usize = 0;
+        for _ in 0..audit_trail_count {
+            if cursor + 8 > trail.len() {
+                return Err(BridgeError::OfflineNoteProve);
+            }
+            let len = usize::try_from(u64::from_le_bytes(
+                <[u8; 8]>::try_from(&trail[cursor..cursor + 8])
+                    .map_err(|_| BridgeError::OfflineNoteProve)?,
+            ))
+            .map_err(|_| BridgeError::OfflineNoteProve)?;
+            cursor += 8;
+            if cursor + len > trail.len() {
+                return Err(BridgeError::OfflineNoteProve);
+            }
+            let audit: iroha_data_model::offline::OfflineNoteAuditBundle =
+                norito::decode_from_bytes(&trail[cursor..cursor + len])
+                    .map_err(|_| BridgeError::OfflineNoteProve)?;
+            cursor += len;
+            instructions.push(InstructionBox::from(
+                iroha_data_model::isi::offline::AuditOfflineNote::new(audit),
+            ));
+        }
+        if cursor != trail.len() {
+            return Err(BridgeError::OfflineNoteProve);
+        }
+
+        let redeem_bytes =
+            unsafe { slice::from_raw_parts(redeem_norito_ptr, redeem_norito_len as usize) };
+        let redemption: iroha_data_model::offline::OfflineNoteRedeem =
+            norito::decode_from_bytes(redeem_bytes).map_err(|_| BridgeError::OfflineNoteProve)?;
+        instructions.push(InstructionBox::from(
+            iroha_data_model::isi::offline::RedeemOfflineNote::new(redemption),
+        ));
+
+        let (signed_bytes, hash_bytes) = encode_asset_transaction_with_nonce(
+            chain_id,
+            authority,
+            creation_time_ms,
+            ttl,
+            nonce,
+            private_key,
+            move || Executable::from(instructions),
+        );
+        write_hash(out_hash_ptr, out_hash_len, &hash_bytes)?;
+        unsafe { write_bytes_bridge(out_signed_ptr, out_signed_len, &signed_bytes) }?;
+        Ok(())
+    })();
+
+    bridge_result_to_code(result)
+}
+
 fn prove_offline_note_redeem_recursive(
     redeem_archive: &[u8],
 ) -> BridgeResult<iroha_data_model::offline::OfflineNoteRecursiveProof> {
@@ -4290,7 +4585,7 @@ pub extern "C" fn connect_norito_free(ptr_: *mut c_uchar) {
 
 #[cfg(test)]
 mod offline_note_prover_tests {
-    use std::sync::OnceLock;
+    use std::{ffi::CString, sync::OnceLock};
 
     use iroha_core::zk::{
         KAGEMUSHA_HOP_MAX_PROOF_BYTES, OFFLINE_NOTE_RECURSIVE_CIRCUIT_ID, ZK_BACKEND_HALO2_IPA,
@@ -4334,6 +4629,17 @@ mod offline_note_prover_tests {
     fn sample_account(seed: u8) -> AccountId {
         let keypair = KeyPair::from_seed(vec![seed; 32], Algorithm::Ed25519);
         AccountId::new(keypair.public_key().clone())
+    }
+
+    fn sample_authority_and_private_key(seed: u8) -> (CString, Vec<u8>) {
+        let keypair = KeyPair::from_seed(vec![seed; 32], Algorithm::Ed25519);
+        let (public_key, private_key) = keypair.into_parts();
+        let account = AccountId::new(public_key);
+        let (_algorithm, private_bytes) = private_key.to_bytes();
+        (
+            CString::new(account.to_string()).expect("valid cstring"),
+            private_bytes,
+        )
     }
 
     fn sample_asset(account: AccountId) -> AssetId {
@@ -4446,6 +4752,16 @@ mod offline_note_prover_tests {
             assertion_usage_count_limit: None,
             one_use: true,
             issuer_signature: sample_signature(seed.wrapping_add(1)),
+        }
+    }
+
+    fn sample_issue() -> OfflineNoteIssue {
+        let account = sample_account(0x91);
+        OfflineNoteIssue {
+            note_commitment: Hash::new(b"offline-note-issued-note"),
+            key_certificate: sample_certificate(&account, 0x92),
+            asset: sample_asset(account),
+            amount: Numeric::new(10, 0),
         }
     }
 
@@ -5734,6 +6050,174 @@ mod offline_note_prover_tests {
         assert_eq!(status, ERR_OFFLINE_NOTE_PROVE);
         assert!(out_ptr.is_null());
         assert_eq!(out_len, 0);
+    }
+
+    fn decode_signed_from_ffi_output(
+        out_hash: [u8; Hash::LENGTH],
+        out_ptr: *mut c_uchar,
+        out_len: c_ulong,
+    ) -> SignedTransaction {
+        assert!(!out_ptr.is_null());
+        let bytes = unsafe { slice::from_raw_parts(out_ptr, out_len as usize) };
+        let signed = decode_signed_transaction(bytes).expect("decode signed transaction");
+        assert_eq!(out_hash, *signed.hash().as_ref());
+        connect_norito_free(out_ptr);
+        signed
+    }
+
+    fn assert_single_instruction<T: 'static>(signed: &SignedTransaction) {
+        match signed.instructions() {
+            Executable::Instructions(instructions) => {
+                assert_eq!(instructions.len(), 1);
+                assert!(instructions[0].as_any().downcast_ref::<T>().is_some());
+            }
+            other => panic!("unexpected executable: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn offline_note_signed_transaction_ffis_encode_canonical_transactions() {
+        let chain = CString::new("00000042").expect("valid chain id");
+        let (authority, private_key) = sample_authority_and_private_key(0x55);
+        let issue_archive = norito::to_bytes(&sample_issue()).expect("encode issue");
+        let redeem_archive = norito::to_bytes(&sample_redemption()).expect("encode redemption");
+        let audit_archive = norito::to_bytes(&sample_audit()).expect("encode audit");
+        let mut out_ptr: *mut c_uchar = ptr::null_mut();
+        let mut out_len: c_ulong = 0;
+        let mut out_hash = [0u8; Hash::LENGTH];
+
+        let issue_status = unsafe {
+            connect_norito_encode_issue_offline_note_signed_transaction(
+                chain.as_ptr(),
+                chain.as_bytes().len() as c_ulong,
+                authority.as_ptr(),
+                authority.as_bytes().len() as c_ulong,
+                1_736_000_000_000,
+                3_500,
+                1,
+                17,
+                1,
+                issue_archive.as_ptr(),
+                issue_archive.len() as c_ulong,
+                private_key.as_ptr(),
+                private_key.len() as c_ulong,
+                &mut out_ptr,
+                &mut out_len,
+                out_hash.as_mut_ptr(),
+                out_hash.len() as c_ulong,
+            )
+        };
+        assert_eq!(issue_status, 0);
+        let signed = decode_signed_from_ffi_output(out_hash, out_ptr, out_len);
+        assert_single_instruction::<iroha_data_model::isi::offline::IssueOfflineNote>(&signed);
+
+        out_ptr = ptr::null_mut();
+        out_len = 0;
+        out_hash = [0u8; Hash::LENGTH];
+        let redeem_status = unsafe {
+            connect_norito_encode_redeem_offline_note_signed_transaction(
+                chain.as_ptr(),
+                chain.as_bytes().len() as c_ulong,
+                authority.as_ptr(),
+                authority.as_bytes().len() as c_ulong,
+                1_736_000_000_000,
+                0,
+                0,
+                0,
+                0,
+                redeem_archive.as_ptr(),
+                redeem_archive.len() as c_ulong,
+                private_key.as_ptr(),
+                private_key.len() as c_ulong,
+                &mut out_ptr,
+                &mut out_len,
+                out_hash.as_mut_ptr(),
+                out_hash.len() as c_ulong,
+            )
+        };
+        assert_eq!(redeem_status, 0);
+        let signed = decode_signed_from_ffi_output(out_hash, out_ptr, out_len);
+        assert_single_instruction::<iroha_data_model::isi::offline::RedeemOfflineNote>(&signed);
+
+        out_ptr = ptr::null_mut();
+        out_len = 0;
+        out_hash = [0u8; Hash::LENGTH];
+        let audit_status = unsafe {
+            connect_norito_encode_audit_offline_note_signed_transaction(
+                chain.as_ptr(),
+                chain.as_bytes().len() as c_ulong,
+                authority.as_ptr(),
+                authority.as_bytes().len() as c_ulong,
+                1_736_000_000_000,
+                0,
+                0,
+                0,
+                0,
+                audit_archive.as_ptr(),
+                audit_archive.len() as c_ulong,
+                private_key.as_ptr(),
+                private_key.len() as c_ulong,
+                &mut out_ptr,
+                &mut out_len,
+                out_hash.as_mut_ptr(),
+                out_hash.len() as c_ulong,
+            )
+        };
+        assert_eq!(audit_status, 0);
+        let signed = decode_signed_from_ffi_output(out_hash, out_ptr, out_len);
+        assert_single_instruction::<iroha_data_model::isi::offline::AuditOfflineNote>(&signed);
+
+        let mut trail = Vec::new();
+        let audit_len = u64::try_from(audit_archive.len()).expect("audit archive length fits u64");
+        trail.extend_from_slice(&audit_len.to_le_bytes());
+        trail.extend_from_slice(&audit_archive);
+        out_ptr = ptr::null_mut();
+        out_len = 0;
+        out_hash = [0u8; Hash::LENGTH];
+        let defund_status = unsafe {
+            connect_norito_encode_defund_offline_note_signed_transaction(
+                chain.as_ptr(),
+                chain.as_bytes().len() as c_ulong,
+                authority.as_ptr(),
+                authority.as_bytes().len() as c_ulong,
+                1_736_000_000_000,
+                0,
+                0,
+                0,
+                0,
+                trail.as_ptr(),
+                trail.len() as c_ulong,
+                1,
+                redeem_archive.as_ptr(),
+                redeem_archive.len() as c_ulong,
+                private_key.as_ptr(),
+                private_key.len() as c_ulong,
+                &mut out_ptr,
+                &mut out_len,
+                out_hash.as_mut_ptr(),
+                out_hash.len() as c_ulong,
+            )
+        };
+        assert_eq!(defund_status, 0);
+        let signed = decode_signed_from_ffi_output(out_hash, out_ptr, out_len);
+        match signed.instructions() {
+            Executable::Instructions(instructions) => {
+                assert_eq!(instructions.len(), 2);
+                assert!(
+                    instructions[0]
+                        .as_any()
+                        .downcast_ref::<iroha_data_model::isi::offline::AuditOfflineNote>()
+                        .is_some()
+                );
+                assert!(
+                    instructions[1]
+                        .as_any()
+                        .downcast_ref::<iroha_data_model::isi::offline::RedeemOfflineNote>()
+                        .is_some()
+                );
+            }
+            other => panic!("unexpected executable: {other:?}"),
+        }
     }
 }
 

--- a/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/OfflineNoteHalo2Prover.java
+++ b/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/OfflineNoteHalo2Prover.java
@@ -26,7 +26,7 @@ public final class OfflineNoteHalo2Prover {
   private static final int PUBLIC_VALUE_COUNT = 16;
   private static final int ADVICE_COUNT = 22;
   private static final byte[] CANONICAL_VK_HASH =
-      hexBytes("ad4d2ce680df32288d382c8b6403108d7174ca0ba9e558bd93a693f9d770b256");
+      hexBytes("3493ea067302cab2180cef8f5dc60e0e6751ab9bb0c850286e2aaace2f863c25");
   private static final byte[] CANONICAL_TRANSCRIPT_REPR =
       hexBytes("7db2235914292d4e825d6d51e1a880da77f107eb2c7853e3ec9c9d0dccc59813");
   private static final SecureRandom RNG = new SecureRandom();

--- a/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/offline/OfflineNoteHalo2Prover.java
+++ b/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/offline/OfflineNoteHalo2Prover.java
@@ -26,7 +26,7 @@ public final class OfflineNoteHalo2Prover {
   private static final int PUBLIC_VALUE_COUNT = 16;
   private static final int ADVICE_COUNT = 22;
   private static final byte[] CANONICAL_VK_HASH =
-      hexBytes("ad4d2ce680df32288d382c8b6403108d7174ca0ba9e558bd93a693f9d770b256");
+      hexBytes("3493ea067302cab2180cef8f5dc60e0e6751ab9bb0c850286e2aaace2f863c25");
   private static final byte[] CANONICAL_TRANSCRIPT_REPR =
       hexBytes("7db2235914292d4e825d6d51e1a880da77f107eb2c7853e3ec9c9d0dccc59813");
   private static final SecureRandom RNG = new SecureRandom();


### PR DESCRIPTION
## Summary
Make the IrohaSwift SDK's on-chain offline-note operations — **redeem / audit / issue / defund** — work end-to-end against a live node. **Validated live on localnet:** redeem now commits on-chain and the escrowed offline note returns to the online balance (450 → 500).

Four parts, each surfaced only after the previous was fixed:

1. **Encoder (length mismatch).** The SDK hand-rolled the `SignedTransaction` envelope with u64-LE length framing → node rejected with `Norito (de)serialization issue: length mismatch`. Route all four offline-note tx encoders through `connect_norito_bridge` (canonical compact-norito envelope, identical framing to transfer/mint). New Rust FFIs + C header decls; the hand-rolled writer is deleted.
2. **Multi-ISI defund.** `defund` builds an `Executable` of `[Audit_1..Audit_n, Redeem]` from a count-prefixed bearer audit-trail buffer.
3. **Static bridge path.** The statically-linked init path (`IROHASWIFT_BRIDGE_PRESENT`, e.g. release / `-all_load`) only wired the transfer encoders; mint + offline encoders were left nil → `nativeBridgeUnavailable` on static builds. Mirror the dynamic dlsym path. Typealias signatures verified against the C header.
4. **Canonical vk hash sync.** `Halo2OfflineNoteProver.canonicalVKHash` had drifted from the node's `offline_note_recursive_vk_box()` commitment → node rejected `RedeemOfflineNote` with `offline recursive proof verifier commitment mismatch` (offline.rs: `envelope.vk_hash != record.commitment`). Re-synced; `transcript_repr` was unchanged so the proof already verified: `ad4d2ce6… → 3493ea06…`.

## Commits
- `b3d2266fbc` on-chain redeem/audit encoders via bridge
- `6a588e8e59` route all offline-note tx encoders through the bridge (issue/defund)
- `77969364bb` sync offline-note-recursive canonical vk hash to node
- `e0314f06c8` wire offline-note encoders into the static bridge path

## Test plan
- [x] `cargo check -p connect_norito_bridge`
- [x] iOS live localnet: top-up + **redeem commits on-chain** (balance 450 → 500); no length mismatch, no commitment mismatch
- [ ] CI compiles the static `IROHASWIFT_BRIDGE_PRESENT` bridge path
