### PR TITLE
Ignore Java LSP artifacts in Java modules

### DIFF
--- a/java/iroha_android/.gitignore
+++ b/java/iroha_android/.gitignore
@@ -1,0 +1,4 @@
+bin/
+.project
+.classpath
+.settings/

--- a/java/norito_java/.gitignore
+++ b/java/norito_java/.gitignore
@@ -1,0 +1,4 @@
+bin/
+.project
+.classpath
+.settings/


### PR DESCRIPTION
## Context

JDT.LS (Eclipse-based Java language server) generates `.project`, `.classpath`, `.settings/`, and `bin/` directories in each Gradle module when syncing the project via Buildship. These transient tooling artifacts pollute `git status` for anyone running a Java LSP (including Claude Code's `jdtls-lsp` plugin).

### Solution

Add `.gitignore` files to `java/iroha_android` and `java/norito_java` covering the four artifact patterns produced by JDT.LS/Buildship.