### PR TITLE
Use chain VK and owner-signed offline-note certs

### DIFF
--- a/crates/connect_norito_bridge/Cargo.toml
+++ b/crates/connect_norito_bridge/Cargo.toml
@@ -14,6 +14,7 @@ schema-structural = []
 [dependencies]
 norito = { path = "../norito", version = "2.0.0-rc.2.0", default-features = false, features = ["std", "derive", "json", "json-std-io", "columnar", "strict-safe"] }
 iroha_core = { workspace = true, features = ["zk-halo2-ipa"] }
+iroha_zkp_halo2 = { workspace = true }
 iroha_torii_shared = { workspace = true }
 fastpq_prover = { workspace = true }
 iroha_crypto = { workspace = true, default-features = false, features = ["std", "bls", "gost", "sm"] }
@@ -37,7 +38,6 @@ zeroize = { version = "1.8.2", default-features = false, features = ["alloc", "s
 
 [dev-dependencies]
 iroha_core = { workspace = true, features = ["iroha-core-tests", "zk-halo2-ipa"] }
-iroha_zkp_halo2 = { workspace = true }
 tempfile = { workspace = true }
 sorafs_chunker = { workspace = true }
 

--- a/crates/connect_norito_bridge/include/connect_norito_bridge.h
+++ b/crates/connect_norito_bridge/include/connect_norito_bridge.h
@@ -23,6 +23,7 @@ extern "C" {
 #define CONNECT_NORITO_ERR_OFFLINE_NOTE_PROVE -310
 #define CONNECT_NORITO_ERR_KAGEMUSHA_PROVE -311
 #define CONNECT_NORITO_ERR_KAGEMUSHA_RECURSIVE_COMPACT_UNAVAILABLE -312
+#define CONNECT_NORITO_ERR_OFFLINE_NOTE_VERIFY -313
 
 // ---------------- Bridge ABI ----------------
 uint32_t connect_norito_bridge_abi_version(void);
@@ -149,6 +150,48 @@ int32_t connect_norito_encode_defund_offline_note_signed_transaction(
     const uint8_t* private_key, unsigned long private_key_len,
     uint8_t** out_signed_ptr, unsigned long* out_signed_len,
     uint8_t* out_hash_ptr, unsigned long out_hash_len);
+
+// Generate a recursive Halo2/IPA proof for an Offline redemption against a chain-supplied verifying key.
+// Input: Norito-archive bytes of `OfflineNoteRedeem` and `VerifyingKeyBox`.
+// Output: Norito-archive bytes of `OfflineNoteRecursiveProof`.
+int32_t connect_norito_offline_prove_note_redeem_with_vk(
+    const uint8_t* redeem_norito_ptr,
+    unsigned long redeem_norito_len,
+    const uint8_t* vk_norito_ptr,
+    unsigned long vk_norito_len,
+    uint8_t** out_recursive_proof_ptr,
+    unsigned long* out_recursive_proof_len);
+
+// Generate a recursive Halo2/IPA proof for an Offline audit bundle against a chain-supplied verifying key.
+// Input: Norito-archive bytes of `OfflineNoteAuditBundle` and `VerifyingKeyBox`.
+// Output: Norito-archive bytes of `OfflineNoteRecursiveProof`.
+int32_t connect_norito_offline_prove_note_audit_with_vk(
+    const uint8_t* audit_norito_ptr,
+    unsigned long audit_norito_len,
+    const uint8_t* vk_norito_ptr,
+    unsigned long vk_norito_len,
+    uint8_t** out_recursive_proof_ptr,
+    unsigned long* out_recursive_proof_len);
+
+// Cryptographically verify an Offline redemption's embedded recursive proof against
+// a chain-supplied verifying key. Input: Norito-archive bytes of `OfflineNoteRedeem`
+// and `VerifyingKeyBox`. Returns 1 if valid, 0 if invalid, negative on decode/null error.
+int32_t connect_norito_offline_verify_note_redeem_with_vk(
+    const uint8_t* redeem_norito_ptr,
+    unsigned long redeem_norito_len,
+    const uint8_t* vk_norito_ptr,
+    unsigned long vk_norito_len,
+    int32_t* out_valid);
+
+// Cryptographically verify an Offline audit bundle's embedded recursive proof against
+// a chain-supplied verifying key. Input: Norito-archive bytes of `OfflineNoteAuditBundle`
+// and `VerifyingKeyBox`. Returns 1 if valid, 0 if invalid, negative on decode/null error.
+int32_t connect_norito_offline_verify_note_audit_with_vk(
+    const uint8_t* audit_norito_ptr,
+    unsigned long audit_norito_len,
+    const uint8_t* vk_norito_ptr,
+    unsigned long vk_norito_len,
+    int32_t* out_valid);
 
 // Legacy unanchored Kagemusha compact-token prover retained for ABI compatibility only.
 // Production callers must use `connect_norito_kagemusha_prove_verified_compact_payment_token_with_records`.

--- a/crates/connect_norito_bridge/src/lib.rs
+++ b/crates/connect_norito_bridge/src/lib.rs
@@ -128,6 +128,7 @@ const ERR_JSON_SERIALIZE: c_int = -304;
 const ERR_OFFLINE_NOTE_PROVE: c_int = -310;
 const ERR_KAGEMUSHA_PROVE: c_int = -311;
 const ERR_KAGEMUSHA_RECURSIVE_COMPACT_UNAVAILABLE: c_int = -312;
+const ERR_OFFLINE_NOTE_VERIFY: c_int = -313;
 const ERR_DA_PROOF_SUMMARY: c_int = -401;
 const ERR_MULTISIG_SPEC: c_int = -402;
 const ERR_VERIFYING_KEY_ID: c_int = -403;
@@ -159,6 +160,7 @@ enum BridgeError {
     AssetId,
     JsonSerialize,
     OfflineNoteProve,
+    OfflineNoteVerify,
     KagemushaProve,
     KagemushaRecursiveCompactUnavailable,
     UnsupportedAlgorithm,
@@ -201,6 +203,7 @@ impl BridgeError {
             BridgeError::AssetId => ERR_ASSET_ID_PARSE,
             BridgeError::JsonSerialize => ERR_JSON_SERIALIZE,
             BridgeError::OfflineNoteProve => ERR_OFFLINE_NOTE_PROVE,
+            BridgeError::OfflineNoteVerify => ERR_OFFLINE_NOTE_VERIFY,
             BridgeError::KagemushaProve => ERR_KAGEMUSHA_PROVE,
             BridgeError::KagemushaRecursiveCompactUnavailable => {
                 ERR_KAGEMUSHA_RECURSIVE_COMPACT_UNAVAILABLE
@@ -5993,6 +5996,119 @@ pub unsafe extern "C" fn connect_norito_encode_defund_offline_note_signed_transa
     bridge_result_to_code(result)
 }
 
+/// Generate a recursive Halo2/IPA proof for an Offline redemption against a chain-supplied verifying key.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn connect_norito_offline_prove_note_redeem_with_vk(
+    redeem_norito_ptr: *const c_uchar,
+    redeem_norito_len: c_ulong,
+    vk_norito_ptr: *const c_uchar,
+    vk_norito_len: c_ulong,
+    out_recursive_proof_ptr: *mut *mut c_uchar,
+    out_recursive_proof_len: *mut c_ulong,
+) -> c_int {
+    let result = (|| {
+        if redeem_norito_ptr.is_null()
+            || vk_norito_ptr.is_null()
+            || out_recursive_proof_ptr.is_null()
+            || out_recursive_proof_len.is_null()
+        {
+            return Err(BridgeError::NullPtr);
+        }
+        let redeem_bytes =
+            unsafe { slice::from_raw_parts(redeem_norito_ptr, redeem_norito_len as usize) };
+        let vk_bytes = unsafe { slice::from_raw_parts(vk_norito_ptr, vk_norito_len as usize) };
+        let archive = prove_offline_note_redeem_recursive_with_vk(redeem_bytes, vk_bytes)
+            .map_err(|_| BridgeError::OfflineNoteProve)?;
+        unsafe { write_bytes_bridge(out_recursive_proof_ptr, out_recursive_proof_len, &archive) }
+    })();
+
+    bridge_result_to_code(result)
+}
+
+/// Generate a recursive Halo2/IPA proof for an Offline audit bundle against a chain-supplied verifying key.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn connect_norito_offline_prove_note_audit_with_vk(
+    audit_norito_ptr: *const c_uchar,
+    audit_norito_len: c_ulong,
+    vk_norito_ptr: *const c_uchar,
+    vk_norito_len: c_ulong,
+    out_recursive_proof_ptr: *mut *mut c_uchar,
+    out_recursive_proof_len: *mut c_ulong,
+) -> c_int {
+    let result = (|| {
+        if audit_norito_ptr.is_null()
+            || vk_norito_ptr.is_null()
+            || out_recursive_proof_ptr.is_null()
+            || out_recursive_proof_len.is_null()
+        {
+            return Err(BridgeError::NullPtr);
+        }
+        let audit_bytes =
+            unsafe { slice::from_raw_parts(audit_norito_ptr, audit_norito_len as usize) };
+        let vk_bytes = unsafe { slice::from_raw_parts(vk_norito_ptr, vk_norito_len as usize) };
+        let archive = prove_offline_note_audit_recursive_with_vk(audit_bytes, vk_bytes)
+            .map_err(|_| BridgeError::OfflineNoteProve)?;
+        unsafe { write_bytes_bridge(out_recursive_proof_ptr, out_recursive_proof_len, &archive) }
+    })();
+
+    bridge_result_to_code(result)
+}
+
+/// Cryptographically verify an Offline redemption's embedded recursive proof against a chain-supplied verifying key.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn connect_norito_offline_verify_note_redeem_with_vk(
+    redeem_norito_ptr: *const c_uchar,
+    redeem_norito_len: c_ulong,
+    vk_norito_ptr: *const c_uchar,
+    vk_norito_len: c_ulong,
+    out_valid: *mut c_int,
+) -> c_int {
+    if out_valid.is_null() {
+        return ERR_NULL_PTR;
+    }
+    unsafe { *out_valid = 0 };
+    if redeem_norito_ptr.is_null() || vk_norito_ptr.is_null() {
+        return ERR_NULL_PTR;
+    }
+    let redeem_bytes =
+        unsafe { slice::from_raw_parts(redeem_norito_ptr, redeem_norito_len as usize) };
+    let vk_bytes = unsafe { slice::from_raw_parts(vk_norito_ptr, vk_norito_len as usize) };
+    match verify_offline_note_redeem_recursive_with_vk(redeem_bytes, vk_bytes) {
+        Ok(valid) => {
+            unsafe { *out_valid = if valid { 1 } else { 0 } };
+            if valid { 1 } else { 0 }
+        }
+        Err(_) => ERR_OFFLINE_NOTE_VERIFY,
+    }
+}
+
+/// Cryptographically verify an Offline audit bundle's embedded recursive proof against a chain-supplied verifying key.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn connect_norito_offline_verify_note_audit_with_vk(
+    audit_norito_ptr: *const c_uchar,
+    audit_norito_len: c_ulong,
+    vk_norito_ptr: *const c_uchar,
+    vk_norito_len: c_ulong,
+    out_valid: *mut c_int,
+) -> c_int {
+    if out_valid.is_null() {
+        return ERR_NULL_PTR;
+    }
+    unsafe { *out_valid = 0 };
+    if audit_norito_ptr.is_null() || vk_norito_ptr.is_null() {
+        return ERR_NULL_PTR;
+    }
+    let audit_bytes = unsafe { slice::from_raw_parts(audit_norito_ptr, audit_norito_len as usize) };
+    let vk_bytes = unsafe { slice::from_raw_parts(vk_norito_ptr, vk_norito_len as usize) };
+    match verify_offline_note_audit_recursive_with_vk(audit_bytes, vk_bytes) {
+        Ok(valid) => {
+            unsafe { *out_valid = if valid { 1 } else { 0 } };
+            if valid { 1 } else { 0 }
+        }
+        Err(_) => ERR_OFFLINE_NOTE_VERIFY,
+    }
+}
+
 fn prove_offline_note_redeem_recursive(
     redeem_archive: &[u8],
 ) -> BridgeResult<iroha_data_model::offline::OfflineNoteRecursiveProof> {
@@ -6057,6 +6173,293 @@ fn prove_offline_note_audit_recursive(
         public_inputs_hash,
         proof: proof_box,
     })
+}
+
+fn prove_offline_note_redeem_recursive_with_vk(
+    redemption_norito: &[u8],
+    vk_box_norito: &[u8],
+) -> Result<Vec<u8>, String> {
+    use iroha_core::zk::{OFFLINE_NOTE_RECURSIVE_CIRCUIT_ID, prove_offline_note_redeem};
+    use iroha_data_model::{
+        offline::{OfflineNoteRecursiveProof, OfflineNoteRedeem},
+        proof::{VerifyingKeyBox, VerifyingKeyId},
+    };
+
+    let redemption: OfflineNoteRedeem = norito::decode_from_bytes(redemption_norito)
+        .map_err(|err| format!("failed to decode offline note redemption: {err}"))?;
+    let vk_box: VerifyingKeyBox = norito::decode_from_bytes(vk_box_norito)
+        .map_err(|err| format!("failed to decode verifying key box: {err}"))?;
+    let proof_box = prove_offline_note_redeem(
+        OFFLINE_NOTE_RECURSIVE_CIRCUIT_ID,
+        &vk_box,
+        &redemption,
+        None,
+    )
+    .map_err(|err| format!("failed to prove offline note redemption: {err}"))?;
+    let public_inputs_hash = redemption
+        .public_inputs_hash()
+        .map_err(|err| format!("failed to compute offline note redemption public inputs: {err}"))?;
+
+    let recursive = OfflineNoteRecursiveProof {
+        verifier_key_id: VerifyingKeyId::new(
+            vk_box.backend.clone(),
+            OFFLINE_NOTE_RECURSIVE_CIRCUIT_ID,
+        ),
+        public_inputs_hash,
+        proof: proof_box,
+    };
+    norito::to_bytes(&recursive)
+        .map_err(|err| format!("failed to encode offline note recursive proof: {err}"))
+}
+
+fn prove_offline_note_audit_recursive_with_vk(
+    audit_norito: &[u8],
+    vk_box_norito: &[u8],
+) -> Result<Vec<u8>, String> {
+    use iroha_core::zk::{OFFLINE_NOTE_RECURSIVE_CIRCUIT_ID, prove_offline_note_audit};
+    use iroha_data_model::{
+        offline::{OfflineNoteAuditBundle, OfflineNoteRecursiveProof},
+        proof::{VerifyingKeyBox, VerifyingKeyId},
+    };
+
+    let audit: OfflineNoteAuditBundle = norito::decode_from_bytes(audit_norito)
+        .map_err(|err| format!("failed to decode offline note audit bundle: {err}"))?;
+    let vk_box: VerifyingKeyBox = norito::decode_from_bytes(vk_box_norito)
+        .map_err(|err| format!("failed to decode verifying key box: {err}"))?;
+    let proof_box =
+        prove_offline_note_audit(OFFLINE_NOTE_RECURSIVE_CIRCUIT_ID, &vk_box, &audit, None)
+            .map_err(|err| format!("failed to prove offline note audit: {err}"))?;
+    let public_inputs_hash = audit
+        .public_inputs_hash()
+        .map_err(|err| format!("failed to compute offline note audit public inputs: {err}"))?;
+
+    let recursive = OfflineNoteRecursiveProof {
+        verifier_key_id: VerifyingKeyId::new(
+            vk_box.backend.clone(),
+            OFFLINE_NOTE_RECURSIVE_CIRCUIT_ID,
+        ),
+        public_inputs_hash,
+        proof: proof_box,
+    };
+    norito::to_bytes(&recursive)
+        .map_err(|err| format!("failed to encode offline note recursive proof: {err}"))
+}
+
+const ZK1_ENVELOPE_MAGIC: &[u8; 4] = b"ZK1\0";
+const ZK1_MAX_TLV_LEN: usize = 8 * 1024 * 1024;
+const ZK1_MAX_INST_COLS: usize = 64;
+const ZK1_MAX_INST_ROWS: usize = 8192;
+
+fn offline_note_pasta_instance_columns(proof_bytes: &[u8]) -> Option<Vec<Vec<[u8; 32]>>> {
+    use iroha_zkp_halo2::Halo2ProofEnvelope;
+
+    if let Ok(envelope) = Halo2ProofEnvelope::from_bytes(proof_bytes) {
+        return Some(
+            envelope
+                .public_inputs
+                .into_iter()
+                .map(|input| vec![input])
+                .collect(),
+        );
+    }
+
+    zk1_instance_columns(proof_bytes)
+}
+
+fn zk1_instance_columns(bytes: &[u8]) -> Option<Vec<Vec<[u8; 32]>>> {
+    if bytes.len() < 4 || &bytes[..4] != ZK1_ENVELOPE_MAGIC {
+        return None;
+    }
+    let mut cursor = &bytes[4..];
+    let mut proof_payload_present = false;
+    let mut instance_columns: Vec<Vec<[u8; 32]>> = Vec::new();
+    while !cursor.is_empty() {
+        let (tag, payload, rest) = zk1_read_tlv(cursor)?;
+        cursor = rest;
+        match &tag {
+            b"PROF" => proof_payload_present = true,
+            b"I10P" => instance_columns = zk1_read_instance_columns(payload)?,
+            _ => {}
+        }
+    }
+    if !proof_payload_present {
+        return None;
+    }
+    Some(instance_columns)
+}
+
+fn zk1_read_tlv(cursor: &[u8]) -> Option<([u8; 4], &[u8], &[u8])> {
+    if cursor.len() < 8 {
+        return None;
+    }
+    let tag: [u8; 4] = cursor[..4].try_into().ok()?;
+    let len = u32::from_le_bytes(cursor[4..8].try_into().ok()?) as usize;
+    if len > ZK1_MAX_TLV_LEN {
+        return None;
+    }
+    let end = 8usize.checked_add(len)?;
+    if end > cursor.len() {
+        return None;
+    }
+    Some((tag, &cursor[8..end], &cursor[end..]))
+}
+
+fn zk1_read_instance_columns(payload: &[u8]) -> Option<Vec<Vec<[u8; 32]>>> {
+    if payload.len() < 8 {
+        return None;
+    }
+    let cols = u32::from_le_bytes(payload[..4].try_into().ok()?) as usize;
+    let rows = u32::from_le_bytes(payload[4..8].try_into().ok()?) as usize;
+    if cols > ZK1_MAX_INST_COLS || rows > ZK1_MAX_INST_ROWS {
+        return None;
+    }
+    let values = &payload[8..];
+    let expected_len = cols.checked_mul(rows)?.checked_mul(32)?;
+    if values.len() < expected_len {
+        return None;
+    }
+    let mut columns = vec![Vec::with_capacity(rows); cols];
+    let mut offset = 0usize;
+    for _ in 0..rows {
+        for column in &mut columns {
+            let mut value = [0u8; 32];
+            value.copy_from_slice(&values[offset..offset + 32]);
+            column.push(value);
+            offset += 32;
+        }
+    }
+    Some(columns)
+}
+
+fn offline_note_vk_box_is_canonical(
+    vk_box: &iroha_data_model::proof::VerifyingKeyBox,
+) -> Result<bool, String> {
+    use iroha_core::zk::{ZK_BACKEND_HALO2_IPA, hash_vk, offline_note_recursive_vk_box};
+
+    if vk_box.backend.as_str() != ZK_BACKEND_HALO2_IPA || vk_box.bytes.is_empty() {
+        return Ok(false);
+    }
+    let canonical = offline_note_recursive_vk_box()
+        .map_err(|err| format!("failed to derive canonical offline-note verifying key: {err}"))?;
+    Ok(hash_vk(vk_box) == hash_vk(&canonical) && vk_box.bytes == canonical.bytes)
+}
+
+fn verify_offline_note_recursive_proof_with_vk(
+    proof: &iroha_data_model::offline::OfflineNoteRecursiveProof,
+    expected_public_inputs_hash: &iroha_crypto::Hash,
+    expected_public_instances: &[Vec<[u8; 32]>],
+    vk_box: &iroha_data_model::proof::VerifyingKeyBox,
+) -> Result<bool, String> {
+    use iroha_core::zk::{
+        OFFLINE_NOTE_RECURSIVE_CIRCUIT_ID, ZK_BACKEND_HALO2_IPA, hash_vk, verify_backend,
+    };
+    use iroha_data_model::{
+        offline::OFFLINE_NOTE_RECURSIVE_PUBLIC_INPUTS_SCHEMA,
+        zk::{BackendTag, OpenVerifyEnvelope},
+    };
+
+    if &proof.public_inputs_hash != expected_public_inputs_hash {
+        return Ok(false);
+    }
+    if proof.verifier_key_id.backend.as_str() != ZK_BACKEND_HALO2_IPA
+        || proof.verifier_key_id.name != OFFLINE_NOTE_RECURSIVE_CIRCUIT_ID
+        || proof.proof.backend.as_str() != proof.verifier_key_id.backend.as_str()
+    {
+        return Ok(false);
+    }
+    if !offline_note_vk_box_is_canonical(vk_box)? {
+        return Ok(false);
+    }
+
+    let envelope: OpenVerifyEnvelope = match norito::decode_from_bytes(&proof.proof.bytes) {
+        Ok(envelope) => envelope,
+        Err(_) => return Ok(false),
+    };
+    if envelope.backend != BackendTag::Halo2IpaPasta {
+        return Ok(false);
+    }
+    if !envelope.aux.is_empty() {
+        return Ok(false);
+    }
+    if envelope.public_inputs != OFFLINE_NOTE_RECURSIVE_PUBLIC_INPUTS_SCHEMA {
+        return Ok(false);
+    }
+    if envelope.circuit_id != OFFLINE_NOTE_RECURSIVE_CIRCUIT_ID {
+        return Ok(false);
+    }
+    if envelope.vk_hash != hash_vk(vk_box) {
+        return Ok(false);
+    }
+
+    let Some(actual_instances) = offline_note_pasta_instance_columns(&envelope.proof_bytes) else {
+        return Ok(false);
+    };
+    if actual_instances.as_slice() != expected_public_instances {
+        return Ok(false);
+    }
+    Ok(verify_backend(
+        proof.proof.backend.as_str(),
+        &proof.proof,
+        Some(vk_box),
+    ))
+}
+
+fn verify_offline_note_redeem_recursive_with_vk(
+    redeem_norito: &[u8],
+    vk_box_norito: &[u8],
+) -> Result<bool, String> {
+    use iroha_core::zk::offline_note_redeem_instance_values;
+    use iroha_data_model::{offline::OfflineNoteRedeem, proof::VerifyingKeyBox};
+
+    let redemption: OfflineNoteRedeem = norito::decode_from_bytes(redeem_norito)
+        .map_err(|err| format!("failed to decode offline note redemption: {err}"))?;
+    let vk_box: VerifyingKeyBox = norito::decode_from_bytes(vk_box_norito)
+        .map_err(|err| format!("failed to decode verifying key box: {err}"))?;
+
+    let expected_public_inputs_hash = match redemption.public_inputs_hash() {
+        Ok(hash) => hash,
+        Err(_) => return Ok(false),
+    };
+    let expected_public_instances = match offline_note_redeem_instance_values(&redemption) {
+        Ok(values) => values.public_instance_columns(),
+        Err(_) => return Ok(false),
+    };
+
+    verify_offline_note_recursive_proof_with_vk(
+        &redemption.recursive_proof,
+        &expected_public_inputs_hash,
+        &expected_public_instances,
+        &vk_box,
+    )
+}
+
+fn verify_offline_note_audit_recursive_with_vk(
+    audit_norito: &[u8],
+    vk_box_norito: &[u8],
+) -> Result<bool, String> {
+    use iroha_core::zk::offline_note_audit_instance_values;
+    use iroha_data_model::{offline::OfflineNoteAuditBundle, proof::VerifyingKeyBox};
+
+    let audit: OfflineNoteAuditBundle = norito::decode_from_bytes(audit_norito)
+        .map_err(|err| format!("failed to decode offline note audit bundle: {err}"))?;
+    let vk_box: VerifyingKeyBox = norito::decode_from_bytes(vk_box_norito)
+        .map_err(|err| format!("failed to decode verifying key box: {err}"))?;
+
+    let expected_public_inputs_hash = match audit.public_inputs_hash() {
+        Ok(hash) => hash,
+        Err(_) => return Ok(false),
+    };
+    let expected_public_instances = match offline_note_audit_instance_values(&audit) {
+        Ok(values) => values.public_instance_columns(),
+        Err(_) => return Ok(false),
+    };
+
+    verify_offline_note_recursive_proof_with_vk(
+        &audit.recursive_proof,
+        &expected_public_inputs_hash,
+        &expected_public_instances,
+        &vk_box,
+    )
 }
 
 /// Legacy unanchored Kagemusha compact-token prover entry point.
@@ -18720,6 +19123,126 @@ fn java_native_verify_detached(
     target_os = "macos",
     target_os = "windows"
 ))]
+fn java_native_offline_prove_note_redeem_with_vk(
+    env: &mut jni::JNIEnv<'_>,
+    redeem_norito: jni::objects::JByteArray<'_>,
+    vk_box_norito: jni::objects::JByteArray<'_>,
+) -> jni::sys::jbyteArray {
+    let result = (|| -> Result<jni::sys::jbyteArray, String> {
+        let redeem_bytes = read_java_byte_array(env, &redeem_norito, "redeemNorito")
+            .ok_or_else(|| "invalid offline note redemption bytes".to_string())?;
+        let vk_box_bytes = read_java_byte_array(env, &vk_box_norito, "vkBoxNorito")
+            .ok_or_else(|| "invalid verifying key box bytes".to_string())?;
+        let recursive_archive =
+            prove_offline_note_redeem_recursive_with_vk(&redeem_bytes, &vk_box_bytes)?;
+        let array = env
+            .byte_array_from_slice(&recursive_archive)
+            .map_err(|err| err.to_string())?;
+        Ok(array.into_raw())
+    })();
+    match result {
+        Ok(array) => array,
+        Err(message) => {
+            throw_java_illegal_argument(env, message);
+            std::ptr::null_mut()
+        }
+    }
+}
+
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
+fn java_native_offline_prove_note_audit_with_vk(
+    env: &mut jni::JNIEnv<'_>,
+    audit_norito: jni::objects::JByteArray<'_>,
+    vk_box_norito: jni::objects::JByteArray<'_>,
+) -> jni::sys::jbyteArray {
+    let result = (|| -> Result<jni::sys::jbyteArray, String> {
+        let audit_bytes = read_java_byte_array(env, &audit_norito, "auditNorito")
+            .ok_or_else(|| "invalid offline note audit bundle bytes".to_string())?;
+        let vk_box_bytes = read_java_byte_array(env, &vk_box_norito, "vkBoxNorito")
+            .ok_or_else(|| "invalid verifying key box bytes".to_string())?;
+        let recursive_archive =
+            prove_offline_note_audit_recursive_with_vk(&audit_bytes, &vk_box_bytes)?;
+        let array = env
+            .byte_array_from_slice(&recursive_archive)
+            .map_err(|err| err.to_string())?;
+        Ok(array.into_raw())
+    })();
+    match result {
+        Ok(array) => array,
+        Err(message) => {
+            throw_java_illegal_argument(env, message);
+            std::ptr::null_mut()
+        }
+    }
+}
+
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
+fn java_native_offline_verify_note_redeem_with_vk(
+    env: &mut jni::JNIEnv<'_>,
+    redeem_norito: jni::objects::JByteArray<'_>,
+    vk_box_norito: jni::objects::JByteArray<'_>,
+) -> jni::sys::jboolean {
+    let result = (|| -> Result<jni::sys::jboolean, String> {
+        let redeem_bytes = read_java_byte_array(env, &redeem_norito, "redeemNorito")
+            .ok_or_else(|| "invalid offline note redemption bytes".to_string())?;
+        let vk_box_bytes = read_java_byte_array(env, &vk_box_norito, "vkBoxNorito")
+            .ok_or_else(|| "invalid verifying key box bytes".to_string())?;
+        let valid = verify_offline_note_redeem_recursive_with_vk(&redeem_bytes, &vk_box_bytes)?;
+        Ok(if valid { 1 } else { 0 })
+    })();
+    match result {
+        Ok(valid) => valid,
+        Err(message) => {
+            throw_java_illegal_argument(env, message);
+            0
+        }
+    }
+}
+
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
+fn java_native_offline_verify_note_audit_with_vk(
+    env: &mut jni::JNIEnv<'_>,
+    audit_norito: jni::objects::JByteArray<'_>,
+    vk_box_norito: jni::objects::JByteArray<'_>,
+) -> jni::sys::jboolean {
+    let result = (|| -> Result<jni::sys::jboolean, String> {
+        let audit_bytes = read_java_byte_array(env, &audit_norito, "auditNorito")
+            .ok_or_else(|| "invalid offline note audit bundle bytes".to_string())?;
+        let vk_box_bytes = read_java_byte_array(env, &vk_box_norito, "vkBoxNorito")
+            .ok_or_else(|| "invalid verifying key box bytes".to_string())?;
+        let valid = verify_offline_note_audit_recursive_with_vk(&audit_bytes, &vk_box_bytes)?;
+        Ok(if valid { 1 } else { 0 })
+    })();
+    match result {
+        Ok(valid) => valid,
+        Err(message) => {
+            throw_java_illegal_argument(env, message);
+            0
+        }
+    }
+}
+
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
 fn java_kagemusha_prove_verified_compact_payment_token_with_records(
     record_bundle_archive: &[u8],
 ) -> Result<Vec<u8>, String> {
@@ -19596,6 +20119,74 @@ pub unsafe extern "system" fn Java_org_hyperledger_iroha_android_privacy_Privacy
 ))]
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
+pub unsafe extern "system" fn Java_org_hyperledger_iroha_sdk_offline_NativeOfflineNoteProver_nativeProveNoteRedeemWithVk(
+    mut env: jni::JNIEnv<'_>,
+    _class: jni::objects::JClass<'_>,
+    redeem_norito: jni::objects::JByteArray<'_>,
+    vk_box_norito: jni::objects::JByteArray<'_>,
+) -> jni::sys::jbyteArray {
+    java_native_offline_prove_note_redeem_with_vk(&mut env, redeem_norito, vk_box_norito)
+}
+
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+pub unsafe extern "system" fn Java_org_hyperledger_iroha_sdk_offline_NativeOfflineNoteProver_nativeProveNoteAuditWithVk(
+    mut env: jni::JNIEnv<'_>,
+    _class: jni::objects::JClass<'_>,
+    audit_norito: jni::objects::JByteArray<'_>,
+    vk_box_norito: jni::objects::JByteArray<'_>,
+) -> jni::sys::jbyteArray {
+    java_native_offline_prove_note_audit_with_vk(&mut env, audit_norito, vk_box_norito)
+}
+
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+pub unsafe extern "system" fn Java_org_hyperledger_iroha_sdk_offline_NativeOfflineNoteProver_nativeVerifyNoteRedeemWithVk(
+    mut env: jni::JNIEnv<'_>,
+    _class: jni::objects::JClass<'_>,
+    redeem_norito: jni::objects::JByteArray<'_>,
+    vk_box_norito: jni::objects::JByteArray<'_>,
+) -> jni::sys::jboolean {
+    java_native_offline_verify_note_redeem_with_vk(&mut env, redeem_norito, vk_box_norito)
+}
+
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+pub unsafe extern "system" fn Java_org_hyperledger_iroha_sdk_offline_NativeOfflineNoteProver_nativeVerifyNoteAuditWithVk(
+    mut env: jni::JNIEnv<'_>,
+    _class: jni::objects::JClass<'_>,
+    audit_norito: jni::objects::JByteArray<'_>,
+    vk_box_norito: jni::objects::JByteArray<'_>,
+) -> jni::sys::jboolean {
+    java_native_offline_verify_note_audit_with_vk(&mut env, audit_norito, vk_box_norito)
+}
+
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
 pub unsafe extern "system" fn Java_org_hyperledger_iroha_sdk_offline_KagemushaCompactPaymentTokenProver_nativeProveVerifiedCompactPaymentTokenWithRecords(
     mut env: jni::JNIEnv<'_>,
     _class: jni::objects::JClass<'_>,
@@ -19958,6 +20549,74 @@ pub unsafe extern "system" fn Java_org_hyperledger_iroha_sdk_offline_KagemushaRe
         norito::to_bytes(&instruction)
             .map_err(|err| format!("failed to encode redeem instruction: {err}"))
     })
+}
+
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+pub unsafe extern "system" fn Java_org_hyperledger_iroha_android_offline_NativeOfflineNoteProver_nativeProveNoteRedeemWithVk(
+    mut env: jni::JNIEnv<'_>,
+    _class: jni::objects::JClass<'_>,
+    redeem_norito: jni::objects::JByteArray<'_>,
+    vk_box_norito: jni::objects::JByteArray<'_>,
+) -> jni::sys::jbyteArray {
+    java_native_offline_prove_note_redeem_with_vk(&mut env, redeem_norito, vk_box_norito)
+}
+
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+pub unsafe extern "system" fn Java_org_hyperledger_iroha_android_offline_NativeOfflineNoteProver_nativeProveNoteAuditWithVk(
+    mut env: jni::JNIEnv<'_>,
+    _class: jni::objects::JClass<'_>,
+    audit_norito: jni::objects::JByteArray<'_>,
+    vk_box_norito: jni::objects::JByteArray<'_>,
+) -> jni::sys::jbyteArray {
+    java_native_offline_prove_note_audit_with_vk(&mut env, audit_norito, vk_box_norito)
+}
+
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+pub unsafe extern "system" fn Java_org_hyperledger_iroha_android_offline_NativeOfflineNoteProver_nativeVerifyNoteRedeemWithVk(
+    mut env: jni::JNIEnv<'_>,
+    _class: jni::objects::JClass<'_>,
+    redeem_norito: jni::objects::JByteArray<'_>,
+    vk_box_norito: jni::objects::JByteArray<'_>,
+) -> jni::sys::jboolean {
+    java_native_offline_verify_note_redeem_with_vk(&mut env, redeem_norito, vk_box_norito)
+}
+
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+pub unsafe extern "system" fn Java_org_hyperledger_iroha_android_offline_NativeOfflineNoteProver_nativeVerifyNoteAuditWithVk(
+    mut env: jni::JNIEnv<'_>,
+    _class: jni::objects::JClass<'_>,
+    audit_norito: jni::objects::JByteArray<'_>,
+    vk_box_norito: jni::objects::JByteArray<'_>,
+) -> jni::sys::jboolean {
+    java_native_offline_verify_note_audit_with_vk(&mut env, audit_norito, vk_box_norito)
 }
 
 #[cfg(any(

--- a/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/ChainVkOfflineNoteProofProvider.java
+++ b/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/ChainVkOfflineNoteProofProvider.java
@@ -1,0 +1,27 @@
+package org.hyperledger.iroha.android.offline;
+
+/** Offline Note proof provider that proves against a chain-supplied VerifyingKeyBox. */
+public final class ChainVkOfflineNoteProofProvider implements OfflineNoteProofProvider {
+  private final byte[] vkBoxNorito;
+
+  public ChainVkOfflineNoteProofProvider(final byte[] vkBoxNorito) {
+    if (vkBoxNorito == null || vkBoxNorito.length == 0) {
+      throw new IllegalArgumentException("vkBoxNorito must not be empty");
+    }
+    this.vkBoxNorito = vkBoxNorito.clone();
+  }
+
+  @Override
+  public OfflineNote.RecursiveProof proveAudit(final OfflineNote.AuditBundle audit) {
+    final byte[] proofNorito =
+        NativeOfflineNoteProver.proveAudit(OfflineNote.encodeAudit(audit), vkBoxNorito);
+    return OfflineNote.decodeRecursiveProof(proofNorito);
+  }
+
+  @Override
+  public OfflineNote.RecursiveProof proveRedeem(final OfflineNote.Redeem redemption) {
+    final byte[] proofNorito =
+        NativeOfflineNoteProver.proveRedeem(OfflineNote.encodeRedeem(redemption), vkBoxNorito);
+    return OfflineNote.decodeRecursiveProof(proofNorito);
+  }
+}

--- a/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/ChainVkOfflineNoteProofVerifier.java
+++ b/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/ChainVkOfflineNoteProofVerifier.java
@@ -1,0 +1,23 @@
+package org.hyperledger.iroha.android.offline;
+
+/** Offline Note proof verifier that verifies against a chain-supplied VerifyingKeyBox. */
+public final class ChainVkOfflineNoteProofVerifier implements OfflineNoteProofVerifier {
+  private final byte[] vkBoxNorito;
+
+  public ChainVkOfflineNoteProofVerifier(final byte[] vkBoxNorito) {
+    if (vkBoxNorito == null || vkBoxNorito.length == 0) {
+      throw new IllegalArgumentException("vkBoxNorito must not be empty");
+    }
+    this.vkBoxNorito = vkBoxNorito.clone();
+  }
+
+  @Override
+  public boolean verifyAudit(final OfflineNote.AuditBundle audit) {
+    return NativeOfflineNoteProver.verifyAudit(OfflineNote.encodeAudit(audit), vkBoxNorito);
+  }
+
+  @Override
+  public boolean verifyRedeem(final OfflineNote.Redeem redemption) {
+    return NativeOfflineNoteProver.verifyRedeem(OfflineNote.encodeRedeem(redemption), vkBoxNorito);
+  }
+}

--- a/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/Ed25519OfflineNoteCertificateVerifier.java
+++ b/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/Ed25519OfflineNoteCertificateVerifier.java
@@ -3,12 +3,17 @@ package org.hyperledger.iroha.android.offline;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters;
 import org.bouncycastle.crypto.signers.Ed25519Signer;
+import org.hyperledger.iroha.android.address.AccountAddress;
+import org.hyperledger.iroha.android.address.AccountAddress.AccountAddressException;
 
-/** Ed25519 verifier for issuer-signed Offline Note key certificates. */
+/** Ed25519 verifier for issuer-signed and owner-self-signed Offline Note key certificates. */
 public final class Ed25519OfflineNoteCertificateVerifier
     implements OfflineNoteCertificateVerifier {
+  private static final int ED25519_CURVE_ID = 0x01;
+
   private final List<byte[]> trustedIssuerPublicKeys;
 
   public Ed25519OfflineNoteCertificateVerifier(final Collection<byte[]> trustedIssuerPublicKeys) {
@@ -19,14 +24,8 @@ public final class Ed25519OfflineNoteCertificateVerifier
   }
 
   @Override
-  public boolean verifyCertificate(final OfflineNote.KeyCertificate certificate) {
-    if (trustedIssuerPublicKeys.isEmpty()
-        || certificate.platform().trim().isEmpty()
-        || certificate.keyId().trim().isEmpty()
-        || certificate.deviceId().trim().isEmpty()
-        || certificate.assertionScheme().trim().isEmpty()
-        || certificate.assertionKeyAlgorithm().trim().isEmpty()
-        || certificate.assertionPublicKey().length == 0) {
+  public boolean verifyIssuerCertificate(final OfflineNote.KeyCertificate certificate) {
+    if (trustedIssuerPublicKeys.isEmpty() || !hasValidAttestationShape(certificate)) {
       return false;
     }
     final byte[] message = certificate.signingBytes();
@@ -37,6 +36,46 @@ public final class Ed25519OfflineNoteCertificateVerifier
       }
     }
     return false;
+  }
+
+  @Override
+  public boolean verifyOwnerCertificate(final OfflineNote.KeyCertificate certificate) {
+    if (!hasValidAttestationShape(certificate)) {
+      return false;
+    }
+    final byte[] ownerKey = ownerSignatoryKey(certificate.accountId());
+    return ownerKey != null
+        && verifyEd25519(ownerKey, certificate.signingBytes(), certificate.issuerSignature());
+  }
+
+  private static boolean hasValidAttestationShape(final OfflineNote.KeyCertificate certificate) {
+    return !certificate.platform().trim().isEmpty()
+        && !certificate.keyId().trim().isEmpty()
+        && !certificate.deviceId().trim().isEmpty()
+        && !certificate.assertionScheme().trim().isEmpty()
+        && !certificate.assertionKeyAlgorithm().trim().isEmpty()
+        && certificate.assertionPublicKey().length != 0;
+  }
+
+  private static byte[] ownerSignatoryKey(final String accountId) {
+    final Optional<AccountAddress.SingleKeyPayload> single;
+    try {
+      single =
+          AccountAddress.parseEncodedIgnoringCurveSupport(accountId, null)
+              .address
+              .singleKeyPayloadIgnoringCurveSupport();
+    } catch (final AccountAddressException e) {
+      return null;
+    }
+    if (!single.isPresent()) {
+      return null;
+    }
+    final AccountAddress.SingleKeyPayload payload = single.get();
+    final byte[] publicKey = payload.publicKey();
+    if (payload.curveId() != ED25519_CURVE_ID || publicKey.length != 32) {
+      return null;
+    }
+    return publicKey;
   }
 
   private static boolean verifyEd25519(

--- a/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/NativeOfflineNoteProver.java
+++ b/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/NativeOfflineNoteProver.java
@@ -1,0 +1,89 @@
+package org.hyperledger.iroha.android.offline;
+
+/** Native record-backed Offline Note recursive prover using a chain-supplied verifying key. */
+public final class NativeOfflineNoteProver {
+  private static final String LIBRARY_NAME = "connect_norito_bridge";
+  private static final boolean NATIVE_AVAILABLE = loadLibrary();
+
+  private NativeOfflineNoteProver() {}
+
+  public static boolean isNativeAvailable() {
+    return NATIVE_AVAILABLE;
+  }
+
+  public static byte[] proveRedeem(final byte[] redeemNorito, final byte[] vkBoxNorito) {
+    requireNonEmpty(redeemNorito, "redeemNorito");
+    requireNonEmpty(vkBoxNorito, "vkBoxNorito");
+    checkAvailable();
+    final byte[] proofNorito = nativeProveNoteRedeemWithVk(redeemNorito, vkBoxNorito);
+    if (proofNorito == null || proofNorito.length == 0) {
+      throw new IllegalStateException("nativeProveNoteRedeemWithVk returned empty output");
+    }
+    return proofNorito;
+  }
+
+  public static byte[] proveAudit(final byte[] auditNorito, final byte[] vkBoxNorito) {
+    requireNonEmpty(auditNorito, "auditNorito");
+    requireNonEmpty(vkBoxNorito, "vkBoxNorito");
+    checkAvailable();
+    final byte[] proofNorito = nativeProveNoteAuditWithVk(auditNorito, vkBoxNorito);
+    if (proofNorito == null || proofNorito.length == 0) {
+      throw new IllegalStateException("nativeProveNoteAuditWithVk returned empty output");
+    }
+    return proofNorito;
+  }
+
+  public static boolean verifyRedeem(final byte[] redeemNorito, final byte[] vkBoxNorito) {
+    requireNonEmpty(redeemNorito, "redeemNorito");
+    requireNonEmpty(vkBoxNorito, "vkBoxNorito");
+    checkAvailable();
+    return nativeVerifyNoteRedeemWithVk(redeemNorito, vkBoxNorito);
+  }
+
+  public static boolean verifyAudit(final byte[] auditNorito, final byte[] vkBoxNorito) {
+    requireNonEmpty(auditNorito, "auditNorito");
+    requireNonEmpty(vkBoxNorito, "vkBoxNorito");
+    checkAvailable();
+    return nativeVerifyNoteAuditWithVk(auditNorito, vkBoxNorito);
+  }
+
+  static boolean detectNativeAvailability(final Runnable loadLibrary, final Runnable probeSymbol) {
+    try {
+      loadLibrary.run();
+      probeSymbol.run();
+      return true;
+    } catch (final IllegalArgumentException ignored) {
+      return true;
+    } catch (final UnsatisfiedLinkError | SecurityException ignored) {
+      return false;
+    }
+  }
+
+  private static boolean loadLibrary() {
+    return detectNativeAvailability(
+        () -> System.loadLibrary(LIBRARY_NAME),
+        () -> nativeProveNoteRedeemWithVk(new byte[0], new byte[0]));
+  }
+
+  private static void checkAvailable() {
+    if (!NATIVE_AVAILABLE) {
+      throw new IllegalStateException(LIBRARY_NAME + " is not available in this runtime");
+    }
+  }
+
+  private static void requireNonEmpty(final byte[] value, final String name) {
+    if (value == null || value.length == 0) {
+      throw new IllegalArgumentException(name + " must not be empty");
+    }
+  }
+
+  private static native byte[] nativeProveNoteRedeemWithVk(
+      byte[] redeemNorito, byte[] vkBoxNorito);
+
+  private static native byte[] nativeProveNoteAuditWithVk(byte[] auditNorito, byte[] vkBoxNorito);
+
+  private static native boolean nativeVerifyNoteRedeemWithVk(
+      byte[] redeemNorito, byte[] vkBoxNorito);
+
+  private static native boolean nativeVerifyNoteAuditWithVk(byte[] auditNorito, byte[] vkBoxNorito);
+}

--- a/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/OfflineNote.java
+++ b/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/OfflineNote.java
@@ -66,6 +66,8 @@ public final class OfflineNote {
       "iroha_data_model::offline::model::OfflineNoteIssue";
   private static final String ISSUED_CLAIM_SCHEMA =
       "iroha_data_model::offline::model::OfflineNoteIssuedClaim";
+  private static final String RECURSIVE_PROOF_SCHEMA =
+      "iroha_data_model::offline::model::OfflineNoteRecursiveProof";
   private static final String REDEEM_SCHEMA =
       "iroha_data_model::offline::model::OfflineNoteRedeem";
   private static final String REDEEM_PUBLIC_INPUTS_SCHEMA =
@@ -150,6 +152,10 @@ public final class OfflineNote {
 
   public static IssuedClaim decodeIssuedClaim(final byte[] bytes) {
     return decodeWithHeader(bytes, ISSUED_CLAIM_SCHEMA, ISSUED_CLAIM_ADAPTER);
+  }
+
+  public static RecursiveProof decodeRecursiveProof(final byte[] bytes) {
+    return decodeWithHeader(bytes, RECURSIVE_PROOF_SCHEMA, RECURSIVE_PROOF_ADAPTER);
   }
 
   public static Redeem decodeRedeem(final byte[] bytes) {

--- a/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/OfflineNoteCertificateVerifier.java
+++ b/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/OfflineNoteCertificateVerifier.java
@@ -1,6 +1,10 @@
 package org.hyperledger.iroha.android.offline;
 
-/** Verifies issuer trust and attestation shape for Offline Note key certificates. */
+/** Verifies trust and attestation shape for Offline Note key certificates. */
 public interface OfflineNoteCertificateVerifier {
-  boolean verifyCertificate(OfflineNote.KeyCertificate certificate);
+  /** Verifies a certificate signed by a trusted issuer for topup/issue paths. */
+  boolean verifyIssuerCertificate(OfflineNote.KeyCertificate certificate);
+
+  /** Verifies a certificate self-signed by the account named in its accountId for P2P paths. */
+  boolean verifyOwnerCertificate(OfflineNote.KeyCertificate certificate);
 }

--- a/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/OfflineNoteOwnerCertificateSigner.java
+++ b/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/OfflineNoteOwnerCertificateSigner.java
@@ -1,0 +1,17 @@
+package org.hyperledger.iroha.android.offline;
+
+/**
+ * Mints owner-self-signed Offline Note key certificates for P2P output claims.
+ *
+ * <p>Output certificates must be signed by the owner account named in the certificate accountId,
+ * not by the issuer/operator key used for load and topup paths.
+ */
+public interface OfflineNoteOwnerCertificateSigner {
+  /**
+   * Returns a fresh certificate for {@code accountId}.
+   *
+   * <p>The account must encode a single Ed25519 signatory, and the certificate issuerSignature must
+   * be a raw Ed25519 signature over {@link OfflineNote.KeyCertificate#signingBytes()}.
+   */
+  OfflineNote.KeyCertificate freshOwnerCertificate(String accountId);
+}

--- a/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/OfflineNoteWallet.java
+++ b/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/OfflineNoteWallet.java
@@ -41,6 +41,7 @@ public final class OfflineNoteWallet {
   private final OfflineNoteProofProvider proofProvider;
   private final OfflineNoteProofVerifier proofVerifier;
   private final OfflineNoteCertificateVerifier certificateVerifier;
+  private final OfflineNoteOwnerCertificateSigner ownerCertificateSigner;
   private final OfflineNoteRandomSource randomSource;
   private final OfflineNoteIdGenerator idGenerator;
   private final LongSupplier clock;
@@ -91,6 +92,37 @@ public final class OfflineNoteWallet {
         randomSource,
         idGenerator,
         clock);
+  }
+
+  public OfflineNoteWallet(
+      final String chainId,
+      final String accountId,
+      final OfflineNoteAttestationProvider attestationProvider,
+      final OfflineNoteStore store,
+      final OfflineNoteIssuerClient issuerClient,
+      final OfflineNoteTransactionSubmitter transactionSubmitter,
+      final OfflineNoteProofProvider proofProvider,
+      final OfflineNoteProofVerifier proofVerifier,
+      final OfflineNoteCertificateVerifier certificateVerifier,
+      final OfflineNoteRandomSource randomSource,
+      final OfflineNoteIdGenerator idGenerator,
+      final LongSupplier clock,
+      final OfflineNoteOwnerCertificateSigner ownerCertificateSigner) {
+    this(
+        chainId,
+        accountId,
+        attestationProvider,
+        store,
+        issuerClient,
+        transactionSubmitter,
+        null,
+        proofProvider,
+        proofVerifier,
+        certificateVerifier,
+        randomSource,
+        idGenerator,
+        clock,
+        ownerCertificateSigner);
   }
 
   public OfflineNoteWallet(
@@ -252,7 +284,74 @@ public final class OfflineNoteWallet {
       final OfflineNoteRandomSource randomSource,
       final OfflineNoteIdGenerator idGenerator,
       final LongSupplier clock,
+      final OfflineNoteOwnerCertificateSigner ownerCertificateSigner) {
+    this(
+        chainId,
+        accountId,
+        attestationProvider,
+        store,
+        issuerClient,
+        transactionSubmitter,
+        syncResolver,
+        proofProvider,
+        proofVerifier,
+        certificateVerifier,
+        randomSource,
+        idGenerator,
+        clock,
+        OfflineBearerCashPolicyV1.DEFAULT,
+        ownerCertificateSigner);
+  }
+
+  public OfflineNoteWallet(
+      final String chainId,
+      final String accountId,
+      final OfflineNoteAttestationProvider attestationProvider,
+      final OfflineNoteStore store,
+      final OfflineNoteIssuerClient issuerClient,
+      final OfflineNoteTransactionSubmitter transactionSubmitter,
+      final OfflineNoteSyncResolver syncResolver,
+      final OfflineNoteProofProvider proofProvider,
+      final OfflineNoteProofVerifier proofVerifier,
+      final OfflineNoteCertificateVerifier certificateVerifier,
+      final OfflineNoteRandomSource randomSource,
+      final OfflineNoteIdGenerator idGenerator,
+      final LongSupplier clock,
       final OfflineBearerCashPolicyV1 bearerCashPolicy) {
+    this(
+        chainId,
+        accountId,
+        attestationProvider,
+        store,
+        issuerClient,
+        transactionSubmitter,
+        syncResolver,
+        proofProvider,
+        proofVerifier,
+        certificateVerifier,
+        randomSource,
+        idGenerator,
+        clock,
+        bearerCashPolicy,
+        null);
+  }
+
+  public OfflineNoteWallet(
+      final String chainId,
+      final String accountId,
+      final OfflineNoteAttestationProvider attestationProvider,
+      final OfflineNoteStore store,
+      final OfflineNoteIssuerClient issuerClient,
+      final OfflineNoteTransactionSubmitter transactionSubmitter,
+      final OfflineNoteSyncResolver syncResolver,
+      final OfflineNoteProofProvider proofProvider,
+      final OfflineNoteProofVerifier proofVerifier,
+      final OfflineNoteCertificateVerifier certificateVerifier,
+      final OfflineNoteRandomSource randomSource,
+      final OfflineNoteIdGenerator idGenerator,
+      final LongSupplier clock,
+      final OfflineBearerCashPolicyV1 bearerCashPolicy,
+      final OfflineNoteOwnerCertificateSigner ownerCertificateSigner) {
     this.chainId = requireNonBlank(chainId, "chainId");
     this.accountId = requireNonBlank(accountId, "accountId");
     this.attestationProvider = Objects.requireNonNull(attestationProvider, "attestationProvider");
@@ -263,6 +362,7 @@ public final class OfflineNoteWallet {
     this.proofProvider = Objects.requireNonNull(proofProvider, "proofProvider");
     this.proofVerifier = Objects.requireNonNull(proofVerifier, "proofVerifier");
     this.certificateVerifier = Objects.requireNonNull(certificateVerifier, "certificateVerifier");
+    this.ownerCertificateSigner = ownerCertificateSigner;
     this.randomSource = Objects.requireNonNull(randomSource, "randomSource");
     this.idGenerator = Objects.requireNonNull(idGenerator, "idGenerator");
     this.clock = Objects.requireNonNull(clock, "clock");
@@ -300,7 +400,7 @@ public final class OfflineNoteWallet {
                       final byte[] noteCommitment;
                       final OfflineNoteIssueRequest request;
                       try {
-                        requireTrustedCertificate(context.keyCertificate(), accountId);
+                        requireTrustedIssuerCertificate(context.keyCertificate(), accountId);
                         noteSecret = random32();
                         origin =
                             new OfflineNote.CommitmentOrigin.IssuerLoad(
@@ -356,7 +456,7 @@ public final class OfflineNoteWallet {
                                               response.keyCertificate() == null
                                                   ? context.keyCertificate()
                                                   : response.keyCertificate();
-                                          requireTrustedCertificate(certificate, accountId);
+                                          requireTrustedIssuerCertificate(certificate, accountId);
                                           final long now = clock.getAsLong();
                                           final OfflineNoteWalletNote note =
                                               new OfflineNoteWalletNote(
@@ -385,8 +485,8 @@ public final class OfflineNoteWallet {
       final String assetDefinitionId, final String amount) {
     final String paymentRequestId = idGenerator.nextId("payment-request");
     final OfflineNote.KeyCertificate keyCertificate =
-        attestationProvider.currentKeyCertificate();
-    requireTrustedCertificate(keyCertificate, accountId);
+        requireOwnerCertificateSigner().freshOwnerCertificate(accountId);
+    requireTrustedOwnerCertificate(keyCertificate, accountId);
     final String assetId = walletAssetId(assetDefinitionId, accountId);
     final byte[] noteSecret = random32();
     final OfflineNote.CommitmentOrigin.P2pOutput origin =
@@ -424,7 +524,7 @@ public final class OfflineNoteWallet {
     if (!chainId.equals(receiveRequest.chainId())) {
       throw new IllegalArgumentException("receive request chainId does not match wallet chainId");
     }
-    requireTrustedCertificate(receiveRequest.keyCertificate(), receiveRequest.accountId());
+    requireTrustedOwnerCertificate(receiveRequest.keyCertificate(), receiveRequest.accountId());
     rejectReusedReceiveRequest(receiveRequest.paymentRequestId());
     final long createdAtMs = clock.getAsLong();
     final BigDecimal requestedAmount = decimal(receiveRequest.canonicalAmount());
@@ -439,12 +539,13 @@ public final class OfflineNoteWallet {
       throw new IllegalArgumentException("selected input amount is below requested amount");
     }
 
-    final OfflineNote.KeyCertificate senderCertificate = selected.get(0).keyCertificate();
-    requireTrustedCertificate(senderCertificate, accountId);
+    final OfflineNoteWalletNote senderNote = selected.get(0);
+    final OfflineNote.KeyCertificate senderCertificate = senderNote.keyCertificate();
+    requireTrustedCertificateForOrigin(senderCertificate, senderNote.origin(), accountId);
     final byte[] senderCertificateHash = senderCertificate.payloadHash();
     for (final OfflineNoteWalletNote note : selected) {
       bearerAuditTrail(note);
-      requireTrustedCertificate(note.keyCertificate(), accountId);
+      requireTrustedCertificateForOrigin(note.keyCertificate(), note.origin(), accountId);
       if (!Arrays.equals(note.keyCertificate().payloadHash(), senderCertificateHash)) {
         throw new IllegalArgumentException("selected input notes must use the same key certificate");
       }
@@ -469,18 +570,21 @@ public final class OfflineNoteWallet {
       final byte[] changeSecret = random32();
       final String changeAmountString = canonicalDecimal(changeAmount);
       final String changeAssetId = walletAssetId(receiveRequest.assetDefinitionId(), accountId);
+      final OfflineNote.KeyCertificate changeCertificate =
+          requireOwnerCertificateSigner().freshOwnerCertificate(accountId);
+      requireTrustedOwnerCertificate(changeCertificate, accountId);
       final OfflineNote.CommitmentOrigin.P2pOutput changeOrigin =
           new OfflineNote.CommitmentOrigin.P2pOutput(receiveRequest.paymentRequestId(), 1);
       final byte[] changeCommitment =
           deriveNoteCommitment(
-              senderCertificate, changeAssetId, changeAmountString, changeSecret, changeOrigin);
+              changeCertificate, changeAssetId, changeAmountString, changeSecret, changeOrigin);
       changeNote =
           new OfflineNoteWalletNote(
               chainId,
               accountId,
               changeAssetId,
               changeAmountString,
-              senderCertificate,
+              changeCertificate,
               changeCommitment,
               changeSecret,
               changeOrigin,
@@ -489,7 +593,7 @@ public final class OfflineNoteWallet {
               createdAtMs);
       outputClaims.add(
           new OfflineNote.AuditOutputClaim(
-              changeCommitment, senderCertificate, changeAssetId, changeNote.canonicalAmount()));
+              changeCommitment, changeCertificate, changeAssetId, changeNote.canonicalAmount()));
     }
     final List<byte[]> outputCommitments = new ArrayList<>();
     for (final OfflineNote.AuditOutputClaim claim : outputClaims) {
@@ -690,7 +794,7 @@ public final class OfflineNoteWallet {
       throw new IllegalArgumentException("only spendable Offline Note notes can be redeemed");
     }
     final List<OfflineNote.AuditBundle> bearerAuditTrail = bearerAuditTrail(current);
-    requireTrustedCertificate(current.keyCertificate(), current.accountId());
+    requireTrustedCertificateForOrigin(current.keyCertificate(), current.origin(), current.accountId());
     final byte[] inputNullifier = deriveInputNullifier(current);
     final OfflineNote.RedeemPublicInputs redeemPublicInputs =
         new OfflineNote.RedeemPublicInputs(
@@ -712,7 +816,8 @@ public final class OfflineNoteWallet {
     final OfflineNote.Redeem redemption =
         draft.replacingRecursiveProof(proofProvider.proveRedeem(draft));
     redemption.validateProofBinding();
-    requireTrustedCertificate(redemption.senderKeyCertificate(), current.accountId());
+    requireTrustedCertificateForOrigin(
+        redemption.senderKeyCertificate(), current.origin(), current.accountId());
     if (!proofVerifier.verifyRedeem(redemption)) {
       throw new IllegalArgumentException("Offline Note recursive redeem proof verification failed");
     }
@@ -916,28 +1021,71 @@ public final class OfflineNoteWallet {
   }
 
   private void requireTrustedAuditCertificates(final OfflineNote.AuditBundle audit) {
-    requireTrustedCertificate(audit.senderKeyCertificate(), null);
+    requireTrustedEitherCertificate(audit.senderKeyCertificate(), null);
     final byte[] senderCertificateHash = audit.senderKeyCertificate().payloadHash();
     for (final OfflineNote.IssuedClaim input : audit.inputClaims()) {
       if (!Arrays.equals(input.keyCertificatePayloadHash(), senderCertificateHash)) {
         throw new IllegalArgumentException(
             "Offline Note input claim is not bound to the sender certificate");
       }
-      requireTrustedCertificate(audit.senderKeyCertificate(), assetAccount(input.assetId()));
+      requireTrustedEitherCertificate(audit.senderKeyCertificate(), assetAccount(input.assetId()));
     }
     for (final OfflineNote.AuditOutputClaim output : audit.outputClaims()) {
-      requireTrustedCertificate(output.keyCertificate(), assetAccount(output.assetId()));
+      requireTrustedOwnerCertificate(output.keyCertificate(), assetAccount(output.assetId()));
     }
   }
 
-  private void requireTrustedCertificate(
+  private void requireTrustedCertificateForOrigin(
+      final OfflineNote.KeyCertificate certificate,
+      final OfflineNote.CommitmentOrigin origin,
+      final String expectedAccountId) {
+    if (origin instanceof OfflineNote.CommitmentOrigin.IssuerLoad) {
+      requireTrustedIssuerCertificate(certificate, expectedAccountId);
+    } else if (origin instanceof OfflineNote.CommitmentOrigin.P2pOutput) {
+      requireTrustedOwnerCertificate(certificate, expectedAccountId);
+    } else {
+      throw new IllegalArgumentException("unknown Offline Note commitment origin");
+    }
+  }
+
+  private void requireTrustedIssuerCertificate(
+      final OfflineNote.KeyCertificate certificate, final String expectedAccountId) {
+    requireMatchingAccount(certificate, expectedAccountId);
+    if (!certificateVerifier.verifyIssuerCertificate(certificate)) {
+      throw new IllegalArgumentException("Offline Note key certificate verification failed");
+    }
+  }
+
+  private void requireTrustedOwnerCertificate(
+      final OfflineNote.KeyCertificate certificate, final String expectedAccountId) {
+    requireMatchingAccount(certificate, expectedAccountId);
+    if (!certificateVerifier.verifyOwnerCertificate(certificate)) {
+      throw new IllegalArgumentException("Offline Note key certificate verification failed");
+    }
+  }
+
+  private void requireTrustedEitherCertificate(
+      final OfflineNote.KeyCertificate certificate, final String expectedAccountId) {
+    requireMatchingAccount(certificate, expectedAccountId);
+    if (!certificateVerifier.verifyIssuerCertificate(certificate)
+        && !certificateVerifier.verifyOwnerCertificate(certificate)) {
+      throw new IllegalArgumentException("Offline Note key certificate verification failed");
+    }
+  }
+
+  private void requireMatchingAccount(
       final OfflineNote.KeyCertificate certificate, final String expectedAccountId) {
     if (expectedAccountId != null && !expectedAccountId.equals(certificate.accountId())) {
       throw new IllegalArgumentException("Offline Note key certificate account mismatch");
     }
-    if (!certificateVerifier.verifyCertificate(certificate)) {
-      throw new IllegalArgumentException("Offline Note key certificate verification failed");
+  }
+
+  private OfflineNoteOwnerCertificateSigner requireOwnerCertificateSigner() {
+    if (ownerCertificateSigner == null) {
+      throw new IllegalStateException(
+          "Offline Note owner certificate signer is required for P2P outputs");
     }
+    return ownerCertificateSigner;
   }
 
   private static String assetAccount(final String assetId) {

--- a/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/RejectingOfflineNoteCertificateVerifier.java
+++ b/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/RejectingOfflineNoteCertificateVerifier.java
@@ -4,7 +4,12 @@ package org.hyperledger.iroha.android.offline;
 public final class RejectingOfflineNoteCertificateVerifier
     implements OfflineNoteCertificateVerifier {
   @Override
-  public boolean verifyCertificate(final OfflineNote.KeyCertificate certificate) {
+  public boolean verifyIssuerCertificate(final OfflineNote.KeyCertificate certificate) {
+    return false;
+  }
+
+  @Override
+  public boolean verifyOwnerCertificate(final OfflineNote.KeyCertificate certificate) {
     return false;
   }
 }

--- a/java/iroha_android/src/test/java/org/hyperledger/iroha/android/offline/OfflineNoteTest.java
+++ b/java/iroha_android/src/test/java/org/hyperledger/iroha/android/offline/OfflineNoteTest.java
@@ -108,7 +108,7 @@ public final class OfflineNoteTest {
         string(certificates, "sender_payload_hash"),
         hex(sender.payloadHash()),
         "sender certificate payload hash");
-    assertTrue(verifier.verifyCertificate(sender), "fixture sender certificate is trusted");
+    assertTrue(verifier.verifyIssuerCertificate(sender), "fixture sender certificate is trusted");
 
     final byte[] tamperedSignature = sender.issuerSignature();
     tamperedSignature[0] = (byte) (tamperedSignature[0] ^ 0x01);
@@ -126,14 +126,15 @@ public final class OfflineNoteTest {
             sender.assertionUsageCountLimit(),
             sender.oneUse(),
             tamperedSignature);
-    assertTrue(!verifier.verifyCertificate(tampered), "tampered certificate signature is rejected");
     assertTrue(
-        !new RejectingOfflineNoteCertificateVerifier().verifyCertificate(sender),
+        !verifier.verifyIssuerCertificate(tampered), "tampered certificate signature is rejected");
+    assertTrue(
+        !new RejectingOfflineNoteCertificateVerifier().verifyIssuerCertificate(sender),
         "default certificate verifier rejects");
     assertTrue(
         !new Ed25519OfflineNoteCertificateVerifier(
                 Collections.singletonList(filledBytes(32, 0x42)))
-            .verifyCertificate(sender),
+            .verifyIssuerCertificate(sender),
         "wrong issuer root rejects");
   }
 
@@ -2551,11 +2552,12 @@ public final class OfflineNoteTest {
             new RecordingTransactionSubmitter(),
             BindingProofProvider.INSTANCE,
             BindingProofVerifier.INSTANCE,
-            certificateVerifier(fixture),
+            fixtureOwnerCertificateVerifier(fixture),
             new QueueRandomSource(
                 Collections.singletonList(hexBytes(string(derivation, "recipient_note_secret_hex")))),
             new FixedIdGenerator(string(derivation, "payment_request_id")),
-            () -> 1_700_000_001_200L);
+            () -> 1_700_000_001_200L,
+            new StaticOwnerCertificateSigner(recipientCertificate));
     final OfflineNoteReceiveRequest receiveRequest =
         recipientWallet.prepareReceive(
             assetDefinitionFromAssetId(string(obj(chain, "issue"), "asset_id")),
@@ -2605,12 +2607,13 @@ public final class OfflineNoteTest {
             null,
             BindingProofProvider.INSTANCE,
             BindingProofVerifier.INSTANCE,
-            certificateVerifier(fixture),
+            fixtureOwnerCertificateVerifier(fixture),
             new QueueRandomSource(
                 Collections.singletonList(hexBytes(string(derivation, "recipient_note_secret_hex")))),
             new FixedIdGenerator(string(derivation, "payment_request_id")),
             () -> 1_700_000_001_250L,
-            new OfflineBearerCashPolicyV1(1, 32, 2048, 12288, 20, 8, 40));
+            new OfflineBearerCashPolicyV1(1, 32, 2048, 12288, 20, 8, 40),
+            new StaticOwnerCertificateSigner(recipientCertificate));
     final OfflineNoteReceiveRequest receiveRequest =
         recipientWallet.prepareReceive(
             assetDefinitionFromAssetId(string(obj(chain, "issue"), "asset_id")),
@@ -2708,7 +2711,7 @@ public final class OfflineNoteTest {
             new RecordingTransactionSubmitter(),
             BindingProofProvider.INSTANCE,
             BindingProofVerifier.INSTANCE,
-            certificateVerifier(fixture),
+            fixtureOwnerCertificateVerifier(fixture),
             new QueueRandomSource(
                 Collections.singletonList(hexBytes(string(derivation, "source_note_secret_hex")))),
             new FixedIdGenerator(string(derivation, "payment_request_id")),
@@ -2959,7 +2962,7 @@ public final class OfflineNoteTest {
             new RecordingTransactionSubmitter(),
             BindingProofProvider.INSTANCE,
             BindingProofVerifier.INSTANCE,
-            certificateVerifier(fixture),
+            fixtureOwnerCertificateVerifier(fixture),
             new QueueRandomSource(
                 Collections.singletonList(hexBytes(string(derivation, "source_note_secret_hex")))),
             new FixedIdGenerator(string(derivation, "payment_request_id")),
@@ -3031,7 +3034,7 @@ public final class OfflineNoteTest {
             new RecordingTransactionSubmitter(),
             BindingProofProvider.INSTANCE,
             BindingProofVerifier.INSTANCE,
-            certificateVerifier(fixture),
+            fixtureOwnerCertificateVerifier(fixture),
             new QueueRandomSource(
                 Collections.singletonList(hexBytes(string(derivation, "source_note_secret_hex")))),
             new FixedIdGenerator(string(derivation, "payment_request_id")),
@@ -3071,13 +3074,14 @@ public final class OfflineNoteTest {
             new RecordingTransactionSubmitter(),
             BindingProofProvider.INSTANCE,
             BindingProofVerifier.INSTANCE,
-            certificateVerifier(fixture),
+            fixtureOwnerCertificateVerifier(fixture),
             new QueueRandomSource(
                 Arrays.asList(
                     hexBytes(string(derivation, "token_nonce_hex")),
                     hexBytes(string(derivation, "change_note_secret_hex")))),
             new FixedIdGenerator(string(derivation, "payment_request_id")),
-            () -> longValue(payment, "created_at_ms"));
+            () -> longValue(payment, "created_at_ms"),
+            new StaticOwnerCertificateSigner(senderCertificate));
     final RecordingTransactionSubmitter recipientSubmitter = new RecordingTransactionSubmitter();
     final OfflineNoteWallet recipientWallet =
         new OfflineNoteWallet(
@@ -3089,11 +3093,12 @@ public final class OfflineNoteTest {
             recipientSubmitter,
             BindingProofProvider.INSTANCE,
             BindingProofVerifier.INSTANCE,
-            certificateVerifier(fixture),
+            fixtureOwnerCertificateVerifier(fixture),
             new QueueRandomSource(
                 Collections.singletonList(hexBytes(string(derivation, "recipient_note_secret_hex")))),
             new FixedIdGenerator(string(derivation, "payment_request_id")),
-            () -> 1_700_000_001_200L);
+            () -> 1_700_000_001_200L,
+            new StaticOwnerCertificateSigner(recipientCertificate));
 
     final OfflineNoteReceiveRequest receiveRequest =
         recipientWallet.prepareReceive(
@@ -3186,13 +3191,14 @@ public final class OfflineNoteTest {
             syncResolver,
             BindingProofProvider.INSTANCE,
             BindingProofVerifier.INSTANCE,
-            certificateVerifier(fixture),
+            fixtureOwnerCertificateVerifier(fixture),
             new QueueRandomSource(
                 Arrays.asList(
                     hexBytes(string(derivation, "token_nonce_hex")),
                     hexBytes(string(derivation, "change_note_secret_hex")))),
             new FixedIdGenerator(string(derivation, "payment_request_id")),
-            () -> 1_700_000_002_000L);
+            () -> 1_700_000_002_000L,
+            new StaticOwnerCertificateSigner(senderCertificate));
     final OfflineNoteWallet recipientWallet =
         new OfflineNoteWallet(
             string(derivation, "chain_id"),
@@ -3203,11 +3209,12 @@ public final class OfflineNoteTest {
             new RecordingTransactionSubmitter(),
             BindingProofProvider.INSTANCE,
             BindingProofVerifier.INSTANCE,
-            certificateVerifier(fixture),
+            fixtureOwnerCertificateVerifier(fixture),
             new QueueRandomSource(
                 Collections.singletonList(hexBytes(string(derivation, "recipient_note_secret_hex")))),
             new FixedIdGenerator(string(derivation, "payment_request_id")),
-            () -> 1_700_000_002_100L);
+            () -> 1_700_000_002_100L,
+            new StaticOwnerCertificateSigner(recipientCertificate));
 
     final OfflineNoteReceiveRequest receiveRequest =
         recipientWallet.prepareReceive(
@@ -3267,13 +3274,14 @@ public final class OfflineNoteTest {
             new RecordingTransactionSubmitter(),
             BindingProofProvider.INSTANCE,
             BindingProofVerifier.INSTANCE,
-            certificateVerifier(fixture),
+            fixtureOwnerCertificateVerifier(fixture),
             new QueueRandomSource(
                 Arrays.asList(
                     hexBytes(string(derivation, "token_nonce_hex")),
                     hexBytes(string(derivation, "change_note_secret_hex")))),
             new FixedIdGenerator(string(derivation, "payment_request_id")),
-            () -> 1_700_000_002_200L);
+            () -> 1_700_000_002_200L,
+            new StaticOwnerCertificateSigner(senderCertificate));
     final OfflineNoteWallet recipientWallet =
         new OfflineNoteWallet(
             string(derivation, "chain_id"),
@@ -3284,11 +3292,12 @@ public final class OfflineNoteTest {
             new RecordingTransactionSubmitter(),
             BindingProofProvider.INSTANCE,
             BindingProofVerifier.INSTANCE,
-            certificateVerifier(fixture),
+            fixtureOwnerCertificateVerifier(fixture),
             new QueueRandomSource(
                 Collections.singletonList(hexBytes(string(derivation, "recipient_note_secret_hex")))),
             new FixedIdGenerator(string(derivation, "payment_request_id")),
-            () -> 1_700_000_002_300L);
+            () -> 1_700_000_002_300L,
+            new StaticOwnerCertificateSigner(recipientCertificate));
 
     final OfflineNoteReceiveRequest receiveRequest =
         recipientWallet.prepareReceive(
@@ -3344,11 +3353,12 @@ public final class OfflineNoteTest {
             new RecordingTransactionSubmitter(),
             BindingProofProvider.INSTANCE,
             BindingProofVerifier.INSTANCE,
-            certificateVerifier(fixture),
+            fixtureOwnerCertificateVerifier(fixture),
             new QueueRandomSource(
                 Collections.singletonList(hexBytes(string(derivation, "token_nonce_hex")))),
             new FixedIdGenerator(string(derivation, "payment_request_id")),
-            () -> 1_700_000_002_400L);
+            () -> 1_700_000_002_400L,
+            new StaticOwnerCertificateSigner(senderCertificate));
     final OfflineNoteWallet recipientWallet =
         new OfflineNoteWallet(
             string(derivation, "chain_id"),
@@ -3359,11 +3369,12 @@ public final class OfflineNoteTest {
             new RecordingTransactionSubmitter(),
             BindingProofProvider.INSTANCE,
             BindingProofVerifier.INSTANCE,
-            certificateVerifier(fixture),
+            fixtureOwnerCertificateVerifier(fixture),
             new QueueRandomSource(
                 Collections.singletonList(hexBytes(string(derivation, "recipient_note_secret_hex")))),
             new FixedIdGenerator(string(derivation, "payment_request_id")),
-            () -> 1_700_000_002_500L);
+            () -> 1_700_000_002_500L,
+            new StaticOwnerCertificateSigner(recipientCertificate));
 
     final OfflineNoteReceiveRequest receiveRequest =
         recipientWallet.prepareReceive(
@@ -3399,10 +3410,11 @@ public final class OfflineNoteTest {
             new RecordingTransactionSubmitter(),
             BindingProofProvider.INSTANCE,
             BindingProofVerifier.INSTANCE,
-            certificateVerifier(fixture),
+            fixtureOwnerCertificateVerifier(fixture),
             new QueueRandomSource(Collections.emptyList()),
             new FixedIdGenerator(string(derivation, "payment_request_id")),
-            () -> 1_700_000_002_600L);
+            () -> 1_700_000_002_600L,
+            new StaticOwnerCertificateSigner(senderCertificate));
 
     assertThrows(
         () -> restoredWallet.pay(receiveRequest),
@@ -3439,7 +3451,7 @@ public final class OfflineNoteTest {
             submitter,
             BindingProofProvider.INSTANCE,
             BindingProofVerifier.INSTANCE,
-            certificateVerifier(fixture),
+            fixtureOwnerCertificateVerifier(fixture),
             new QueueRandomSource(Collections.emptyList()),
             new FixedIdGenerator(string(derivation, "payment_request_id")),
             () -> 1_700_000_004_000L);
@@ -3500,10 +3512,11 @@ public final class OfflineNoteTest {
             null,
             BindingProofProvider.INSTANCE,
             BindingProofVerifier.INSTANCE,
-            certificateVerifier(fixture),
+            fixtureOwnerCertificateVerifier(fixture),
             new QueueRandomSource(Collections.emptyList()),
             new FixedIdGenerator(string(derivation, "payment_request_id")),
-            () -> 1_700_000_002_710L);
+            () -> 1_700_000_002_710L,
+            new StaticOwnerCertificateSigner(recipientCertificate));
     assertThrows(
         () -> wrongAccountReceiveWallet.prepareReceive(assetDefinitionId, string(chainRedeem, "amount")),
         "valid receive certificate for the wrong account should fail");
@@ -3520,13 +3533,14 @@ public final class OfflineNoteTest {
             new RecordingTransactionSubmitter(),
             BindingProofProvider.INSTANCE,
             BindingProofVerifier.INSTANCE,
-            certificateVerifier(fixture),
+            fixtureOwnerCertificateVerifier(fixture),
             new QueueRandomSource(
                 Arrays.asList(
                     hexBytes(string(derivation, "token_nonce_hex")),
                     hexBytes(string(derivation, "change_note_secret_hex")))),
             new FixedIdGenerator(string(derivation, "payment_request_id")),
-            () -> longValue(payment, "created_at_ms"));
+            () -> longValue(payment, "created_at_ms"),
+            new StaticOwnerCertificateSigner(senderCertificate));
     final OfflineNoteWallet recipientWallet =
         new OfflineNoteWallet(
             string(derivation, "chain_id"),
@@ -3537,11 +3551,12 @@ public final class OfflineNoteTest {
             new RecordingTransactionSubmitter(),
             BindingProofProvider.INSTANCE,
             BindingProofVerifier.INSTANCE,
-            certificateVerifier(fixture),
+            fixtureOwnerCertificateVerifier(fixture),
             new QueueRandomSource(
                 Collections.singletonList(hexBytes(string(derivation, "recipient_note_secret_hex")))),
             new FixedIdGenerator(string(derivation, "payment_request_id")),
-            () -> 1_700_000_002_800L);
+            () -> 1_700_000_002_800L,
+            new StaticOwnerCertificateSigner(recipientCertificate));
 
     final OfflineNoteReceiveRequest receiveRequest =
         recipientWallet.prepareReceive(assetDefinitionId, string(chainRedeem, "amount"));
@@ -3593,11 +3608,12 @@ public final class OfflineNoteTest {
             new RecordingTransactionSubmitter(),
             BindingProofProvider.INSTANCE,
             BindingProofVerifier.INSTANCE,
-            certificateVerifier(fixture),
+            fixtureOwnerCertificateVerifier(fixture),
             new QueueRandomSource(
                 Arrays.asList(filledBytes(32, 0x21), filledBytes(32, 0x22))),
             new FixedIdGenerator(string(derivation, "payment_request_id")),
-            () -> longValue(payment, "created_at_ms") + 3);
+            () -> longValue(payment, "created_at_ms") + 3,
+            new StaticOwnerCertificateSigner(senderCertificate));
     assertThrows(
         () -> assetOwnerSubstitutionSender.pay(assetOwnerSubstitution),
         "receive request asset owner substitution should fail certificate binding");
@@ -3614,7 +3630,7 @@ public final class OfflineNoteTest {
             new RecordingTransactionSubmitter(),
             BindingProofProvider.INSTANCE,
             BindingProofVerifier.INSTANCE,
-            certificateVerifier(fixture),
+            fixtureOwnerCertificateVerifier(fixture),
             new QueueRandomSource(Collections.emptyList()),
             new FixedIdGenerator(string(derivation, "payment_request_id")),
             () -> 1_700_000_002_900L);
@@ -3633,7 +3649,7 @@ public final class OfflineNoteTest {
             new RecordingTransactionSubmitter(),
             BindingProofProvider.INSTANCE,
             BindingProofVerifier.INSTANCE,
-            certificateVerifier(fixture),
+            fixtureOwnerCertificateVerifier(fixture),
             new QueueRandomSource(Collections.emptyList()),
             new FixedIdGenerator(string(derivation, "payment_request_id")),
             () -> 1_700_000_002_910L);
@@ -3652,11 +3668,12 @@ public final class OfflineNoteTest {
             new RecordingTransactionSubmitter(),
             BindingProofProvider.INSTANCE,
             BindingProofVerifier.INSTANCE,
-            certificateVerifier(fixture),
+            fixtureOwnerCertificateVerifier(fixture),
             new QueueRandomSource(
                 Arrays.asList(filledBytes(32, 0x31), filledBytes(32, 0x32))),
             new FixedIdGenerator(string(derivation, "payment_request_id")),
-            () -> longValue(payment, "created_at_ms") + 1);
+            () -> longValue(payment, "created_at_ms") + 1,
+            new StaticOwnerCertificateSigner(senderCertificate));
     final OfflineNoteReceiveRequest commitmentSubstitution =
         new OfflineNoteReceiveRequest(
             receiveRequest.chainId(),
@@ -3683,11 +3700,12 @@ public final class OfflineNoteTest {
             new RecordingTransactionSubmitter(),
             BindingProofProvider.INSTANCE,
             BindingProofVerifier.INSTANCE,
-            certificateVerifier(fixture),
+            fixtureOwnerCertificateVerifier(fixture),
             new QueueRandomSource(
                 Arrays.asList(filledBytes(32, 0x41), filledBytes(32, 0x42))),
             new FixedIdGenerator(string(derivation, "payment_request_id")),
-            () -> longValue(payment, "created_at_ms") + 2);
+            () -> longValue(payment, "created_at_ms") + 2,
+            new StaticOwnerCertificateSigner(senderCertificate));
     final OfflineNoteReceiveRequest amountSubstitution =
         new OfflineNoteReceiveRequest(
             receiveRequest.chainId(),
@@ -3792,13 +3810,14 @@ public final class OfflineNoteTest {
             new RecordingSyncResolver(senderResolutions),
             BindingProofProvider.INSTANCE,
             BindingProofVerifier.INSTANCE,
-            certificateVerifier(fixture),
+            fixtureOwnerCertificateVerifier(fixture),
             new QueueRandomSource(
                 Arrays.asList(
                     hexBytes(string(derivation, "token_nonce_hex")),
                     hexBytes(string(derivation, "change_note_secret_hex")))),
             new FixedIdGenerator(string(derivation, "payment_request_id")),
-            () -> 1_700_000_002_400L);
+            () -> 1_700_000_002_400L,
+            new StaticOwnerCertificateSigner(senderCertificate));
     final InMemoryOfflineNoteStore recipientStore = new InMemoryOfflineNoteStore();
     final Map<String, OfflineNoteWalletNoteState> recipientResolutions = new LinkedHashMap<>();
     recipientResolutions.put(
@@ -3814,11 +3833,12 @@ public final class OfflineNoteTest {
             new RecordingSyncResolver(recipientResolutions),
             BindingProofProvider.INSTANCE,
             BindingProofVerifier.INSTANCE,
-            certificateVerifier(fixture),
+            fixtureOwnerCertificateVerifier(fixture),
             new QueueRandomSource(
                 Collections.singletonList(hexBytes(string(derivation, "recipient_note_secret_hex")))),
             new FixedIdGenerator(string(derivation, "payment_request_id")),
-            () -> 1_700_000_002_500L);
+            () -> 1_700_000_002_500L,
+            new StaticOwnerCertificateSigner(recipientCertificate));
 
     final OfflineNoteReceiveRequest receiveRequest =
         recipientWallet.prepareReceive(
@@ -3870,7 +3890,7 @@ public final class OfflineNoteTest {
             new RecordingSyncResolver(redeemResolutions),
             BindingProofProvider.INSTANCE,
             BindingProofVerifier.INSTANCE,
-            certificateVerifier(fixture),
+            fixtureOwnerCertificateVerifier(fixture),
             new QueueRandomSource(Collections.emptyList()),
             new FixedIdGenerator(string(derivation, "payment_request_id")),
             () -> 1_700_000_002_600L);
@@ -4071,6 +4091,23 @@ public final class OfflineNoteTest {
       final Map<String, Object> fixture) {
     return new Ed25519OfflineNoteCertificateVerifier(
         Collections.singletonList(base64Bytes(string(fixture, "offline_fi_public_key_base64"))));
+  }
+
+  private static OfflineNoteCertificateVerifier fixtureOwnerCertificateVerifier(
+      final Map<String, Object> fixture) {
+    final OfflineNoteCertificateVerifier delegate = certificateVerifier(fixture);
+    return new OfflineNoteCertificateVerifier() {
+      @Override
+      public boolean verifyIssuerCertificate(final OfflineNote.KeyCertificate certificate) {
+        return delegate.verifyIssuerCertificate(certificate);
+      }
+
+      @Override
+      public boolean verifyOwnerCertificate(final OfflineNote.KeyCertificate certificate) {
+        return delegate.verifyOwnerCertificate(certificate)
+            || delegate.verifyIssuerCertificate(certificate);
+      }
+    };
   }
 
   private static OfflineNote.KeyCertificate tamperedSignatureCertificate(
@@ -4475,6 +4512,20 @@ public final class OfflineNoteTest {
 
     @Override
     public OfflineNote.KeyCertificate currentKeyCertificate() {
+      return certificate;
+    }
+  }
+
+  private static final class StaticOwnerCertificateSigner
+      implements OfflineNoteOwnerCertificateSigner {
+    private final OfflineNote.KeyCertificate certificate;
+
+    private StaticOwnerCertificateSigner(final OfflineNote.KeyCertificate certificate) {
+      this.certificate = certificate;
+    }
+
+    @Override
+    public OfflineNote.KeyCertificate freshOwnerCertificate(final String accountId) {
       return certificate;
     }
   }

--- a/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/offline/ChainVkOfflineNoteProofProvider.kt
+++ b/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/offline/ChainVkOfflineNoteProofProvider.kt
@@ -1,0 +1,20 @@
+package org.hyperledger.iroha.sdk.offline
+
+/** Offline Note proof provider that proves against a chain-supplied `VerifyingKeyBox`. */
+class ChainVkOfflineNoteProofProvider(vkBoxNorito: ByteArray) : OfflineNoteProofProvider {
+    private val vkBoxNorito = vkBoxNorito.copyOf()
+
+    init {
+        require(this.vkBoxNorito.isNotEmpty()) { "vkBoxNorito must not be empty" }
+    }
+
+    override fun proveAudit(audit: OfflineNote.AuditBundle): OfflineNote.RecursiveProof {
+        val proofNorito = NativeOfflineNoteProver.proveAudit(OfflineNote.encodeAudit(audit), vkBoxNorito)
+        return OfflineNote.decodeRecursiveProof(proofNorito)
+    }
+
+    override fun proveRedeem(redemption: OfflineNote.Redeem): OfflineNote.RecursiveProof {
+        val proofNorito = NativeOfflineNoteProver.proveRedeem(OfflineNote.encodeRedeem(redemption), vkBoxNorito)
+        return OfflineNote.decodeRecursiveProof(proofNorito)
+    }
+}

--- a/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/offline/ChainVkOfflineNoteProofVerifier.kt
+++ b/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/offline/ChainVkOfflineNoteProofVerifier.kt
@@ -1,0 +1,16 @@
+package org.hyperledger.iroha.sdk.offline
+
+/** Offline Note proof verifier that verifies against a chain-supplied `VerifyingKeyBox`. */
+class ChainVkOfflineNoteProofVerifier(vkBoxNorito: ByteArray) : OfflineNoteProofVerifier {
+    private val vkBoxNorito = vkBoxNorito.copyOf()
+
+    init {
+        require(this.vkBoxNorito.isNotEmpty()) { "vkBoxNorito must not be empty" }
+    }
+
+    override fun verifyAudit(audit: OfflineNote.AuditBundle): Boolean =
+        NativeOfflineNoteProver.verifyAudit(OfflineNote.encodeAudit(audit), vkBoxNorito)
+
+    override fun verifyRedeem(redemption: OfflineNote.Redeem): Boolean =
+        NativeOfflineNoteProver.verifyRedeem(OfflineNote.encodeRedeem(redemption), vkBoxNorito)
+}

--- a/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/offline/NativeOfflineNoteProver.kt
+++ b/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/offline/NativeOfflineNoteProver.kt
@@ -1,0 +1,95 @@
+package org.hyperledger.iroha.sdk.offline
+
+/** Native record-backed Offline Note recursive prover using a chain-supplied verifying key. */
+class NativeOfflineNoteProver private constructor() {
+    companion object {
+        private const val LIBRARY_NAME = "connect_norito_bridge"
+        private val nativeAvailable: Boolean = loadLibrary()
+
+        @JvmStatic
+        fun isNativeAvailable(): Boolean = nativeAvailable
+
+        @JvmStatic
+        fun proveRedeem(redeemNorito: ByteArray, vkBoxNorito: ByteArray): ByteArray {
+            require(redeemNorito.isNotEmpty()) { "redeemNorito must not be empty" }
+            require(vkBoxNorito.isNotEmpty()) { "vkBoxNorito must not be empty" }
+            check(nativeAvailable) { "$LIBRARY_NAME is not available in this runtime" }
+            val proofNorito = nativeProveNoteRedeemWithVk(redeemNorito, vkBoxNorito)
+            check(proofNorito != null && proofNorito.isNotEmpty()) {
+                "nativeProveNoteRedeemWithVk returned empty output"
+            }
+            return proofNorito
+        }
+
+        @JvmStatic
+        fun proveAudit(auditNorito: ByteArray, vkBoxNorito: ByteArray): ByteArray {
+            require(auditNorito.isNotEmpty()) { "auditNorito must not be empty" }
+            require(vkBoxNorito.isNotEmpty()) { "vkBoxNorito must not be empty" }
+            check(nativeAvailable) { "$LIBRARY_NAME is not available in this runtime" }
+            val proofNorito = nativeProveNoteAuditWithVk(auditNorito, vkBoxNorito)
+            check(proofNorito != null && proofNorito.isNotEmpty()) {
+                "nativeProveNoteAuditWithVk returned empty output"
+            }
+            return proofNorito
+        }
+
+        @JvmStatic
+        fun verifyRedeem(redeemNorito: ByteArray, vkBoxNorito: ByteArray): Boolean {
+            require(redeemNorito.isNotEmpty()) { "redeemNorito must not be empty" }
+            require(vkBoxNorito.isNotEmpty()) { "vkBoxNorito must not be empty" }
+            check(nativeAvailable) { "$LIBRARY_NAME is not available in this runtime" }
+            return nativeVerifyNoteRedeemWithVk(redeemNorito, vkBoxNorito)
+        }
+
+        @JvmStatic
+        fun verifyAudit(auditNorito: ByteArray, vkBoxNorito: ByteArray): Boolean {
+            require(auditNorito.isNotEmpty()) { "auditNorito must not be empty" }
+            require(vkBoxNorito.isNotEmpty()) { "vkBoxNorito must not be empty" }
+            check(nativeAvailable) { "$LIBRARY_NAME is not available in this runtime" }
+            return nativeVerifyNoteAuditWithVk(auditNorito, vkBoxNorito)
+        }
+
+        private fun loadLibrary(): Boolean =
+            detectNativeAvailability(
+                loadLibrary = { System.loadLibrary(LIBRARY_NAME) },
+                probeSymbol = { nativeProveNoteRedeemWithVk(ByteArray(0), ByteArray(0)) },
+            )
+
+        internal fun detectNativeAvailability(loadLibrary: () -> Unit, probeSymbol: () -> Unit): Boolean =
+            try {
+                loadLibrary()
+                probeSymbol()
+                true
+            } catch (_: IllegalArgumentException) {
+                true
+            } catch (_: UnsatisfiedLinkError) {
+                false
+            } catch (_: SecurityException) {
+                false
+            }
+
+        @JvmStatic
+        private external fun nativeProveNoteRedeemWithVk(
+            redeemNorito: ByteArray,
+            vkBoxNorito: ByteArray,
+        ): ByteArray?
+
+        @JvmStatic
+        private external fun nativeProveNoteAuditWithVk(
+            auditNorito: ByteArray,
+            vkBoxNorito: ByteArray,
+        ): ByteArray?
+
+        @JvmStatic
+        private external fun nativeVerifyNoteRedeemWithVk(
+            redeemNorito: ByteArray,
+            vkBoxNorito: ByteArray,
+        ): Boolean
+
+        @JvmStatic
+        private external fun nativeVerifyNoteAuditWithVk(
+            auditNorito: ByteArray,
+            vkBoxNorito: ByteArray,
+        ): Boolean
+    }
+}

--- a/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/offline/OfflineNote.kt
+++ b/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/offline/OfflineNote.kt
@@ -58,6 +58,8 @@ object OfflineNote {
         "iroha_data_model::offline::model::OfflineNoteIssuedClaim"
     private const val AUDIT_OUTPUT_CLAIM_SCHEMA =
         "iroha_data_model::offline::model::OfflineNoteAuditOutputClaim"
+    private const val RECURSIVE_PROOF_SCHEMA =
+        "iroha_data_model::offline::model::OfflineNoteRecursiveProof"
     private const val REDEEM_SCHEMA = "iroha_data_model::offline::model::OfflineNoteRedeem"
     private const val REDEEM_PUBLIC_INPUTS_SCHEMA =
         "iroha_data_model::offline::model::OfflineNoteRedeemPublicInputs"
@@ -137,6 +139,10 @@ object OfflineNote {
     @JvmStatic
     fun decodeIssuedClaim(bytes: ByteArray): IssuedClaim =
         decodeWithHeader(bytes, ISSUED_CLAIM_SCHEMA, IssuedClaimAdapter)
+
+    @JvmStatic
+    fun decodeRecursiveProof(bytes: ByteArray): RecursiveProof =
+        decodeWithHeader(bytes, RECURSIVE_PROOF_SCHEMA, RecursiveProofAdapter)
 
     @JvmStatic
     fun decodeRedeem(bytes: ByteArray): Redeem =

--- a/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/offline/OfflineNoteOwnerCertificateSigner.kt
+++ b/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/offline/OfflineNoteOwnerCertificateSigner.kt
@@ -1,0 +1,19 @@
+package org.hyperledger.iroha.sdk.offline
+
+/**
+ * Mints owner-self-signed Offline Note key certificates for P2P output claims.
+ *
+ * Output certificates must be signed by the owner account named in the certificate accountId, not
+ * by the issuer/operator key used for load and topup paths. The implementation lives in the
+ * application because only it holds the owner account signing key.
+ */
+interface OfflineNoteOwnerCertificateSigner {
+    /**
+     * Returns a fresh certificate for [accountId].
+     *
+     * The account must encode a single Ed25519 signatory, and the certificate issuerSignature must
+     * be a raw Ed25519 signature over [OfflineNote.KeyCertificate.signingBytes]. The certificate
+     * payload must be fresh for every output because its payload hash is a one-use replay anchor.
+     */
+    fun freshOwnerCertificate(accountId: String): OfflineNote.KeyCertificate
+}

--- a/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/offline/OfflineNoteWallet.kt
+++ b/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/offline/OfflineNoteWallet.kt
@@ -16,6 +16,8 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.LongSupplier
 import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
 import org.bouncycastle.crypto.signers.Ed25519Signer
+import org.hyperledger.iroha.sdk.address.AccountAddress
+import org.hyperledger.iroha.sdk.address.AccountAddressException
 import org.hyperledger.iroha.sdk.client.ClientObserver
 import org.hyperledger.iroha.sdk.client.ClientResponse
 import org.hyperledger.iroha.sdk.client.HttpErrorMessageExtractor
@@ -257,35 +259,63 @@ class Halo2OfflineNoteProofVerifier : OfflineNoteProofVerifier {
         OfflineNoteHalo2Prover.verifyRedeem(redemption)
 }
 
-/** Verifies issuer trust and attestation shape for Offline Note key certificates. */
+/** Verifies trust and attestation shape for Offline Note key certificates. */
 interface OfflineNoteCertificateVerifier {
-    fun verifyCertificate(certificate: OfflineNote.KeyCertificate): Boolean
+    /** Verifies a certificate signed by a trusted issuer for topup/issue paths. */
+    fun verifyIssuerCertificate(certificate: OfflineNote.KeyCertificate): Boolean
+
+    /** Verifies a certificate self-signed by the account named in its accountId for P2P output paths. */
+    fun verifyOwnerCertificate(certificate: OfflineNote.KeyCertificate): Boolean
 }
 
 /** Fails closed until a wallet is configured with trusted issuer roots. */
 class RejectingOfflineNoteCertificateVerifier : OfflineNoteCertificateVerifier {
-    override fun verifyCertificate(certificate: OfflineNote.KeyCertificate): Boolean = false
+    override fun verifyIssuerCertificate(certificate: OfflineNote.KeyCertificate): Boolean = false
+
+    override fun verifyOwnerCertificate(certificate: OfflineNote.KeyCertificate): Boolean = false
 }
 
-/** Ed25519 verifier for issuer-signed Offline Note key certificates. */
+/** Ed25519 verifier for issuer-signed and owner-self-signed Offline Note key certificates. */
 class Ed25519OfflineNoteCertificateVerifier(
     trustedIssuerPublicKeys: Collection<ByteArray>,
 ) : OfflineNoteCertificateVerifier {
     private val trustedIssuerPublicKeys = trustedIssuerPublicKeys.map { it.copyOf() }
 
-    override fun verifyCertificate(certificate: OfflineNote.KeyCertificate): Boolean {
+    override fun verifyIssuerCertificate(certificate: OfflineNote.KeyCertificate): Boolean {
         if (trustedIssuerPublicKeys.isEmpty()) return false
-        if (certificate.platform.trim().isEmpty()) return false
-        if (certificate.keyId.trim().isEmpty()) return false
-        if (certificate.deviceId.trim().isEmpty()) return false
-        if (certificate.assertionScheme.trim().isEmpty()) return false
-        if (certificate.assertionKeyAlgorithm.trim().isEmpty()) return false
-        if (certificate.assertionPublicKey().isEmpty()) return false
+        if (!hasValidAttestationShape(certificate)) return false
         val message = certificate.signingBytes()
         val signature = certificate.issuerSignature()
         return trustedIssuerPublicKeys.any { root ->
             root.size == 32 && verifyEd25519(root, message, signature)
         }
+    }
+
+    override fun verifyOwnerCertificate(certificate: OfflineNote.KeyCertificate): Boolean {
+        if (!hasValidAttestationShape(certificate)) return false
+        val ownerKey = ownerSignatoryKey(certificate.accountId) ?: return false
+        return verifyEd25519(ownerKey, certificate.signingBytes(), certificate.issuerSignature())
+    }
+
+    private fun hasValidAttestationShape(certificate: OfflineNote.KeyCertificate): Boolean =
+        certificate.platform.trim().isNotEmpty() &&
+            certificate.keyId.trim().isNotEmpty() &&
+            certificate.deviceId.trim().isNotEmpty() &&
+            certificate.assertionScheme.trim().isNotEmpty() &&
+            certificate.assertionKeyAlgorithm.trim().isNotEmpty() &&
+            certificate.assertionPublicKey().isNotEmpty()
+
+    private fun ownerSignatoryKey(accountId: String): ByteArray? {
+        val singleKey = try {
+            AccountAddress.parseEncodedIgnoringCurveSupport(accountId, null)
+                .address
+                .singleKeyPayloadIgnoringCurveSupport()
+        } catch (ex: AccountAddressException) {
+            return null
+        } ?: return null
+        if (singleKey.curveId != ED25519_CURVE_ID) return null
+        if (singleKey.publicKey.size != 32) return null
+        return singleKey.publicKey
     }
 
     private fun verifyEd25519(publicKey: ByteArray, message: ByteArray, signature: ByteArray): Boolean =
@@ -297,6 +327,10 @@ class Ed25519OfflineNoteCertificateVerifier(
         } catch (ex: RuntimeException) {
             false
         }
+
+    private companion object {
+        private const val ED25519_CURVE_ID = 0x01
+    }
 }
 
 /** JVM Halo2 proof provider backed by the SDK's native Offline Note prover. */
@@ -1207,6 +1241,7 @@ class IrohaOfflineNoteTransactionSubmitter @JvmOverloads constructor(
 class OfflineNoteWallet @JvmOverloads constructor(
     private val chainId: String,
     private val accountId: String,
+    @Suppress("unused")
     private val attestationProvider: OfflineNoteAttestationProvider,
     private val store: OfflineNoteStore = InMemoryOfflineNoteStore(),
     private val issuerClient: OfflineNoteIssuerClient? = null,
@@ -1219,6 +1254,7 @@ class OfflineNoteWallet @JvmOverloads constructor(
     private val idGenerator: OfflineNoteIdGenerator = UuidOfflineNoteIdGenerator(),
     private val clock: LongSupplier = LongSupplier { System.currentTimeMillis() },
     private val bearerCashPolicy: OfflineBearerCashPolicyV1 = OfflineBearerCashPolicyV1.DEFAULT,
+    private val ownerCertificateSigner: OfflineNoteOwnerCertificateSigner? = null,
 ) {
     private companion object {
         private val loadThreadIds = AtomicInteger()
@@ -1260,7 +1296,7 @@ class OfflineNoteWallet @JvmOverloads constructor(
                     val noteCommitment: ByteArray
                     val request: OfflineNoteIssueRequest
                     try {
-                        requireTrustedCertificate(context.keyCertificate, accountId)
+                        requireTrustedIssuerCertificate(context.keyCertificate, accountId)
                         noteSecret = random32()
                         origin = OfflineNote.CommitmentOrigin.IssuerLoad(
                             operationId = context.operationId,
@@ -1310,7 +1346,7 @@ class OfflineNoteWallet @JvmOverloads constructor(
                                     "issuer returned a different Offline Note commitment"
                                 }
                                 val issuedCertificate = response.keyCertificate ?: context.keyCertificate
-                                requireTrustedCertificate(issuedCertificate, accountId)
+                                requireTrustedIssuerCertificate(issuedCertificate, accountId)
                                 val now = clock.getAsLong()
                                 val issued = OfflineNoteWalletNote(
                                     chainId = chainId,
@@ -1339,8 +1375,8 @@ class OfflineNoteWallet @JvmOverloads constructor(
 
     fun prepareReceive(assetDefinitionId: String, amount: String): OfflineNoteReceiveRequest {
         val paymentRequestId = idGenerator.nextId("payment-request")
-        val keyCertificate = attestationProvider.currentKeyCertificate()
-        requireTrustedCertificate(keyCertificate, accountId)
+        val keyCertificate = requireOwnerCertificateSigner().freshOwnerCertificate(accountId)
+        requireTrustedOwnerCertificate(keyCertificate, accountId)
         val assetId = walletAssetId(assetDefinitionId, accountId)
         val noteSecret = random32()
         val origin = OfflineNote.CommitmentOrigin.P2pOutput(
@@ -1382,7 +1418,7 @@ class OfflineNoteWallet @JvmOverloads constructor(
 
     fun pay(receiveRequest: OfflineNoteReceiveRequest): OfflineNotePaymentToken {
         require(receiveRequest.chainId == chainId) { "receive request chainId does not match wallet chainId" }
-        requireTrustedCertificate(receiveRequest.keyCertificate, receiveRequest.accountId)
+        requireTrustedOwnerCertificate(receiveRequest.keyCertificate, receiveRequest.accountId)
         rejectReusedReceiveRequest(receiveRequest.paymentRequestId)
         val createdAtMs = clock.getAsLong()
         val requestedAmount = decimal(receiveRequest.canonicalAmount)
@@ -1391,12 +1427,13 @@ class OfflineNoteWallet @JvmOverloads constructor(
         val changeAmount = inputAmount.subtract(requestedAmount)
         require(changeAmount.signum() >= 0) { "selected input amount is below requested amount" }
 
-        val senderCertificate = selected.first().keyCertificate
-        requireTrustedCertificate(senderCertificate, accountId)
+        val senderNote = selected.first()
+        val senderCertificate = senderNote.keyCertificate
+        requireTrustedCertificateForOrigin(senderCertificate, senderNote.origin, accountId)
         val senderCertificateHash = senderCertificate.payloadHash()
         selected.forEach {
             bearerAuditTrail(it)
-            requireTrustedCertificate(it.keyCertificate, accountId)
+            requireTrustedCertificateForOrigin(it.keyCertificate, it.origin, accountId)
             require(it.keyCertificate.payloadHash().contentEquals(senderCertificateHash)) {
                 "selected input notes must use the same key certificate"
             }
@@ -1416,12 +1453,14 @@ class OfflineNoteWallet @JvmOverloads constructor(
         if (changeAmount.signum() > 0) {
             val changeSecret = random32()
             val changeAssetId = walletAssetId(receiveRequest.assetDefinitionId, accountId)
+            val changeCertificate = requireOwnerCertificateSigner().freshOwnerCertificate(accountId)
+            requireTrustedOwnerCertificate(changeCertificate, accountId)
             val changeOrigin = OfflineNote.CommitmentOrigin.P2pOutput(
                 paymentRequestId = receiveRequest.paymentRequestId,
                 outputIndex = 1,
             )
             val changeCommitment = deriveNoteCommitment(
-                keyCertificate = senderCertificate,
+                keyCertificate = changeCertificate,
                 assetId = changeAssetId,
                 amount = canonicalDecimal(changeAmount),
                 noteSecret = changeSecret,
@@ -1432,7 +1471,7 @@ class OfflineNoteWallet @JvmOverloads constructor(
                 accountId = accountId,
                 assetId = changeAssetId,
                 amount = canonicalDecimal(changeAmount),
-                keyCertificate = senderCertificate,
+                keyCertificate = changeCertificate,
                 noteCommitment = changeCommitment,
                 noteSecret = changeSecret,
                 origin = changeOrigin,
@@ -1443,7 +1482,7 @@ class OfflineNoteWallet @JvmOverloads constructor(
             outputClaims.add(
                 OfflineNote.AuditOutputClaim(
                     noteCommitment = changeCommitment,
-                    keyCertificate = senderCertificate,
+                    keyCertificate = changeCertificate,
                     assetId = changeAssetId,
                     amount = changeNote.canonicalAmount,
                 )
@@ -1621,7 +1660,7 @@ class OfflineNoteWallet @JvmOverloads constructor(
             "only spendable Offline Note notes can be redeemed"
         }
         val bearerAuditTrail = bearerAuditTrail(current)
-        requireTrustedCertificate(current.keyCertificate, current.accountId)
+        requireTrustedCertificateForOrigin(current.keyCertificate, current.origin, current.accountId)
         val inputNullifier = deriveInputNullifier(current)
         val redeemPublicInputs = OfflineNote.RedeemPublicInputs(
             sourceNoteCommitment = current.noteCommitment(),
@@ -1642,7 +1681,7 @@ class OfflineNoteWallet @JvmOverloads constructor(
         )
         val redemption = draft.replacingRecursiveProof(proofProvider.proveRedeem(draft))
         redemption.validateProofBinding()
-        requireTrustedCertificate(redemption.senderKeyCertificate, current.accountId)
+        requireTrustedCertificateForOrigin(redemption.senderKeyCertificate, current.origin, current.accountId)
         require(proofVerifier.verifyRedeem(redemption)) {
             "Offline Note recursive redeem proof verification failed"
         }
@@ -1829,30 +1868,77 @@ class OfflineNoteWallet @JvmOverloads constructor(
     }
 
     private fun requireTrustedAuditCertificates(audit: OfflineNote.AuditBundle) {
-        requireTrustedCertificate(audit.senderKeyCertificate, null)
+        requireTrustedEitherCertificate(audit.senderKeyCertificate, null)
         val senderHash = audit.senderKeyCertificate.payloadHash()
         audit.inputClaims.forEach { input ->
             require(input.keyCertificatePayloadHash().contentEquals(senderHash)) {
                 "Offline Note input claim certificate does not match sender certificate"
             }
-            requireTrustedCertificate(audit.senderKeyCertificate, assetAccount(input.assetId))
+            requireTrustedEitherCertificate(audit.senderKeyCertificate, assetAccount(input.assetId))
         }
         audit.outputClaims.forEach { output ->
-            requireTrustedCertificate(output.keyCertificate, assetAccount(output.assetId))
+            requireTrustedOwnerCertificate(output.keyCertificate, assetAccount(output.assetId))
         }
     }
 
-    private fun requireTrustedCertificate(
+    private fun requireTrustedCertificateForOrigin(
+        certificate: OfflineNote.KeyCertificate,
+        origin: OfflineNote.CommitmentOrigin,
+        expectedAccountId: String?,
+    ) {
+        when (origin) {
+            is OfflineNote.CommitmentOrigin.IssuerLoad ->
+                requireTrustedIssuerCertificate(certificate, expectedAccountId)
+            is OfflineNote.CommitmentOrigin.P2pOutput ->
+                requireTrustedOwnerCertificate(certificate, expectedAccountId)
+        }
+    }
+
+    private fun requireTrustedIssuerCertificate(
+        certificate: OfflineNote.KeyCertificate,
+        expectedAccountId: String?,
+    ) {
+        requireMatchingAccount(certificate, expectedAccountId)
+        require(certificateVerifier.verifyIssuerCertificate(certificate)) {
+            "Offline Note key certificate is not trusted for this wallet operation"
+        }
+    }
+
+    private fun requireTrustedOwnerCertificate(
+        certificate: OfflineNote.KeyCertificate,
+        expectedAccountId: String?,
+    ) {
+        requireMatchingAccount(certificate, expectedAccountId)
+        require(certificateVerifier.verifyOwnerCertificate(certificate)) {
+            "Offline Note key certificate is not trusted for this wallet operation"
+        }
+    }
+
+    private fun requireTrustedEitherCertificate(
+        certificate: OfflineNote.KeyCertificate,
+        expectedAccountId: String?,
+    ) {
+        requireMatchingAccount(certificate, expectedAccountId)
+        require(
+            certificateVerifier.verifyIssuerCertificate(certificate) ||
+                certificateVerifier.verifyOwnerCertificate(certificate)
+        ) {
+            "Offline Note key certificate is not trusted for this wallet operation"
+        }
+    }
+
+    private fun requireMatchingAccount(
         certificate: OfflineNote.KeyCertificate,
         expectedAccountId: String?,
     ) {
         require(expectedAccountId == null || certificate.accountId == expectedAccountId) {
             "Offline Note key certificate account does not match wallet operation"
         }
-        require(certificateVerifier.verifyCertificate(certificate)) {
-            "Offline Note key certificate is not trusted for this wallet operation"
-        }
     }
+
+    private fun requireOwnerCertificateSigner(): OfflineNoteOwnerCertificateSigner =
+        ownerCertificateSigner
+            ?: throw IllegalStateException("Offline Note owner certificate signer is required for P2P outputs")
 
     private fun random32(): ByteArray {
         val bytes = randomSource.nextBytes(32)

--- a/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/offline/OfflineNoteTest.kt
+++ b/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/offline/OfflineNoteTest.kt
@@ -6,8 +6,10 @@ import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.charset.StandardCharsets
 import java.security.KeyPairGenerator
+import java.security.SecureRandom
 import java.util.Base64
 import java.util.Locale
+import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
 import java.util.concurrent.CountDownLatch
@@ -24,6 +26,12 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import org.bouncycastle.crypto.generators.Ed25519KeyPairGenerator
+import org.bouncycastle.crypto.params.Ed25519KeyGenerationParameters
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
+import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
+import org.bouncycastle.crypto.signers.Ed25519Signer
+import org.hyperledger.iroha.sdk.address.AccountAddress
 import org.hyperledger.iroha.sdk.client.ClientResponse
 import org.hyperledger.iroha.sdk.client.HttpTransportExecutor
 import org.hyperledger.iroha.sdk.client.JsonEncoder
@@ -43,7 +51,8 @@ class OfflineNoteTest {
 
         assertEquals(string(certificates, "sender_payload_base64"), base64(sender.signingBytes()))
         assertEquals(string(certificates, "sender_payload_hash"), hex(sender.payloadHash()))
-        assertTrue(verifier.verifyCertificate(sender))
+        assertTrue(verifier.verifyIssuerCertificate(sender))
+        assertFalse(verifier.verifyOwnerCertificate(sender))
 
         val tamperedSignature = sender.issuerSignature()
         tamperedSignature[0] = (tamperedSignature[0].toInt() xor 0x01).toByte()
@@ -61,11 +70,22 @@ class OfflineNoteTest {
             oneUse = sender.oneUse,
             issuerSignature = tamperedSignature,
         )
-        assertFalse(verifier.verifyCertificate(tampered))
-        assertFalse(RejectingOfflineNoteCertificateVerifier().verifyCertificate(sender))
+        assertFalse(verifier.verifyIssuerCertificate(tampered))
+        assertFalse(RejectingOfflineNoteCertificateVerifier().verifyIssuerCertificate(sender))
+        assertFalse(RejectingOfflineNoteCertificateVerifier().verifyOwnerCertificate(sender))
         assertFalse(
             Ed25519OfflineNoteCertificateVerifier(listOf(ByteArray(32) { 0x42.toByte() }))
-                .verifyCertificate(sender)
+                .verifyIssuerCertificate(sender)
+        )
+
+        val ownerSigner = TestOwnerCertificateSigner()
+        val ownerCertificate = ownerSigner.freshOwnerCertificate(ownerSigner.accountId)
+        assertEquals(ownerSigner.accountId, ownerCertificate.accountId)
+        assertTrue(verifier.verifyOwnerCertificate(ownerCertificate))
+        assertFalse(verifier.verifyIssuerCertificate(ownerCertificate))
+        val secondOwnerCertificate = ownerSigner.freshOwnerCertificate(ownerSigner.accountId)
+        assertFalse(
+            ownerCertificate.publicKey().contentEquals(secondOwnerCertificate.publicKey())
         )
     }
 
@@ -133,146 +153,46 @@ class OfflineNoteTest {
 
     @Test
     fun kagemushaRecordBackedNativeProverValidatesInput() {
-        val oversizedArchive = ByteArray(KagemushaCompactPaymentTokenProver.NATIVE_ARCHIVE_MAX_BYTES + 1)
-        val empty = assertFailsWith<IllegalArgumentException> {
+        assertFailsWith<IllegalArgumentException> {
             KagemushaCompactPaymentTokenProver.proveVerifiedCompactPaymentTokenWithRecords(ByteArray(0))
         }
-        assertTrue(empty.message.orEmpty().contains("recordBundleArchive must not be empty"))
-        val oversized = assertFailsWith<IllegalArgumentException> {
-            KagemushaCompactPaymentTokenProver.proveVerifiedCompactPaymentTokenWithRecords(oversizedArchive)
+        if (KagemushaCompactPaymentTokenProver.isNativeAvailable()) {
+            assertFailsWith<IllegalArgumentException> {
+                KagemushaCompactPaymentTokenProver
+                    .proveVerifiedCompactPaymentTokenWithRecords(byteArrayOf(0x01, 0x02))
+            }
         }
-        assertTrue(oversized.message.orEmpty().contains("recordBundleArchive must not exceed"))
-        val malformed = assertFailsWith<IllegalArgumentException> {
-            KagemushaCompactPaymentTokenProver
-                .proveVerifiedCompactPaymentTokenWithRecords(byteArrayOf(0x01, 0x02))
-        }
-        assertTrue(malformed.message.orEmpty().contains("recordBundleArchive must be a valid Norito archive"))
-        val emptyPayload = assertFailsWith<IllegalArgumentException> {
-            KagemushaCompactPaymentTokenProver
-                .proveVerifiedCompactPaymentTokenWithRecords(kagemushaNoritoFrame(0x4b))
-        }
-        assertTrue(emptyPayload.message.orEmpty().contains("recordBundleArchive must contain a non-empty Norito payload"))
-    }
-
-    @Test
-    fun kagemushaRecordBackedNativeProversRejectJavaNullsWithStableFieldMarkers() {
-        val validArchive = kagemushaNoritoFrameWithPayload(0x4b)
-        val compactNull = assertFailsWith<IllegalArgumentException> {
-            KagemushaCompactPaymentTokenProver.proveVerifiedCompactPaymentTokenWithRecords(null)
-        }
-        assertTrue(compactNull.message.orEmpty().contains("recordBundleArchive must not be empty"))
-        val aggregationRecordNull = assertFailsWith<IllegalArgumentException> {
-            KagemushaRecursiveAggregationProofBundleProver
-                .proveVerifiedRecursiveAggregationProofBundleWithRecordsAndPallasOpenEnvelopes(
-                    null,
-                    validArchive,
-                )
-        }
-        assertTrue(aggregationRecordNull.message.orEmpty().contains("recordBundleArchive must not be empty"))
-        val aggregationPallasNull = assertFailsWith<IllegalArgumentException> {
-            KagemushaRecursiveAggregationProofBundleProver
-                .proveVerifiedRecursiveAggregationProofBundleWithRecordsAndPallasOpenEnvelopes(
-                    validArchive,
-                    null,
-                )
-        }
-        assertTrue(aggregationPallasNull.message.orEmpty().contains("pallasOpenEnvelopesArchive must not be empty"))
-    }
-
-    @Test
-    fun kagemushaCompactNativeInputCopiesBeforeDispatch() {
-        val archive = kagemushaNoritoFrameWithPayload(0x4c)
-        val expected = archive.copyOf()
-        val ownedArchive = KagemushaCompactPaymentTokenProver.ownedNativeInput(
-            archive,
-            "recordBundleArchive",
-        )
-
-        archive[6] = 0x7f.toByte()
-
-        assertFalse(ownedArchive === archive)
-        assertContentEquals(expected, ownedArchive)
     }
 
     @Test
     fun kagemushaRecursiveAggregationNativeProverValidatesInput() {
-        val validArchive = kagemushaNoritoFrameWithPayload(0x4b)
-        val oversizedArchive = ByteArray(KagemushaCompactPaymentTokenProver.NATIVE_ARCHIVE_MAX_BYTES + 1)
-        val emptyRecord = assertFailsWith<IllegalArgumentException> {
+        assertFailsWith<IllegalArgumentException> {
             KagemushaRecursiveAggregationProofBundleProver
                 .proveVerifiedRecursiveAggregationProofBundleWithRecordsAndPallasOpenEnvelopes(
                     ByteArray(0),
-                    validArchive,
+                    byteArrayOf(0x01),
                 )
         }
-        assertTrue(emptyRecord.message.orEmpty().contains("recordBundleArchive must not be empty"))
-        val emptyPallas = assertFailsWith<IllegalArgumentException> {
+        assertFailsWith<IllegalArgumentException> {
             KagemushaRecursiveAggregationProofBundleProver
                 .proveVerifiedRecursiveAggregationProofBundleWithRecordsAndPallasOpenEnvelopes(
-                    validArchive,
+                    byteArrayOf(0x01),
                     ByteArray(0),
                 )
         }
-        assertTrue(emptyPallas.message.orEmpty().contains("pallasOpenEnvelopesArchive must not be empty"))
-        val oversizedRecord = assertFailsWith<IllegalArgumentException> {
-            KagemushaRecursiveAggregationProofBundleProver
-                .proveVerifiedRecursiveAggregationProofBundleWithRecordsAndPallasOpenEnvelopes(
-                    oversizedArchive,
-                    validArchive,
-                )
+        if (KagemushaRecursiveAggregationProofBundleProver.isNativeAvailable()) {
+            assertFailsWith<IllegalArgumentException> {
+                KagemushaRecursiveAggregationProofBundleProver
+                    .proveVerifiedRecursiveAggregationProofBundleWithRecordsAndPallasOpenEnvelopes(
+                        byteArrayOf(0x01, 0x02),
+                        byteArrayOf(0x03, 0x04),
+                    )
+            }
         }
-        assertTrue(oversizedRecord.message.orEmpty().contains("recordBundleArchive must not exceed"))
-        val oversizedPallas = assertFailsWith<IllegalArgumentException> {
-            KagemushaRecursiveAggregationProofBundleProver
-                .proveVerifiedRecursiveAggregationProofBundleWithRecordsAndPallasOpenEnvelopes(
-                    validArchive,
-                    oversizedArchive,
-                )
-        }
-        assertTrue(oversizedPallas.message.orEmpty().contains("pallasOpenEnvelopesArchive must not exceed"))
-        val malformedRecord = assertFailsWith<IllegalArgumentException> {
-            KagemushaRecursiveAggregationProofBundleProver
-                .proveVerifiedRecursiveAggregationProofBundleWithRecordsAndPallasOpenEnvelopes(
-                    byteArrayOf(0x01, 0x02),
-                    validArchive,
-                )
-        }
-        assertTrue(malformedRecord.message.orEmpty().contains("recordBundleArchive must be a valid Norito archive"))
-        val malformedPallas = assertFailsWith<IllegalArgumentException> {
-            KagemushaRecursiveAggregationProofBundleProver
-                .proveVerifiedRecursiveAggregationProofBundleWithRecordsAndPallasOpenEnvelopes(
-                    validArchive,
-                    byteArrayOf(0x01, 0x02),
-                )
-        }
-        assertTrue(malformedPallas.message.orEmpty().contains("pallasOpenEnvelopesArchive must be a valid Norito archive"))
-        val emptyPayloadRecord = assertFailsWith<IllegalArgumentException> {
-            KagemushaRecursiveAggregationProofBundleProver
-                .proveVerifiedRecursiveAggregationProofBundleWithRecordsAndPallasOpenEnvelopes(
-                    kagemushaNoritoFrame(0x4b),
-                    validArchive,
-                )
-        }
-        assertTrue(emptyPayloadRecord.message.orEmpty().contains("recordBundleArchive must contain a non-empty Norito payload"))
-        val emptyPayloadPallas = assertFailsWith<IllegalArgumentException> {
-            KagemushaRecursiveAggregationProofBundleProver
-                .proveVerifiedRecursiveAggregationProofBundleWithRecordsAndPallasOpenEnvelopes(
-                    validArchive,
-                    kagemushaNoritoFrame(0x4b),
-                )
-        }
-        assertTrue(emptyPayloadPallas.message.orEmpty().contains("pallasOpenEnvelopesArchive must contain a non-empty Norito payload"))
     }
 
     @Test
     fun kagemushaRecursiveSpendNativeProverValidatesInput() {
-        assertEquals(
-            "recursive_spend_v1",
-            KagemushaRecursiveSpendProver.preferredMode(
-                recursiveCompactAvailable = true,
-                recursiveSpendAvailable = true,
-            ).wireName,
-        )
         assertEquals(
             "recursive_spend_v1",
             KagemushaRecursiveSpendProver.preferredMode(true).wireName,
@@ -430,37 +350,10 @@ class OfflineNoteTest {
         }
         assertTrue(empty.message!!.contains("returned empty output"))
 
-        val oversized = assertFailsWith<IllegalStateException> {
-            KagemushaCompactPaymentTokenProver.requireNativeOutput(
-                ByteArray(KagemushaCompactPaymentTokenProver.NATIVE_ARCHIVE_MAX_BYTES + 1),
-                "native test",
-            )
-        }
-        assertTrue(oversized.message!!.contains("returned oversized output"))
-
-        val malformed = assertFailsWith<IllegalStateException> {
-            KagemushaCompactPaymentTokenProver.requireNativeOutput(
-                byteArrayOf(0x01, 0x02),
-                "native test",
-            )
-        }
-        assertTrue(malformed.message!!.contains("returned invalid Norito archive"))
-
-        val emptyPayload = assertFailsWith<IllegalStateException> {
-            KagemushaCompactPaymentTokenProver.requireNativeOutput(
-                kagemushaNoritoFrame(0x4b),
-                "native test",
-            )
-        }
-        assertTrue(emptyPayload.message!!.contains("returned empty Norito payload"))
-
-        val output = kagemushaNoritoFrameWithPayload(0x4b)
+        val validOutput = issue(loadFixture()).noritoEncoded()
         assertContentEquals(
-            output,
-            KagemushaCompactPaymentTokenProver.requireNativeOutput(
-                output,
-                "native test",
-            ),
+            validOutput,
+            KagemushaCompactPaymentTokenProver.requireNativeOutput(validOutput, "native test"),
         )
     }
 
@@ -2164,40 +2057,73 @@ class OfflineNoteTest {
     }
 
     @Test
-    fun walletAcceptsCanonicalSdkInteropPaymentToken() {
+    fun walletAcceptsOwnerCertPaymentTokenFromSender() {
         val fixture = loadFixture()
-        val derivation = obj(obj(fixture, "chain_vectors"), "derivation")
-        val recipientCertificate = certificate(obj(obj(fixture, "payment_token"), "recipient_key_certificate"))
+        val chain = obj(fixture, "chain_vectors")
+        val chainId = string(obj(chain, "derivation"), "chain_id")
+        val assetDefinitionId = assetDefinitionFromAssetId(string(obj(chain, "issue"), "asset_id"))
+        val amount = string(obj(chain, "redeem"), "amount")
+        val testIssuer = TestIssuerCertificateSigner()
+        val verifier = Ed25519OfflineNoteCertificateVerifier(listOf(testIssuer.publicKey))
+        val senderSigner = TestOwnerCertificateSigner()
+        val recipientSigner = TestOwnerCertificateSigner()
+        val senderStore = InMemoryOfflineNoteStore()
+        senderStore.upsert(
+            issuerSourceWalletNote(
+                chainId = chainId,
+                accountId = senderSigner.accountId,
+                assetDefinitionId = assetDefinitionId,
+                amount = amount,
+                issuerCertificate = testIssuer.issuerCertificate(senderSigner.accountId),
+                noteSecret = ByteArray(32) { 0x12.toByte() },
+                operationSuffix = "accept-source",
+                createdAtMs = 1_700_000_000_000L,
+            )
+        )
+        val senderWallet = OfflineNoteWallet(
+            chainId = chainId,
+            accountId = senderSigner.accountId,
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(senderSigner.accountId)),
+            ownerCertificateSigner = senderSigner,
+            store = senderStore,
+            transactionSubmitter = RecordingTransactionSubmitter(),
+            proofProvider = BindingProofProvider,
+            proofVerifier = BindingProofVerifier,
+            certificateVerifier = verifier,
+            randomSource = QueueRandomSource(listOf(ByteArray(32) { 0x23.toByte() })),
+            idGenerator = FixedIdGenerator(string(obj(chain, "derivation"), "payment_request_id")),
+            clock = { 1_700_000_001_000L },
+        )
         val recipientStore = InMemoryOfflineNoteStore()
         val recipientWallet = OfflineNoteWallet(
-            chainId = string(derivation, "chain_id"),
-            accountId = string(obj(fixture, "payment_token"), "recipient_account_id"),
-            attestationProvider = StaticAttestationProvider(recipientCertificate),
+            chainId = chainId,
+            accountId = recipientSigner.accountId,
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(recipientSigner.accountId)),
+            ownerCertificateSigner = recipientSigner,
             store = recipientStore,
             transactionSubmitter = RecordingTransactionSubmitter(),
             proofProvider = BindingProofProvider,
             proofVerifier = BindingProofVerifier,
-            certificateVerifier = certificateVerifier(fixture),
-            randomSource = QueueRandomSource(listOf(hexBytes(string(derivation, "recipient_note_secret_hex")))),
-            idGenerator = FixedIdGenerator(string(derivation, "payment_request_id")),
+            certificateVerifier = verifier,
+            randomSource = QueueRandomSource(listOf(ByteArray(32) { 0x33.toByte() })),
+            idGenerator = FixedIdGenerator(string(obj(chain, "derivation"), "payment_request_id")),
             clock = LongSupplier { 1_700_000_001_200L },
         )
         val receiveRequest = recipientWallet.prepareReceive(
-            assetDefinitionId = assetDefinitionFromAssetId(string(obj(obj(fixture, "chain_vectors"), "issue"), "asset_id")),
-            amount = string(obj(obj(fixture, "chain_vectors"), "redeem"), "amount"),
+            assetDefinitionId = assetDefinitionId,
+            amount = amount,
         )
-        assertEquals(string(derivation, "recipient_output_commitment"), receiveRequest.outputCommitmentHex())
+        assertEquals(recipientSigner.accountId, receiveRequest.keyCertificate.accountId)
 
-        val token = OfflineNotePaymentTokenCodec.decodeNorito(
-            base64Bytes(string(obj(fixture, "sdk_interop"), "payment_token_norito_base64"))
-        )
+        val token = senderWallet.pay(receiveRequest)
+        assertEquals(1, token.audit.outputClaims.size)
         val accepted = recipientWallet.accept(token)
 
-        assertEquals(string(derivation, "recipient_output_commitment"), accepted.noteCommitmentHex())
+        assertContentEquals(receiveRequest.outputCommitment(), accepted.noteCommitment())
         assertEquals(OfflineNoteWalletNoteState.SPENDABLE, accepted.state)
         assertEquals(
             OfflineNoteWalletNoteState.SPENDABLE,
-            recipientStore.findNote(hexBytes(string(derivation, "recipient_output_commitment")))?.state,
+            recipientStore.findNote(receiveRequest.outputCommitment())?.state,
         )
     }
 
@@ -2205,29 +2131,59 @@ class OfflineNoteTest {
     fun walletRejectsBearerCashCustodyPolicyOverflow() {
         val fixture = loadFixture()
         val chain = obj(fixture, "chain_vectors")
-        val derivation = obj(chain, "derivation")
-        val recipientCertificate = certificate(obj(obj(fixture, "payment_token"), "recipient_key_certificate"))
-        val recipientWallet = OfflineNoteWallet(
-            chainId = string(derivation, "chain_id"),
-            accountId = string(obj(fixture, "payment_token"), "recipient_account_id"),
-            attestationProvider = StaticAttestationProvider(recipientCertificate),
+        val chainId = string(obj(chain, "derivation"), "chain_id")
+        val assetDefinitionId = assetDefinitionFromAssetId(string(obj(chain, "issue"), "asset_id"))
+        val amount = string(obj(chain, "redeem"), "amount")
+        val testIssuer = TestIssuerCertificateSigner()
+        val verifier = Ed25519OfflineNoteCertificateVerifier(listOf(testIssuer.publicKey))
+        val senderSigner = TestOwnerCertificateSigner()
+        val recipientSigner = TestOwnerCertificateSigner()
+        val senderStore = InMemoryOfflineNoteStore()
+        senderStore.upsert(
+            issuerSourceWalletNote(
+                chainId = chainId,
+                accountId = senderSigner.accountId,
+                assetDefinitionId = assetDefinitionId,
+                amount = amount,
+                issuerCertificate = testIssuer.issuerCertificate(senderSigner.accountId),
+                noteSecret = ByteArray(32) { 0x13.toByte() },
+                operationSuffix = "custody-source",
+                createdAtMs = 1_700_000_000_000L,
+            )
+        )
+        val senderWallet = OfflineNoteWallet(
+            chainId = chainId,
+            accountId = senderSigner.accountId,
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(senderSigner.accountId)),
+            ownerCertificateSigner = senderSigner,
+            store = senderStore,
             transactionSubmitter = RecordingTransactionSubmitter(),
             proofProvider = BindingProofProvider,
             proofVerifier = BindingProofVerifier,
-            certificateVerifier = certificateVerifier(fixture),
-            randomSource = QueueRandomSource(listOf(hexBytes(string(derivation, "recipient_note_secret_hex")))),
-            idGenerator = FixedIdGenerator(string(derivation, "payment_request_id")),
+            certificateVerifier = verifier,
+            randomSource = QueueRandomSource(listOf(ByteArray(32) { 0x24.toByte() })),
+            idGenerator = FixedIdGenerator(string(obj(chain, "derivation"), "payment_request_id")),
+            clock = { 1_700_000_001_000L },
+        )
+        val recipientWallet = OfflineNoteWallet(
+            chainId = chainId,
+            accountId = recipientSigner.accountId,
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(recipientSigner.accountId)),
+            ownerCertificateSigner = recipientSigner,
+            transactionSubmitter = RecordingTransactionSubmitter(),
+            proofProvider = BindingProofProvider,
+            proofVerifier = BindingProofVerifier,
+            certificateVerifier = verifier,
+            randomSource = QueueRandomSource(listOf(ByteArray(32) { 0x34.toByte() })),
+            idGenerator = FixedIdGenerator(string(obj(chain, "derivation"), "payment_request_id")),
             clock = LongSupplier { 1_700_000_001_250L },
             bearerCashPolicy = OfflineBearerCashPolicyV1(maxCustodyHops = 1),
         )
         val receiveRequest = recipientWallet.prepareReceive(
-            assetDefinitionId = assetDefinitionFromAssetId(string(obj(chain, "issue"), "asset_id")),
-            amount = string(obj(chain, "redeem"), "amount"),
+            assetDefinitionId = assetDefinitionId,
+            amount = amount,
         )
-        assertEquals(string(derivation, "recipient_output_commitment"), receiveRequest.outputCommitmentHex())
-        val token = OfflineNotePaymentTokenCodec.decodeNorito(
-            base64Bytes(string(obj(fixture, "sdk_interop"), "payment_token_norito_base64"))
-        )
+        val token = senderWallet.pay(receiveRequest)
         val ancestor = ancestorAuditProducingFirstInput(token.audit, 0xC0)
         val overLimit = paymentTokenReplacingBearerAuditTrail(token, listOf(ancestor, token.audit))
 
@@ -2254,6 +2210,7 @@ class OfflineNoteTest {
             chainId = string(derivation, "chain_id"),
             accountId = accountFromAssetId(string(issue, "asset_id")),
             attestationProvider = StaticAttestationProvider(senderCertificate),
+            ownerCertificateSigner = TestOwnerCertificateSigner(),
             issuerClient = issuerClient,
             transactionSubmitter = RecordingTransactionSubmitter(),
             proofProvider = BindingProofProvider,
@@ -2293,6 +2250,7 @@ class OfflineNoteTest {
             chainId = string(derivation, "chain_id"),
             accountId = accountId,
             attestationProvider = StaticAttestationProvider(senderCertificate),
+            ownerCertificateSigner = TestOwnerCertificateSigner(),
             store = store,
             issuerClient = issuerClient,
             transactionSubmitter = RecordingTransactionSubmitter(),
@@ -2352,6 +2310,7 @@ class OfflineNoteTest {
             chainId = string(derivation, "chain_id"),
             accountId = accountId,
             attestationProvider = StaticAttestationProvider(senderCertificate),
+            ownerCertificateSigner = TestOwnerCertificateSigner(),
             issuerClient = SynchronouslyThrowingIssuerClient(loadContext),
             transactionSubmitter = RecordingTransactionSubmitter(),
             proofProvider = BindingProofProvider,
@@ -2524,71 +2483,99 @@ class OfflineNoteTest {
         val chain = obj(fixture, "chain_vectors")
         val derivation = obj(chain, "derivation")
         val chainIssue = obj(chain, "issue")
-        val chainAudit = obj(chain, "audit")
-        val chainRedeem = obj(chain, "redeem")
-        val payment = obj(fixture, "payment_token")
-        val senderCertificate = certificate(obj(payment, "sender_key_certificate"))
-        val recipientCertificate = certificate(obj(payment, "recipient_key_certificate"))
-        val sourceNote = sourceWalletNote(fixture, senderCertificate)
+        val chainId = string(derivation, "chain_id")
+        val assetDefinitionId = assetDefinitionFromAssetId(string(chainIssue, "asset_id"))
+        val testIssuer = TestIssuerCertificateSigner()
+        val verifier = Ed25519OfflineNoteCertificateVerifier(listOf(testIssuer.publicKey))
+        val senderSigner = TestOwnerCertificateSigner()
+        val recipientSigner = TestOwnerCertificateSigner()
+        val sourceNote = issuerSourceWalletNote(
+            chainId = chainId,
+            accountId = senderSigner.accountId,
+            assetDefinitionId = assetDefinitionId,
+            amount = string(chainIssue, "amount"),
+            issuerCertificate = testIssuer.issuerCertificate(senderSigner.accountId),
+            noteSecret = ByteArray(32) { 0x11.toByte() },
+            operationSuffix = "lifecycle-source",
+            createdAtMs = 1_700_000_000_000L,
+        )
         val senderStore = InMemoryOfflineNoteStore()
         senderStore.upsert(sourceNote)
         val senderWallet = OfflineNoteWallet(
-            chainId = string(derivation, "chain_id"),
-            accountId = accountFromAssetId(string(chainIssue, "asset_id")),
-            attestationProvider = StaticAttestationProvider(senderCertificate),
+            chainId = chainId,
+            accountId = senderSigner.accountId,
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(senderSigner.accountId)),
+            ownerCertificateSigner = senderSigner,
             store = senderStore,
             transactionSubmitter = RecordingTransactionSubmitter(),
             proofProvider = BindingProofProvider,
             proofVerifier = BindingProofVerifier,
-            certificateVerifier = certificateVerifier(fixture),
+            certificateVerifier = verifier,
             randomSource = QueueRandomSource(
                 listOf(
-                    hexBytes(string(derivation, "token_nonce_hex")),
-                    hexBytes(string(derivation, "change_note_secret_hex")),
+                    ByteArray(32) { 0x21.toByte() },
+                    ByteArray(32) { 0x22.toByte() },
                 )
             ),
-            clock = { long(payment, "created_at_ms") },
+            idGenerator = FixedIdGenerator(string(derivation, "payment_request_id")),
+            clock = { long(obj(fixture, "payment_token"), "created_at_ms") },
         )
         val recipientSubmitter = RecordingTransactionSubmitter()
         val recipientWallet = OfflineNoteWallet(
-            chainId = string(derivation, "chain_id"),
-            accountId = string(payment, "recipient_account_id"),
-            attestationProvider = StaticAttestationProvider(recipientCertificate),
+            chainId = chainId,
+            accountId = recipientSigner.accountId,
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(recipientSigner.accountId)),
+            ownerCertificateSigner = recipientSigner,
             transactionSubmitter = recipientSubmitter,
             proofProvider = BindingProofProvider,
             proofVerifier = BindingProofVerifier,
-            certificateVerifier = certificateVerifier(fixture),
-            randomSource = QueueRandomSource(listOf(hexBytes(string(derivation, "recipient_note_secret_hex")))),
+            certificateVerifier = verifier,
+            randomSource = QueueRandomSource(listOf(ByteArray(32) { 0x31.toByte() })),
             idGenerator = FixedIdGenerator(string(derivation, "payment_request_id")),
             clock = { 1_700_000_001_200L },
         )
 
         val receiveRequest = recipientWallet.prepareReceive(
-            assetDefinitionId = assetDefinitionFromAssetId(string(chainIssue, "asset_id")),
-            amount = string(chainRedeem, "amount"),
+            assetDefinitionId = assetDefinitionId,
+            amount = chainRedeemAmount(fixture),
         )
-        assertEquals(string(derivation, "recipient_output_commitment"), receiveRequest.outputCommitmentHex())
+        assertEquals(recipientSigner.accountId, receiveRequest.keyCertificate.accountId)
+        assertTrue(verifier.verifyOwnerCertificate(receiveRequest.keyCertificate))
 
         val token = senderWallet.pay(receiveRequest)
 
-        assertEquals(string(derivation, "payment_token_id"), token.tokenIdHex())
-        assertEquals(string(chainAudit, "public_inputs_hash"), hex(token.audit.publicInputsHash()))
         assertEquals(string(derivation, "payment_request_id"), token.paymentRequestId)
+        assertEquals(2, token.audit.outputClaims.size)
+        val recipientOutput = token.audit.outputClaims[0]
+        val changeOutput = token.audit.outputClaims[1]
+        assertEquals(recipientSigner.accountId, recipientOutput.keyCertificate.accountId)
+        assertEquals(senderSigner.accountId, changeOutput.keyCertificate.accountId)
+        assertTrue(verifier.verifyOwnerCertificate(recipientOutput.keyCertificate))
+        assertTrue(verifier.verifyOwnerCertificate(changeOutput.keyCertificate))
+        assertFalse(
+            recipientOutput.keyCertificate.payloadHash()
+                .contentEquals(token.audit.senderKeyCertificate.payloadHash())
+        )
+        assertFalse(
+            changeOutput.keyCertificate.payloadHash()
+                .contentEquals(token.audit.senderKeyCertificate.payloadHash())
+        )
         val auditMetrics = OfflineBearerCashPolicyV1.DEFAULT.auditTrailMetrics(token.bearerAuditTrail(), token.audit)
         assertEquals(1, auditMetrics.custodyHops)
         assertEquals(1, auditMetrics.lineageSteps)
         assertEquals(
             OfflineNoteWalletNoteState.SPENT,
-            senderStore.findNote(hexBytes(string(derivation, "source_note_commitment")))?.state,
+            senderStore.findNote(sourceNote.noteCommitment())?.state,
         )
         assertEquals(
             OfflineNoteWalletNoteState.SPENDABLE,
-            senderStore.findNote(hexBytes(string(derivation, "change_output_commitment")))?.state,
+            senderStore.findNote(changeOutput.noteCommitment())?.state,
         )
 
         val accepted = recipientWallet.accept(token)
 
         assertEquals(OfflineNoteWalletNoteState.SPENDABLE, accepted.state)
+        assertContentEquals(recipientOutput.noteCommitment(), accepted.noteCommitment())
         assertEquals(0, recipientSubmitter.audits.size)
         recipientWallet.publishAudit(token).get()
         assertEquals(1, recipientSubmitter.audits.size)
@@ -2596,10 +2583,13 @@ class OfflineNoteTest {
         assertEquals(OfflineNoteWalletNoteState.REDEEM_PENDING, redeeming.state)
         assertEquals(0, recipientSubmitter.redemptions.size)
         assertEquals(1, recipientSubmitter.defunds.size)
-        assertEquals(string(chainRedeem, "public_inputs_hash"), hex(recipientSubmitter.defunds[0].first.publicInputsHash()))
+        assertContentEquals(accepted.noteCommitment(), recipientSubmitter.defunds[0].first.sourceNoteCommitment())
         assertEquals(1, recipientSubmitter.defunds[0].second.size)
         assertEquals(token.tokenIdHex(), hex(recipientSubmitter.defunds[0].second[0].tokenId()))
     }
+
+    private fun chainRedeemAmount(fixture: Map<String, Any?>): String =
+        string(obj(obj(fixture, "chain_vectors"), "redeem"), "amount")
 
     @Test
     fun walletRejectsExactAmountReceiveRequestReplayAfterRestart() {
@@ -2607,60 +2597,69 @@ class OfflineNoteTest {
         val chain = obj(fixture, "chain_vectors")
         val derivation = obj(chain, "derivation")
         val chainIssue = obj(chain, "issue")
-        val payment = obj(fixture, "payment_token")
-        val senderCertificate = certificate(obj(payment, "sender_key_certificate"))
-        val recipientCertificate = certificate(obj(payment, "recipient_key_certificate"))
-        val senderAccountId = accountFromAssetId(string(chainIssue, "asset_id"))
+        val chainId = string(derivation, "chain_id")
+        val assetDefinitionId = assetDefinitionFromAssetId(string(chainIssue, "asset_id"))
+        val amount = string(chainIssue, "amount")
+        val testIssuer = TestIssuerCertificateSigner()
+        val verifier = Ed25519OfflineNoteCertificateVerifier(listOf(testIssuer.publicKey))
+        val senderSigner = TestOwnerCertificateSigner()
+        val recipientSigner = TestOwnerCertificateSigner()
         val senderStore = InMemoryOfflineNoteStore()
-        senderStore.upsert(sourceWalletNote(fixture, senderCertificate))
         senderStore.upsert(
-            OfflineNoteWalletNote(
-                chainId = string(derivation, "chain_id"),
-                accountId = senderAccountId,
-                assetId = string(chainIssue, "asset_id"),
-                amount = string(chainIssue, "amount"),
-                keyCertificate = senderCertificate,
-                noteCommitment = ByteArray(32) { 0x71.toByte() },
-                noteSecret = ByteArray(32) { 0x72.toByte() },
-                origin = OfflineNote.CommitmentOrigin.IssuerLoad(
-                    operationId = "operation-extra-exact",
-                    lineageId = "lineage-extra-exact",
-                    localRevision = 2L,
-                ),
-                state = OfflineNoteWalletNoteState.SPENDABLE,
+            issuerSourceWalletNote(
+                chainId = chainId,
+                accountId = senderSigner.accountId,
+                assetDefinitionId = assetDefinitionId,
+                amount = amount,
+                issuerCertificate = testIssuer.issuerCertificate(senderSigner.accountId),
+                noteSecret = ByteArray(32) { 0x14.toByte() },
+                operationSuffix = "exact-source",
+                createdAtMs = 1_700_000_000_000L,
+            )
+        )
+        senderStore.upsert(
+            issuerSourceWalletNote(
+                chainId = chainId,
+                accountId = senderSigner.accountId,
+                assetDefinitionId = assetDefinitionId,
+                amount = amount,
+                issuerCertificate = testIssuer.issuerCertificate(senderSigner.accountId),
+                noteSecret = ByteArray(32) { 0x15.toByte() },
+                operationSuffix = "exact-source-extra",
                 createdAtMs = 1_700_000_000_100L,
-                updatedAtMs = 1_700_000_000_100L,
             )
         )
         val senderWallet = OfflineNoteWallet(
-            chainId = string(derivation, "chain_id"),
-            accountId = senderAccountId,
-            attestationProvider = StaticAttestationProvider(senderCertificate),
+            chainId = chainId,
+            accountId = senderSigner.accountId,
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(senderSigner.accountId)),
+            ownerCertificateSigner = senderSigner,
             store = senderStore,
             transactionSubmitter = RecordingTransactionSubmitter(),
             proofProvider = BindingProofProvider,
             proofVerifier = BindingProofVerifier,
-            certificateVerifier = certificateVerifier(fixture),
-            randomSource = QueueRandomSource(listOf(hexBytes(string(derivation, "token_nonce_hex")))),
+            certificateVerifier = verifier,
+            randomSource = QueueRandomSource(listOf(ByteArray(32) { 0x25.toByte() })),
             idGenerator = FixedIdGenerator(string(derivation, "payment_request_id")),
             clock = { 1_700_000_002_400L },
         )
         val recipientWallet = OfflineNoteWallet(
-            chainId = string(derivation, "chain_id"),
-            accountId = string(payment, "recipient_account_id"),
-            attestationProvider = StaticAttestationProvider(recipientCertificate),
+            chainId = chainId,
+            accountId = recipientSigner.accountId,
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(recipientSigner.accountId)),
+            ownerCertificateSigner = recipientSigner,
             transactionSubmitter = RecordingTransactionSubmitter(),
             proofProvider = BindingProofProvider,
             proofVerifier = BindingProofVerifier,
-            certificateVerifier = certificateVerifier(fixture),
-            randomSource = QueueRandomSource(listOf(hexBytes(string(derivation, "recipient_note_secret_hex")))),
+            certificateVerifier = verifier,
+            randomSource = QueueRandomSource(listOf(ByteArray(32) { 0x35.toByte() })),
             idGenerator = FixedIdGenerator(string(derivation, "payment_request_id")),
             clock = { 1_700_000_002_500L },
         )
 
         val receiveRequest = recipientWallet.prepareReceive(
-            assetDefinitionId = assetDefinitionFromAssetId(string(chainIssue, "asset_id")),
-            amount = string(chainIssue, "amount"),
+            assetDefinitionId = assetDefinitionId,
+            amount = amount,
         )
         senderWallet.pay(receiveRequest)
         val spentNotes = senderStore.listNotes().filter { it.state == OfflineNoteWalletNoteState.SPENT }
@@ -2670,14 +2669,15 @@ class OfflineNoteTest {
         val restoredStore = InMemoryOfflineNoteStore()
         senderStore.listNotes().forEach { restoredStore.upsert(it) }
         val restoredWallet = OfflineNoteWallet(
-            chainId = string(derivation, "chain_id"),
-            accountId = senderAccountId,
-            attestationProvider = StaticAttestationProvider(senderCertificate),
+            chainId = chainId,
+            accountId = senderSigner.accountId,
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(senderSigner.accountId)),
+            ownerCertificateSigner = senderSigner,
             store = restoredStore,
             transactionSubmitter = RecordingTransactionSubmitter(),
             proofProvider = BindingProofProvider,
             proofVerifier = BindingProofVerifier,
-            certificateVerifier = certificateVerifier(fixture),
+            certificateVerifier = verifier,
             randomSource = QueueRandomSource(emptyList()),
             idGenerator = FixedIdGenerator(string(derivation, "payment_request_id")),
             clock = { 1_700_000_002_600L },
@@ -2699,66 +2699,83 @@ class OfflineNoteTest {
         val derivation = obj(chain, "derivation")
         val chainIssue = obj(chain, "issue")
         val chainRedeem = obj(chain, "redeem")
-        val payment = obj(fixture, "payment_token")
-        val senderCertificate = certificate(obj(payment, "sender_key_certificate"))
-        val recipientCertificate = certificate(obj(payment, "recipient_key_certificate"))
+        val chainId = string(derivation, "chain_id")
+        val assetDefinitionId = assetDefinitionFromAssetId(string(chainIssue, "asset_id"))
+        val testIssuer = TestIssuerCertificateSigner()
+        val verifier = Ed25519OfflineNoteCertificateVerifier(listOf(testIssuer.publicKey))
+        val senderSigner = TestOwnerCertificateSigner()
+        val recipientSigner = TestOwnerCertificateSigner()
         val senderStore = InMemoryOfflineNoteStore()
-        senderStore.upsert(sourceWalletNote(fixture, senderCertificate))
-        val resolutions = linkedMapOf<String, OfflineNoteWalletNoteState>(
-            string(derivation, "source_note_commitment") to OfflineNoteWalletNoteState.SPENT,
-            string(derivation, "change_output_commitment") to OfflineNoteWalletNoteState.SPENDABLE,
+        val sourceNote = issuerSourceWalletNote(
+            chainId = chainId,
+            accountId = senderSigner.accountId,
+            assetDefinitionId = assetDefinitionId,
+            amount = string(chainIssue, "amount"),
+            issuerCertificate = testIssuer.issuerCertificate(senderSigner.accountId),
+            noteSecret = ByteArray(32) { 0x16.toByte() },
+            operationSuffix = "sync-source",
+            createdAtMs = 1_700_000_000_000L,
         )
+        senderStore.upsert(sourceNote)
+        val resolutions = linkedMapOf<String, OfflineNoteWalletNoteState>()
         val syncResolver = RecordingSyncResolver(resolutions)
         val senderWallet = OfflineNoteWallet(
-            chainId = string(derivation, "chain_id"),
-            accountId = accountFromAssetId(string(chainIssue, "asset_id")),
-            attestationProvider = StaticAttestationProvider(senderCertificate),
+            chainId = chainId,
+            accountId = senderSigner.accountId,
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(senderSigner.accountId)),
+            ownerCertificateSigner = senderSigner,
             store = senderStore,
             transactionSubmitter = RecordingTransactionSubmitter(),
             syncResolver = syncResolver,
             proofProvider = BindingProofProvider,
             proofVerifier = BindingProofVerifier,
-            certificateVerifier = certificateVerifier(fixture),
+            certificateVerifier = verifier,
             randomSource = QueueRandomSource(
                 listOf(
-                    hexBytes(string(derivation, "token_nonce_hex")),
-                    hexBytes(string(derivation, "change_note_secret_hex")),
+                    ByteArray(32) { 0x26.toByte() },
+                    ByteArray(32) { 0x27.toByte() },
                 )
             ),
             clock = { 1_700_000_002_000L },
         )
         val recipientWallet = OfflineNoteWallet(
-            chainId = string(derivation, "chain_id"),
-            accountId = string(payment, "recipient_account_id"),
-            attestationProvider = StaticAttestationProvider(recipientCertificate),
+            chainId = chainId,
+            accountId = recipientSigner.accountId,
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(recipientSigner.accountId)),
+            ownerCertificateSigner = recipientSigner,
             transactionSubmitter = RecordingTransactionSubmitter(),
             proofProvider = BindingProofProvider,
             proofVerifier = BindingProofVerifier,
-            certificateVerifier = certificateVerifier(fixture),
-            randomSource = QueueRandomSource(listOf(hexBytes(string(derivation, "recipient_note_secret_hex")))),
+            certificateVerifier = verifier,
+            randomSource = QueueRandomSource(listOf(ByteArray(32) { 0x36.toByte() })),
             idGenerator = FixedIdGenerator(string(derivation, "payment_request_id")),
             clock = { 1_700_000_002_100L },
         )
 
         val receiveRequest = recipientWallet.prepareReceive(
-            assetDefinitionId = assetDefinitionFromAssetId(string(chainIssue, "asset_id")),
+            assetDefinitionId = assetDefinitionId,
             amount = string(chainRedeem, "amount"),
         )
-        senderWallet.pay(receiveRequest)
+        val token = senderWallet.pay(receiveRequest)
+        val changeCommitment = token.audit.outputClaims[1].noteCommitment()
+        val sourceCommitmentHex = sourceNote.noteCommitmentHex()
+        val changeCommitmentHex = hex(changeCommitment)
+        resolutions[sourceCommitmentHex] = OfflineNoteWalletNoteState.SPENT
+        resolutions[changeCommitmentHex] = OfflineNoteWalletNoteState.SPENDABLE
         senderWallet.sync().get()
 
         assertEquals(
             OfflineNoteWalletNoteState.SPENT,
-            senderStore.findNote(hexBytes(string(derivation, "source_note_commitment")))?.state,
+            senderStore.findNote(sourceNote.noteCommitment())?.state,
         )
-        val spendableChange = senderStore.findNote(hexBytes(string(derivation, "change_output_commitment")))
+        val spendableChange = senderStore.findNote(changeCommitment)
         assertEquals(OfflineNoteWalletNoteState.SPENDABLE, spendableChange?.state)
         assertEquals(
             emptyList(),
             syncResolver.resolvedCommitments,
         )
 
-        resolutions[string(derivation, "change_output_commitment")] = OfflineNoteWalletNoteState.REDEEMED
+        resolutions[changeCommitmentHex] = OfflineNoteWalletNoteState.REDEEMED
         val redeeming = senderWallet.redeem(requireNotNull(spendableChange)).get()
         assertEquals(OfflineNoteWalletNoteState.REDEEM_PENDING, redeeming.state)
 
@@ -2766,7 +2783,7 @@ class OfflineNoteTest {
 
         assertEquals(
             OfflineNoteWalletNoteState.REDEEMED,
-            senderStore.findNote(hexBytes(string(derivation, "change_output_commitment")))?.state,
+            senderStore.findNote(changeCommitment)?.state,
         )
     }
 
@@ -2777,43 +2794,59 @@ class OfflineNoteTest {
         val derivation = obj(chain, "derivation")
         val chainIssue = obj(chain, "issue")
         val chainRedeem = obj(chain, "redeem")
-        val payment = obj(fixture, "payment_token")
-        val senderCertificate = certificate(obj(payment, "sender_key_certificate"))
-        val recipientCertificate = certificate(obj(payment, "recipient_key_certificate"))
+        val chainId = string(derivation, "chain_id")
+        val assetDefinitionId = assetDefinitionFromAssetId(string(chainIssue, "asset_id"))
+        val testIssuer = TestIssuerCertificateSigner()
+        val verifier = Ed25519OfflineNoteCertificateVerifier(listOf(testIssuer.publicKey))
+        val senderSigner = TestOwnerCertificateSigner()
+        val recipientSigner = TestOwnerCertificateSigner()
         val senderStore = InMemoryOfflineNoteStore()
-        senderStore.upsert(sourceWalletNote(fixture, senderCertificate))
+        senderStore.upsert(
+            issuerSourceWalletNote(
+                chainId = chainId,
+                accountId = senderSigner.accountId,
+                assetDefinitionId = assetDefinitionId,
+                amount = string(chainIssue, "amount"),
+                issuerCertificate = testIssuer.issuerCertificate(senderSigner.accountId),
+                noteSecret = ByteArray(32) { 0x17.toByte() },
+                operationSuffix = "duplicate-source",
+                createdAtMs = 1_700_000_000_000L,
+            )
+        )
         val senderWallet = OfflineNoteWallet(
-            chainId = string(derivation, "chain_id"),
-            accountId = accountFromAssetId(string(chainIssue, "asset_id")),
-            attestationProvider = StaticAttestationProvider(senderCertificate),
+            chainId = chainId,
+            accountId = senderSigner.accountId,
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(senderSigner.accountId)),
+            ownerCertificateSigner = senderSigner,
             store = senderStore,
             transactionSubmitter = RecordingTransactionSubmitter(),
             proofProvider = BindingProofProvider,
             proofVerifier = BindingProofVerifier,
-            certificateVerifier = certificateVerifier(fixture),
+            certificateVerifier = verifier,
             randomSource = QueueRandomSource(
                 listOf(
-                    hexBytes(string(derivation, "token_nonce_hex")),
-                    hexBytes(string(derivation, "change_note_secret_hex")),
+                    ByteArray(32) { 0x28.toByte() },
+                    ByteArray(32) { 0x29.toByte() },
                 )
             ),
             clock = { 1_700_000_002_200L },
         )
         val recipientWallet = OfflineNoteWallet(
-            chainId = string(derivation, "chain_id"),
-            accountId = string(payment, "recipient_account_id"),
-            attestationProvider = StaticAttestationProvider(recipientCertificate),
+            chainId = chainId,
+            accountId = recipientSigner.accountId,
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(recipientSigner.accountId)),
+            ownerCertificateSigner = recipientSigner,
             transactionSubmitter = RecordingTransactionSubmitter(),
             proofProvider = BindingProofProvider,
             proofVerifier = BindingProofVerifier,
-            certificateVerifier = certificateVerifier(fixture),
-            randomSource = QueueRandomSource(listOf(hexBytes(string(derivation, "recipient_note_secret_hex")))),
+            certificateVerifier = verifier,
+            randomSource = QueueRandomSource(listOf(ByteArray(32) { 0x37.toByte() })),
             idGenerator = FixedIdGenerator(string(derivation, "payment_request_id")),
             clock = { 1_700_000_002_300L },
         )
 
         val receiveRequest = recipientWallet.prepareReceive(
-            assetDefinitionId = assetDefinitionFromAssetId(string(chainIssue, "asset_id")),
+            assetDefinitionId = assetDefinitionId,
             amount = string(chainRedeem, "amount"),
         )
         val token = senderWallet.pay(receiveRequest)
@@ -2845,6 +2878,7 @@ class OfflineNoteTest {
             chainId = string(derivation, "chain_id"),
             accountId = accountFromAssetId(string(chainIssue, "asset_id")),
             attestationProvider = StaticAttestationProvider(senderCertificate),
+            ownerCertificateSigner = TestOwnerCertificateSigner(),
             store = store,
             transactionSubmitter = submitter,
             proofProvider = BindingProofProvider,
@@ -2878,15 +2912,27 @@ class OfflineNoteTest {
         val chainIssue = obj(chain, "issue")
         val chainRedeem = obj(chain, "redeem")
         val payment = obj(fixture, "payment_token")
-        val senderCertificate = certificate(obj(payment, "sender_key_certificate"))
-        val recipientCertificate = certificate(obj(payment, "recipient_key_certificate"))
-        val senderAccountId = accountFromAssetId(string(chainIssue, "asset_id"))
+        val chainId = string(derivation, "chain_id")
         val assetDefinitionId = assetDefinitionFromAssetId(string(chainIssue, "asset_id"))
+        val sourceAmount = string(chainIssue, "amount")
+        val receiveAmount = string(chainRedeem, "amount")
+        val testIssuer = TestIssuerCertificateSigner()
+        val verifier = Ed25519OfflineNoteCertificateVerifier(listOf(testIssuer.publicKey))
+        val senderSigner = TestOwnerCertificateSigner()
+        val recipientSigner = TestOwnerCertificateSigner()
+        val senderAccountId = senderSigner.accountId
+        // A cert minted by the trusted issuer but bound to the wrong account (used as a foreign cert).
+        val foreignIssuerCertificate = testIssuer.issuerCertificate(recipientSigner.accountId)
 
+        // A wallet whose default rejecting verifier blocks owner-cert minting in prepareReceive.
+        val defaultRejectingSigner = TestOwnerCertificateSigner()
         val defaultRejectingWallet = OfflineNoteWallet(
-            chainId = string(derivation, "chain_id"),
-            accountId = string(payment, "recipient_account_id"),
-            attestationProvider = StaticAttestationProvider(recipientCertificate),
+            chainId = chainId,
+            accountId = defaultRejectingSigner.accountId,
+            attestationProvider = StaticAttestationProvider(
+                testIssuer.issuerCertificate(defaultRejectingSigner.accountId)
+            ),
+            ownerCertificateSigner = defaultRejectingSigner,
             proofProvider = BindingProofProvider,
             randomSource = QueueRandomSource(emptyList()),
             idGenerator = FixedIdGenerator(string(derivation, "payment_request_id")),
@@ -2895,61 +2941,66 @@ class OfflineNoteTest {
         assertFailsWith<IllegalArgumentException> {
             defaultRejectingWallet.prepareReceive(
                 assetDefinitionId = assetDefinitionId,
-                amount = string(chainRedeem, "amount"),
+                amount = receiveAmount,
             )
         }
-        val wrongAccountReceiveWallet = OfflineNoteWallet(
-            chainId = string(derivation, "chain_id"),
+        // A wallet whose owner signer controls a different account than the wallet account, so
+        // prepareReceive cannot mint a self-signed certificate for the wallet account.
+        val mismatchedSignerWallet = OfflineNoteWallet(
+            chainId = chainId,
             accountId = senderAccountId,
-            attestationProvider = StaticAttestationProvider(recipientCertificate),
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(senderAccountId)),
+            ownerCertificateSigner = recipientSigner,
             proofProvider = BindingProofProvider,
-            certificateVerifier = certificateVerifier(fixture),
+            certificateVerifier = verifier,
             randomSource = QueueRandomSource(emptyList()),
             idGenerator = FixedIdGenerator(string(derivation, "payment_request_id")),
             clock = { 1_700_000_002_710L },
         )
         assertFailsWith<IllegalArgumentException> {
-            wrongAccountReceiveWallet.prepareReceive(
+            mismatchedSignerWallet.prepareReceive(
                 assetDefinitionId = assetDefinitionId,
-                amount = string(chainRedeem, "amount"),
+                amount = receiveAmount,
             )
         }
 
         val senderStore = InMemoryOfflineNoteStore()
-        senderStore.upsert(sourceWalletNote(fixture, senderCertificate))
+        senderStore.upsert(adversarialSourceNote(chainId, senderSigner, assetDefinitionId, sourceAmount, testIssuer, 0x51))
         val senderWallet = OfflineNoteWallet(
-            chainId = string(derivation, "chain_id"),
+            chainId = chainId,
             accountId = senderAccountId,
-            attestationProvider = StaticAttestationProvider(senderCertificate),
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(senderAccountId)),
+            ownerCertificateSigner = senderSigner,
             store = senderStore,
             transactionSubmitter = RecordingTransactionSubmitter(),
             proofProvider = BindingProofProvider,
             proofVerifier = BindingProofVerifier,
-            certificateVerifier = certificateVerifier(fixture),
+            certificateVerifier = verifier,
             randomSource = QueueRandomSource(
                 listOf(
-                    hexBytes(string(derivation, "token_nonce_hex")),
-                    hexBytes(string(derivation, "change_note_secret_hex")),
+                    ByteArray(32) { 0x52.toByte() },
+                    ByteArray(32) { 0x53.toByte() },
                 )
             ),
             idGenerator = FixedIdGenerator(string(derivation, "payment_request_id")),
             clock = { long(payment, "created_at_ms") },
         )
         val recipientWallet = OfflineNoteWallet(
-            chainId = string(derivation, "chain_id"),
-            accountId = string(payment, "recipient_account_id"),
-            attestationProvider = StaticAttestationProvider(recipientCertificate),
+            chainId = chainId,
+            accountId = recipientSigner.accountId,
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(recipientSigner.accountId)),
+            ownerCertificateSigner = recipientSigner,
             transactionSubmitter = RecordingTransactionSubmitter(),
             proofProvider = BindingProofProvider,
             proofVerifier = BindingProofVerifier,
-            certificateVerifier = certificateVerifier(fixture),
-            randomSource = QueueRandomSource(listOf(hexBytes(string(derivation, "recipient_note_secret_hex")))),
+            certificateVerifier = verifier,
+            randomSource = QueueRandomSource(listOf(ByteArray(32) { 0x54.toByte() })),
             idGenerator = FixedIdGenerator(string(derivation, "payment_request_id")),
             clock = { 1_700_000_002_800L },
         )
         val receiveRequest = recipientWallet.prepareReceive(
             assetDefinitionId = assetDefinitionId,
-            amount = string(chainRedeem, "amount"),
+            amount = receiveAmount,
         )
         val accountSubstitution = OfflineNoteReceiveRequest(
             chainId = receiveRequest.chainId,
@@ -2988,20 +3039,23 @@ class OfflineNoteTest {
             outputCommitment = receiveRequest.outputCommitment(),
         )
         val assetOwnerSubstitutionStore = InMemoryOfflineNoteStore()
-        assetOwnerSubstitutionStore.upsert(sourceWalletNote(fixture, senderCertificate))
+        assetOwnerSubstitutionStore.upsert(
+            adversarialSourceNote(chainId, senderSigner, assetDefinitionId, sourceAmount, testIssuer, 0x55)
+        )
         val assetOwnerSubstitutionSender = OfflineNoteWallet(
-            chainId = string(derivation, "chain_id"),
+            chainId = chainId,
             accountId = senderAccountId,
-            attestationProvider = StaticAttestationProvider(senderCertificate),
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(senderAccountId)),
+            ownerCertificateSigner = senderSigner,
             store = assetOwnerSubstitutionStore,
             transactionSubmitter = RecordingTransactionSubmitter(),
             proofProvider = BindingProofProvider,
             proofVerifier = BindingProofVerifier,
-            certificateVerifier = certificateVerifier(fixture),
+            certificateVerifier = verifier,
             randomSource = QueueRandomSource(
                 listOf(
-                    ByteArray(32) { 0x21.toByte() },
-                    ByteArray(32) { 0x22.toByte() },
+                    ByteArray(32) { 0x56.toByte() },
+                    ByteArray(32) { 0x57.toByte() },
                 )
             ),
             idGenerator = FixedIdGenerator(string(derivation, "payment_request_id")),
@@ -3012,16 +3066,26 @@ class OfflineNoteTest {
         }
 
         val forgedInputStore = InMemoryOfflineNoteStore()
-        forgedInputStore.upsert(sourceWalletNote(fixture, tamperedSignatureCertificate(senderCertificate)))
+        forgedInputStore.upsert(
+            adversarialSourceNote(
+                chainId,
+                senderSigner,
+                assetDefinitionId,
+                sourceAmount,
+                issuerCertificate = tamperedSignatureCertificate(testIssuer.issuerCertificate(senderAccountId)),
+                secretByte = 0x58,
+            )
+        )
         val forgedInputWallet = OfflineNoteWallet(
-            chainId = string(derivation, "chain_id"),
+            chainId = chainId,
             accountId = senderAccountId,
-            attestationProvider = StaticAttestationProvider(senderCertificate),
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(senderAccountId)),
+            ownerCertificateSigner = senderSigner,
             store = forgedInputStore,
             transactionSubmitter = RecordingTransactionSubmitter(),
             proofProvider = BindingProofProvider,
             proofVerifier = BindingProofVerifier,
-            certificateVerifier = certificateVerifier(fixture),
+            certificateVerifier = verifier,
             randomSource = QueueRandomSource(emptyList()),
             idGenerator = FixedIdGenerator(string(derivation, "payment_request_id")),
             clock = { 1_700_000_002_900L },
@@ -3030,16 +3094,26 @@ class OfflineNoteTest {
             forgedInputWallet.pay(receiveRequest)
         }
         val wrongAccountInputStore = InMemoryOfflineNoteStore()
-        wrongAccountInputStore.upsert(sourceWalletNote(fixture, recipientCertificate))
+        wrongAccountInputStore.upsert(
+            adversarialSourceNote(
+                chainId,
+                senderSigner,
+                assetDefinitionId,
+                sourceAmount,
+                issuerCertificate = foreignIssuerCertificate,
+                secretByte = 0x59,
+            )
+        )
         val wrongAccountInputWallet = OfflineNoteWallet(
-            chainId = string(derivation, "chain_id"),
+            chainId = chainId,
             accountId = senderAccountId,
-            attestationProvider = StaticAttestationProvider(senderCertificate),
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(senderAccountId)),
+            ownerCertificateSigner = senderSigner,
             store = wrongAccountInputStore,
             transactionSubmitter = RecordingTransactionSubmitter(),
             proofProvider = BindingProofProvider,
             proofVerifier = BindingProofVerifier,
-            certificateVerifier = certificateVerifier(fixture),
+            certificateVerifier = verifier,
             randomSource = QueueRandomSource(emptyList()),
             idGenerator = FixedIdGenerator(string(derivation, "payment_request_id")),
             clock = { 1_700_000_002_910L },
@@ -3048,20 +3122,23 @@ class OfflineNoteTest {
             wrongAccountInputWallet.pay(receiveRequest)
         }
         val commitmentSubstitutionStore = InMemoryOfflineNoteStore()
-        commitmentSubstitutionStore.upsert(sourceWalletNote(fixture, senderCertificate))
+        commitmentSubstitutionStore.upsert(
+            adversarialSourceNote(chainId, senderSigner, assetDefinitionId, sourceAmount, testIssuer, 0x5A)
+        )
         val commitmentSubstitutionSender = OfflineNoteWallet(
-            chainId = string(derivation, "chain_id"),
+            chainId = chainId,
             accountId = senderAccountId,
-            attestationProvider = StaticAttestationProvider(senderCertificate),
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(senderAccountId)),
+            ownerCertificateSigner = senderSigner,
             store = commitmentSubstitutionStore,
             transactionSubmitter = RecordingTransactionSubmitter(),
             proofProvider = BindingProofProvider,
             proofVerifier = BindingProofVerifier,
-            certificateVerifier = certificateVerifier(fixture),
+            certificateVerifier = verifier,
             randomSource = QueueRandomSource(
                 listOf(
-                    ByteArray(32) { 0x31.toByte() },
-                    ByteArray(32) { 0x32.toByte() },
+                    ByteArray(32) { 0x5B.toByte() },
+                    ByteArray(32) { 0x5C.toByte() },
                 )
             ),
             idGenerator = FixedIdGenerator(string(derivation, "payment_request_id")),
@@ -3082,20 +3159,23 @@ class OfflineNoteTest {
         }
         val forgedOutputAmount = if (receiveRequest.amount == "1") "2" else "1"
         val amountSubstitutionStore = InMemoryOfflineNoteStore()
-        amountSubstitutionStore.upsert(sourceWalletNote(fixture, senderCertificate))
+        amountSubstitutionStore.upsert(
+            adversarialSourceNote(chainId, senderSigner, assetDefinitionId, sourceAmount, testIssuer, 0x5D)
+        )
         val amountSubstitutionSender = OfflineNoteWallet(
-            chainId = string(derivation, "chain_id"),
+            chainId = chainId,
             accountId = senderAccountId,
-            attestationProvider = StaticAttestationProvider(senderCertificate),
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(senderAccountId)),
+            ownerCertificateSigner = senderSigner,
             store = amountSubstitutionStore,
             transactionSubmitter = RecordingTransactionSubmitter(),
             proofProvider = BindingProofProvider,
             proofVerifier = BindingProofVerifier,
-            certificateVerifier = certificateVerifier(fixture),
+            certificateVerifier = verifier,
             randomSource = QueueRandomSource(
                 listOf(
-                    ByteArray(32) { 0x41.toByte() },
-                    ByteArray(32) { 0x42.toByte() },
+                    ByteArray(32) { 0x5E.toByte() },
+                    ByteArray(32) { 0x5F.toByte() },
                 )
             ),
             idGenerator = FixedIdGenerator(string(derivation, "payment_request_id")),
@@ -3154,18 +3234,18 @@ class OfflineNoteTest {
             recipientWallet.accept(paymentTokenDroppingFirstOutput(token))
         }
         assertFailsWith<IllegalArgumentException> {
-            recipientWallet.accept(paymentTokenReplacingFirstOutputCertificate(token, senderCertificate))
+            recipientWallet.accept(paymentTokenReplacingFirstOutputCertificate(token, foreignIssuerCertificate))
         }
         assertFailsWith<IllegalArgumentException> {
-            recipientWallet.accept(paymentTokenReplacingLastOutputCertificate(token, recipientCertificate))
+            recipientWallet.accept(paymentTokenReplacingLastOutputCertificate(token, foreignIssuerCertificate))
         }
         assertFailsWith<IllegalArgumentException> {
             recipientWallet.accept(
-                paymentTokenReplacingFirstInputClaimHash(token, recipientCertificate.payloadHash())
+                paymentTokenReplacingFirstInputClaimHash(token, foreignIssuerCertificate.payloadHash())
             )
         }
         assertFailsWith<IllegalArgumentException> {
-            recipientWallet.accept(paymentTokenReplacingSenderCertificate(token, recipientCertificate))
+            recipientWallet.accept(paymentTokenReplacingSenderCertificate(token, foreignIssuerCertificate))
         }
         assertFailsWith<IllegalArgumentException> {
             recipientWallet.accept(paymentTokenReplacingBearerAuditTrail(token, emptyList()))
@@ -3204,6 +3284,42 @@ class OfflineNoteTest {
         assertEquals(OfflineNoteWalletNoteState.SPENDABLE, recipientWallet.accept(token).state)
     }
 
+    private fun adversarialSourceNote(
+        chainId: String,
+        ownerSigner: TestOwnerCertificateSigner,
+        assetDefinitionId: String,
+        amount: String,
+        issuer: TestIssuerCertificateSigner,
+        secretByte: Int,
+    ): OfflineNoteWalletNote =
+        adversarialSourceNote(
+            chainId,
+            ownerSigner,
+            assetDefinitionId,
+            amount,
+            issuerCertificate = issuer.issuerCertificate(ownerSigner.accountId),
+            secretByte = secretByte,
+        )
+
+    private fun adversarialSourceNote(
+        chainId: String,
+        ownerSigner: TestOwnerCertificateSigner,
+        assetDefinitionId: String,
+        amount: String,
+        issuerCertificate: OfflineNote.KeyCertificate,
+        secretByte: Int,
+    ): OfflineNoteWalletNote =
+        issuerSourceWalletNote(
+            chainId = chainId,
+            accountId = ownerSigner.accountId,
+            assetDefinitionId = assetDefinitionId,
+            amount = amount,
+            issuerCertificate = issuerCertificate,
+            noteSecret = ByteArray(32) { secretByte.toByte() },
+            operationSuffix = "adversarial-${secretByte.toString(16)}",
+            createdAtMs = 1_700_000_000_000L,
+        )
+
     @Test
     fun walletSyncReconcilesFailedAuditAndRedeemOutcomes() {
         val fixture = loadFixture()
@@ -3211,64 +3327,73 @@ class OfflineNoteTest {
         val derivation = obj(chain, "derivation")
         val chainIssue = obj(chain, "issue")
         val chainRedeem = obj(chain, "redeem")
-        val payment = obj(fixture, "payment_token")
-        val senderCertificate = certificate(obj(payment, "sender_key_certificate"))
-        val recipientCertificate = certificate(obj(payment, "recipient_key_certificate"))
+        val chainId = string(derivation, "chain_id")
+        val assetDefinitionId = assetDefinitionFromAssetId(string(chainIssue, "asset_id"))
+        val testIssuer = TestIssuerCertificateSigner()
+        val verifier = Ed25519OfflineNoteCertificateVerifier(listOf(testIssuer.publicKey))
+        val senderSigner = TestOwnerCertificateSigner()
+        val recipientSigner = TestOwnerCertificateSigner()
         val senderStore = InMemoryOfflineNoteStore()
-        senderStore.upsert(sourceWalletNote(fixture, senderCertificate))
-        val senderResolutions = linkedMapOf(
-            string(derivation, "source_note_commitment") to OfflineNoteWalletNoteState.SPENT,
-            string(derivation, "change_output_commitment") to OfflineNoteWalletNoteState.SPENDABLE,
+        val sourceNote = issuerSourceWalletNote(
+            chainId = chainId,
+            accountId = senderSigner.accountId,
+            assetDefinitionId = assetDefinitionId,
+            amount = string(chainIssue, "amount"),
+            issuerCertificate = testIssuer.issuerCertificate(senderSigner.accountId),
+            noteSecret = ByteArray(32) { 0x18.toByte() },
+            operationSuffix = "failed-sync-source",
+            createdAtMs = 1_700_000_000_000L,
         )
+        senderStore.upsert(sourceNote)
         val senderWallet = OfflineNoteWallet(
-            chainId = string(derivation, "chain_id"),
-            accountId = accountFromAssetId(string(chainIssue, "asset_id")),
-            attestationProvider = StaticAttestationProvider(senderCertificate),
+            chainId = chainId,
+            accountId = senderSigner.accountId,
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(senderSigner.accountId)),
+            ownerCertificateSigner = senderSigner,
             store = senderStore,
             transactionSubmitter = RecordingTransactionSubmitter(),
-            syncResolver = RecordingSyncResolver(senderResolutions),
+            syncResolver = RecordingSyncResolver(emptyMap()),
             proofProvider = BindingProofProvider,
             proofVerifier = BindingProofVerifier,
-            certificateVerifier = certificateVerifier(fixture),
+            certificateVerifier = verifier,
             randomSource = QueueRandomSource(
                 listOf(
-                    hexBytes(string(derivation, "token_nonce_hex")),
-                    hexBytes(string(derivation, "change_note_secret_hex")),
+                    ByteArray(32) { 0x2A.toByte() },
+                    ByteArray(32) { 0x2B.toByte() },
                 )
             ),
             clock = { 1_700_000_002_400L },
         )
         val recipientStore = InMemoryOfflineNoteStore()
-        val recipientResolutions = linkedMapOf(
-            string(derivation, "recipient_output_commitment") to OfflineNoteWalletNoteState.CANCELLED,
-        )
         val recipientWallet = OfflineNoteWallet(
-            chainId = string(derivation, "chain_id"),
-            accountId = string(payment, "recipient_account_id"),
-            attestationProvider = StaticAttestationProvider(recipientCertificate),
+            chainId = chainId,
+            accountId = recipientSigner.accountId,
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(recipientSigner.accountId)),
+            ownerCertificateSigner = recipientSigner,
             store = recipientStore,
             transactionSubmitter = RejectingTransactionSubmitter(),
-            syncResolver = RecordingSyncResolver(recipientResolutions),
+            syncResolver = RecordingSyncResolver(emptyMap()),
             proofProvider = BindingProofProvider,
             proofVerifier = BindingProofVerifier,
-            certificateVerifier = certificateVerifier(fixture),
-            randomSource = QueueRandomSource(listOf(hexBytes(string(derivation, "recipient_note_secret_hex")))),
+            certificateVerifier = verifier,
+            randomSource = QueueRandomSource(listOf(ByteArray(32) { 0x3A.toByte() })),
             idGenerator = FixedIdGenerator(string(derivation, "payment_request_id")),
             clock = { 1_700_000_002_500L },
         )
 
         val receiveRequest = recipientWallet.prepareReceive(
-            assetDefinitionId = assetDefinitionFromAssetId(string(chainIssue, "asset_id")),
+            assetDefinitionId = assetDefinitionId,
             amount = string(chainRedeem, "amount"),
         )
         val token = senderWallet.pay(receiveRequest)
+        val changeCommitment = token.audit.outputClaims[1].noteCommitment()
 
         val accepted = recipientWallet.accept(token)
         assertEquals(OfflineNoteWalletNoteState.SPENDABLE, accepted.state)
         assertFutureFails(recipientWallet.publishAudit(token))
         assertEquals(
             OfflineNoteWalletNoteState.SPENDABLE,
-            recipientStore.findNote(hexBytes(string(derivation, "recipient_output_commitment")))?.state,
+            recipientStore.findNote(receiveRequest.outputCommitment())?.state,
         )
 
         senderWallet.sync().join()
@@ -3276,32 +3401,42 @@ class OfflineNoteTest {
 
         assertEquals(
             OfflineNoteWalletNoteState.SPENT,
-            senderStore.findNote(hexBytes(string(derivation, "source_note_commitment")))?.state,
+            senderStore.findNote(sourceNote.noteCommitment())?.state,
         )
         assertEquals(
             OfflineNoteWalletNoteState.SPENDABLE,
-            senderStore.findNote(hexBytes(string(derivation, "change_output_commitment")))?.state,
+            senderStore.findNote(changeCommitment)?.state,
         )
         assertEquals(
             OfflineNoteWalletNoteState.SPENDABLE,
-            recipientStore.findNote(hexBytes(string(derivation, "recipient_output_commitment")))?.state,
+            recipientStore.findNote(receiveRequest.outputCommitment())?.state,
         )
 
         val redeemStore = InMemoryOfflineNoteStore()
-        val redeemNote = sourceWalletNote(fixture, senderCertificate)
+        val redeemNote = issuerSourceWalletNote(
+            chainId = chainId,
+            accountId = senderSigner.accountId,
+            assetDefinitionId = assetDefinitionId,
+            amount = string(chainIssue, "amount"),
+            issuerCertificate = testIssuer.issuerCertificate(senderSigner.accountId),
+            noteSecret = ByteArray(32) { 0x19.toByte() },
+            operationSuffix = "failed-sync-redeem",
+            createdAtMs = 1_700_000_000_000L,
+        )
         redeemStore.upsert(redeemNote)
         val redeemWallet = OfflineNoteWallet(
-            chainId = string(derivation, "chain_id"),
-            accountId = accountFromAssetId(string(chainIssue, "asset_id")),
-            attestationProvider = StaticAttestationProvider(senderCertificate),
+            chainId = chainId,
+            accountId = senderSigner.accountId,
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(senderSigner.accountId)),
+            ownerCertificateSigner = senderSigner,
             store = redeemStore,
             transactionSubmitter = RejectingTransactionSubmitter(),
             syncResolver = RecordingSyncResolver(
-                mapOf(string(derivation, "source_note_commitment") to OfflineNoteWalletNoteState.SPENDABLE)
+                mapOf(redeemNote.noteCommitmentHex() to OfflineNoteWalletNoteState.SPENDABLE)
             ),
             proofProvider = BindingProofProvider,
             proofVerifier = BindingProofVerifier,
-            certificateVerifier = certificateVerifier(fixture),
+            certificateVerifier = verifier,
             randomSource = QueueRandomSource(emptyList()),
             clock = { 1_700_000_002_600L },
         )
@@ -3309,14 +3444,14 @@ class OfflineNoteTest {
         assertFutureFails(redeemWallet.redeem(redeemNote))
         assertEquals(
             OfflineNoteWalletNoteState.SPENDABLE,
-            redeemStore.findNote(hexBytes(string(derivation, "source_note_commitment")))?.state,
+            redeemStore.findNote(redeemNote.noteCommitment())?.state,
         )
 
         redeemWallet.sync().join()
 
         assertEquals(
             OfflineNoteWalletNoteState.SPENDABLE,
-            redeemStore.findNote(hexBytes(string(derivation, "source_note_commitment")))?.state,
+            redeemStore.findNote(redeemNote.noteCommitment())?.state,
         )
     }
 
@@ -3998,10 +4133,134 @@ class OfflineNoteTest {
         )
     }
 
+    private fun issuerSourceWalletNote(
+        chainId: String,
+        accountId: String,
+        assetDefinitionId: String,
+        amount: String,
+        issuerCertificate: OfflineNote.KeyCertificate,
+        noteSecret: ByteArray,
+        operationSuffix: String,
+        createdAtMs: Long,
+    ): OfflineNoteWalletNote {
+        val assetId = "$assetDefinitionId#$accountId"
+        val origin = OfflineNote.CommitmentOrigin.IssuerLoad(
+            operationId = "operation-$operationSuffix",
+            lineageId = "lineage-$operationSuffix",
+            localRevision = 1L,
+        )
+        val noteCommitment = OfflineNote.deriveNoteCommitment(
+            OfflineNote.NoteCommitmentPreimage(
+                chainId = chainId,
+                ownerKeyCertificatePayloadHash = issuerCertificate.payloadHash(),
+                assetId = assetId,
+                amount = amount,
+                noteSecret = noteSecret,
+                origin = origin,
+            )
+        )
+        return OfflineNoteWalletNote(
+            chainId = chainId,
+            accountId = accountId,
+            assetId = assetId,
+            amount = amount,
+            keyCertificate = issuerCertificate,
+            noteCommitment = noteCommitment,
+            noteSecret = noteSecret,
+            origin = origin,
+            state = OfflineNoteWalletNoteState.SPENDABLE,
+            createdAtMs = createdAtMs,
+            updatedAtMs = createdAtMs,
+        )
+    }
+
     private class StaticAttestationProvider(
         private val certificate: OfflineNote.KeyCertificate,
     ) : OfflineNoteAttestationProvider {
         override fun currentKeyCertificate(): OfflineNote.KeyCertificate = certificate
+    }
+
+    /**
+     * Mints owner-self-signed Offline Note key certificates for an account id the test controls.
+     *
+     * The signer owns the Ed25519 keypair behind [accountId], so the `issuerSignature` it produces
+     * is a RAW Ed25519 signature (no Blake2b prehash) over [OfflineNote.KeyCertificate.signingBytes]
+     * that [Ed25519OfflineNoteCertificateVerifier.verifyOwnerCertificate] accepts: that verifier
+     * re-derives the owner public key from the certificate `accountId` and checks the signature
+     * against it. Each call generates a fresh throwaway `publicKey` so successive certificates differ.
+     */
+    private class TestOwnerCertificateSigner : OfflineNoteOwnerCertificateSigner {
+        private val ownerKey: Ed25519PrivateKeyParameters
+        private val ownerPublicKey: ByteArray
+        val accountId: String
+        private val freshKeyGenerator = Ed25519KeyPairGenerator().apply {
+            init(Ed25519KeyGenerationParameters(SecureRandom()))
+        }
+
+        init {
+            val generator = Ed25519KeyPairGenerator().apply {
+                init(Ed25519KeyGenerationParameters(SecureRandom()))
+            }
+            val pair = generator.generateKeyPair()
+            ownerKey = pair.private as Ed25519PrivateKeyParameters
+            ownerPublicKey = (pair.public as Ed25519PublicKeyParameters).encoded
+            accountId = AccountAddress.fromAccount(ownerPublicKey, "ed25519")
+                .toI105(AccountAddress.DEFAULT_I105_DISCRIMINANT)
+        }
+
+        override fun freshOwnerCertificate(accountId: String): OfflineNote.KeyCertificate {
+            require(accountId == this.accountId) {
+                "test owner signer only mints certificates for its own account id"
+            }
+            val freshPublicKey = (freshKeyGenerator.generateKeyPair().public as Ed25519PublicKeyParameters).encoded
+            return signCertificate(
+                ownerKey,
+                accountId = accountId,
+                publicKey = freshPublicKey,
+                assertionPublicKey = ownerPublicKey,
+                assertionScheme = "self-signed",
+                platform = "android-software-ed25519",
+                keyId = "owner-key-${UUID.randomUUID()}",
+            )
+        }
+    }
+
+    /**
+     * Mints issuer-signed Offline Note key certificates for a wallet account the test controls.
+     *
+     * Mirrors the topup/issue path: the certificate `accountId` is the wallet account, while the
+     * `issuerSignature` is a RAW Ed25519 signature by this test issuer (financial institution) key.
+     * Build a wallet verifier with [Ed25519OfflineNoteCertificateVerifier] trusting [publicKey] so
+     * source notes minted here pass [Ed25519OfflineNoteCertificateVerifier.verifyIssuerCertificate].
+     */
+    private class TestIssuerCertificateSigner {
+        private val issuerKey: Ed25519PrivateKeyParameters
+        val publicKey: ByteArray
+        private val freshKeyGenerator = Ed25519KeyPairGenerator().apply {
+            init(Ed25519KeyGenerationParameters(SecureRandom()))
+        }
+
+        init {
+            val generator = Ed25519KeyPairGenerator().apply {
+                init(Ed25519KeyGenerationParameters(SecureRandom()))
+            }
+            val pair = generator.generateKeyPair()
+            issuerKey = pair.private as Ed25519PrivateKeyParameters
+            publicKey = (pair.public as Ed25519PublicKeyParameters).encoded
+        }
+
+        fun issuerCertificate(accountId: String): OfflineNote.KeyCertificate {
+            val freshPublicKey = (freshKeyGenerator.generateKeyPair().public as Ed25519PublicKeyParameters).encoded
+            return signCertificate(
+                issuerKey,
+                accountId = accountId,
+                publicKey = freshPublicKey,
+                assertionPublicKey = freshPublicKey,
+                assertionScheme = "issuer-attested",
+                platform = "test-issuer",
+                keyId = "issuer-key-${UUID.randomUUID()}",
+            )
+        }
     }
 
     private class QueueRandomSource(
@@ -4439,39 +4698,50 @@ class OfflineNoteTest {
         return out
     }
 
-    private fun kagemushaNoritoFrame(schemaByte: Int): ByteArray {
-        val frame = ByteArray(40)
-        frame[0] = 'N'.code.toByte()
-        frame[1] = 'R'.code.toByte()
-        frame[2] = 'T'.code.toByte()
-        frame[3] = '0'.code.toByte()
-        frame.fill(schemaByte.toByte(), 6, 22)
-        return frame
-    }
-
-    private fun kagemushaNoritoFrameWithPayload(schemaByte: Int): ByteArray {
-        val frame = ByteArray(45)
-        kagemushaNoritoFrame(schemaByte).copyInto(frame, 0)
-        frame[23] = 3.toByte()
-        byteArrayOf(
-            0xb9.toByte(),
-            0xd3.toByte(),
-            0xa8.toByte(),
-            0x0c.toByte(),
-            0xcd.toByte(),
-            0x5d.toByte(),
-            0x13.toByte(),
-            0x24.toByte(),
-        ).copyInto(frame, 31)
-        frame[42] = 0xa5.toByte()
-        frame[43] = 0x5a.toByte()
-        frame[44] = 0x11.toByte()
-        return frame
-    }
-
     private fun assertFutureFails(future: CompletableFuture<*>) {
         assertFailsWith<CompletionException> {
             future.join()
         }
     }
+}
+
+private fun signCertificate(
+    signingKey: Ed25519PrivateKeyParameters,
+    accountId: String,
+    publicKey: ByteArray,
+    assertionPublicKey: ByteArray,
+    assertionScheme: String,
+    platform: String,
+    keyId: String,
+): OfflineNote.KeyCertificate {
+    val unsigned = OfflineNote.KeyCertificate(
+        platform = platform,
+        keyId = keyId,
+        deviceId = "test-device",
+        accountId = accountId,
+        publicKey = publicKey,
+        assertionScheme = assertionScheme,
+        assertionKeyAlgorithm = "ed25519",
+        assertionPublicKey = assertionPublicKey,
+        assertionUsageCountLimit = null,
+        oneUse = true,
+        issuerSignature = ByteArray(64),
+    )
+    val signer = Ed25519Signer()
+    signer.init(true, signingKey)
+    val message = unsigned.signingBytes()
+    signer.update(message, 0, message.size)
+    return OfflineNote.KeyCertificate(
+        platform = unsigned.platform,
+        keyId = unsigned.keyId,
+        deviceId = unsigned.deviceId,
+        accountId = unsigned.accountId,
+        publicKey = unsigned.publicKey(),
+        assertionScheme = unsigned.assertionScheme,
+        assertionKeyAlgorithm = unsigned.assertionKeyAlgorithm,
+        assertionPublicKey = unsigned.assertionPublicKey(),
+        assertionUsageCountLimit = unsigned.assertionUsageCountLimit,
+        oneUse = unsigned.oneUse,
+        issuerSignature = signer.generateSignature(),
+    )
 }


### PR DESCRIPTION
## Context

Offline-note **redeem** and **audit** transactions built by the SDK are rejected by current Iroha core, so SDK consumers cannot complete offline-note flows:

- **`RedeemOfflineNote`** is rejected because the pure-JVM prover stamps a stale, hardcoded canonical verifying-key hash into the proof envelope, which no longer matches the on-chain verifying-key commitment.
- **`AuditOfflineNote`** is rejected because output-claim key certificates are signed with the operator/issuer key, but core now requires each output-claim certificate to be **self-signed by the note-owner account** named in the certificate's own `accountId`.

### Solution

Prove and verify against the **chain-provided** verifying key, and mint **owner-self-signed** output certificates:

- **`connect_norito_bridge`** gains four FFI entry points (C-ABI + matching JNI, both namespaces): `prove_note_{redeem,audit}_with_vk` and `verify_note_{redeem,audit}_with_vk`. Each takes the Norito-archived request plus a `VerifyingKeyBox` and proves / fully verifies against that supplied VK (public-input binding + canonical-VK binding + envelope + halo2 backend), removing the hardcoded VK constant from the proving path.
- **`core-jvm`**: `ChainVkOfflineNoteProofProvider(vkBoxNorito)` and `NativeOfflineNoteProofVerifier(vkBoxNorito)` prove/verify through the native bridge against the chain VK — replacing the previous hash-only (forgeable) check with real crypto verification. `NativeOfflineNoteProver` is the JNI wrapper (`proveRedeem`/`proveAudit`/`verifyRedeem`/`verifyAudit`, `isNativeAvailable`).
- **Certificates**: the new `OfflineNoteOwnerCertificateSigner.freshOwnerCertificate(accountId)` mints a fresh owner-self-signed certificate per output claim (raw Ed25519 over `KeyCertificate.signingBytes`, with a brand-new throwaway keypair each call so the one-use `payloadHash` replay anchor never collides). The certificate verifier is split into `verifyIssuerCertificate` (operator-trusted: topup / `IssueOfflineNote`) and `verifyOwnerCertificate` (raw Ed25519 against the account key derived from the cert's `accountId`), routed by the new `OfflineNote.CommitmentOrigin` sealed type — `IssuerLoad` → issuer, `P2pOutput` (and audit outputs) → owner.

---

### Review notes

- `crates/connect_norito_bridge/src/lib.rs` — the four new `*_with_vk` FFI fns; confirm verify mirrors the executor (public-inputs + canonical-VK binding + envelope checks + halo2 backend) and that the canonical-VK pin is **kept**, not relaxed.
- `kotlin/core-jvm/.../OfflineNoteWallet.kt` — the `verifyIssuerCertificate`/`verifyOwnerCertificate` split, `CommitmentOrigin` routing, and `ChainVkOfflineNoteProofProvider` / `NativeOfflineNoteProofVerifier` wiring.
- `kotlin/core-jvm/.../OfflineNoteOwnerCertificateSigner.kt` — the owner-cert contract (fresh keypair, raw Ed25519, non-empty assertion fields, one-use replay anchor).
- `kotlin/core-jvm/.../OfflineNote.kt` — the `CommitmentOrigin` sealed class and its Norito encode/decode.