### PR TITLE
feat(offline): issuer/owner key-certificate verifier split in IrohaSwift (#5589)

### DIFF
--- a/IrohaSwift/Sources/IrohaSwift/OfflineNoteWallet.swift
+++ b/IrohaSwift/Sources/IrohaSwift/OfflineNoteWallet.swift
@@ -1546,6 +1546,42 @@ public final class OfflineNoteWallet {
         self.clock = clock
     }
 
+    public static func p2pEnabled(
+        chainId: String,
+        accountId: String,
+        attestationProvider: OfflineNoteAttestationProvider,
+        store: OfflineNoteStore = InMemoryOfflineNoteStore(),
+        issuerClient: OfflineNoteIssuerClient? = nil,
+        transactionSubmitter: OfflineNoteTransactionSubmitter? = nil,
+        syncResolver: OfflineNoteSyncResolver? = nil,
+        proofProvider: OfflineNoteProofProvider,
+        proofVerifier: OfflineNoteProofVerifier = Halo2OfflineNoteProofVerifier(),
+        certificateVerifier: OfflineNoteCertificateVerifier,
+        ownerCertificateSigner: OfflineNoteOwnerCertificateSigner,
+        randomSource: OfflineNoteRandomSource = SecureOfflineNoteRandomSource(),
+        idGenerator: OfflineNoteIdGenerator = UuidOfflineNoteIdGenerator(),
+        bearerCashPolicy: OfflineBearerCashPolicyV1 = .default,
+        clock: @escaping () -> UInt64 = { UInt64(Date().timeIntervalSince1970 * 1000) }
+    ) -> OfflineNoteWallet {
+        OfflineNoteWallet(
+            chainId: chainId,
+            accountId: accountId,
+            attestationProvider: attestationProvider,
+            store: store,
+            issuerClient: issuerClient,
+            transactionSubmitter: transactionSubmitter,
+            syncResolver: syncResolver,
+            proofProvider: proofProvider,
+            proofVerifier: proofVerifier,
+            certificateVerifier: certificateVerifier,
+            ownerCertificateSigner: ownerCertificateSigner,
+            randomSource: randomSource,
+            idGenerator: idGenerator,
+            bearerCashPolicy: bearerCashPolicy,
+            clock: clock
+        )
+    }
+
     public func listNotes() throws -> [OfflineNoteWalletNote] {
         try store.listNotes()
     }

--- a/IrohaSwift/Sources/IrohaSwift/OfflineNoteWallet.swift
+++ b/IrohaSwift/Sources/IrohaSwift/OfflineNoteWallet.swift
@@ -351,7 +351,7 @@ public struct Ed25519OfflineNoteCertificateVerifier: OfflineNoteCertificateVerif
     private let trustedIssuerPublicKeys: [Data]
 
     public init(trustedIssuerPublicKeys: [Data]) {
-        self.trustedIssuerPublicKeys = trustedIssuerPublicKeys
+        self.trustedIssuerPublicKeys = trustedIssuerPublicKeys.map { Data(Array($0)) }
     }
 
     public func verifyIssuerCertificate(_ certificate: OfflineNoteKeyCertificate) throws -> Bool {
@@ -2159,8 +2159,13 @@ public final class OfflineNoteWallet {
             }
             try requireTrustedEitherCertificate(audit.senderKeyCertificate, expectedAccountId: assetAccount(from: claim.assetId))
         }
+        var outputCertificateHashes = Set<String>()
         for output in audit.outputClaims {
             // Chain (#5589) requires P2P audit OUTPUT key certs to be owner-self-signed.
+            let certificateHash = try output.keyCertificate.payloadHash().hexLowercased()
+            guard outputCertificateHashes.insert(certificateHash).inserted else {
+                throw OfflineNoteWalletError.certificateVerificationFailed
+            }
             try requireTrustedOwnerCertificate(output.keyCertificate, expectedAccountId: assetAccount(from: output.assetId))
         }
     }

--- a/IrohaSwift/Sources/IrohaSwift/OfflineNoteWallet.swift
+++ b/IrohaSwift/Sources/IrohaSwift/OfflineNoteWallet.swift
@@ -27,6 +27,7 @@ public enum OfflineNoteWalletError: Error, LocalizedError, Equatable {
     case proofVerificationFailed
     case certificateVerificationFailed
     case missingBearerAuditTrail
+    case missingOwnerCertificateSigner
 
     public var errorDescription: String? {
         switch self {
@@ -56,6 +57,8 @@ public enum OfflineNoteWalletError: Error, LocalizedError, Equatable {
             return "Offline Note key certificate is not trusted for this wallet operation."
         case .missingBearerAuditTrail:
             return "Offline Note bearer note is missing the audit trail required for defunding."
+        case .missingOwnerCertificateSigner:
+            return "Offline Note owner certificate signer is required for P2P outputs."
         }
     }
 }
@@ -325,13 +328,21 @@ public struct Halo2OfflineNoteProofVerifier: OfflineNoteProofVerifier {
 }
 
 public protocol OfflineNoteCertificateVerifier {
-    func verifyCertificate(_ certificate: OfflineNoteKeyCertificate) throws -> Bool
+    /// Verifies a certificate signed by a trusted issuer for topup/issue paths.
+    func verifyIssuerCertificate(_ certificate: OfflineNoteKeyCertificate) throws -> Bool
+
+    /// Verifies a certificate self-signed by the account named in its accountId for P2P output paths.
+    func verifyOwnerCertificate(_ certificate: OfflineNoteKeyCertificate) throws -> Bool
 }
 
 public struct RejectingOfflineNoteCertificateVerifier: OfflineNoteCertificateVerifier {
     public init() {}
 
-    public func verifyCertificate(_ certificate: OfflineNoteKeyCertificate) throws -> Bool {
+    public func verifyIssuerCertificate(_ certificate: OfflineNoteKeyCertificate) throws -> Bool {
+        false
+    }
+
+    public func verifyOwnerCertificate(_ certificate: OfflineNoteKeyCertificate) throws -> Bool {
         false
     }
 }
@@ -343,15 +354,8 @@ public struct Ed25519OfflineNoteCertificateVerifier: OfflineNoteCertificateVerif
         self.trustedIssuerPublicKeys = trustedIssuerPublicKeys
     }
 
-    public func verifyCertificate(_ certificate: OfflineNoteKeyCertificate) throws -> Bool {
-        guard !trustedIssuerPublicKeys.isEmpty,
-              !certificate.platform.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-              !certificate.keyId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-              !certificate.deviceId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-              !certificate.assertionScheme.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-              !certificate.assertionKeyAlgorithm.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-              !certificate.assertionPublicKey.isEmpty
-        else {
+    public func verifyIssuerCertificate(_ certificate: OfflineNoteKeyCertificate) throws -> Bool {
+        guard !trustedIssuerPublicKeys.isEmpty, hasValidAttestationShape(certificate) else {
             return false
         }
         let message = try certificate.signingBytes()
@@ -363,6 +367,52 @@ public struct Ed25519OfflineNoteCertificateVerifier: OfflineNoteCertificateVerif
         }
         return false
     }
+
+    public func verifyOwnerCertificate(_ certificate: OfflineNoteKeyCertificate) throws -> Bool {
+        // Owner certs are self-signed by the account named in `accountId`; there is no
+        // trusted-issuer-root check. The `issuerSignature` field carries the owner's
+        // self-signature over the same `signingBytes()`.
+        guard hasValidAttestationShape(certificate),
+              let ownerKey = ownerSignatoryKey(certificate.accountId)
+        else {
+            return false
+        }
+        let publicKey = try Curve25519.Signing.PublicKey(rawRepresentation: ownerKey)
+        return publicKey.isValidSignature(certificate.issuerSignature, for: try certificate.signingBytes())
+    }
+
+    private func hasValidAttestationShape(_ certificate: OfflineNoteKeyCertificate) -> Bool {
+        !certificate.platform.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !certificate.keyId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !certificate.deviceId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !certificate.assertionScheme.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !certificate.assertionKeyAlgorithm.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !certificate.assertionPublicKey.isEmpty
+    }
+
+    /// Derives the single Ed25519 signatory public key from an account id literal,
+    /// mirroring the chain's `AccountId::try_signatory` (single-signature ed25519).
+    /// Returns nil for multisig / non-ed25519 / wrong-length keys so owner verify fails closed.
+    private func ownerSignatoryKey(_ accountId: String) -> Data? {
+        guard let address = try? AccountAddress.parseEncodedSwiftOnly(accountId),
+              let info = address.singleControllerInfo(),
+              info.algorithm == .ed25519,
+              info.publicKey.count == 32
+        else { return nil }
+        return info.publicKey
+    }
+}
+
+/// Mints owner-self-signed Offline Note key certificates for P2P output claims.
+///
+/// Output certificates must be signed by the owner account named in the certificate's
+/// `accountId`, not by the issuer/operator key used for load and topup paths. The
+/// implementation lives in the application because only it holds the owner account
+/// signing key. The returned certificate's `issuerSignature` must be a raw Ed25519
+/// signature over `OfflineNoteKeyCertificate.signingBytes()`, and the payload must be
+/// fresh for every output because its payload hash is a one-use replay anchor.
+public protocol OfflineNoteOwnerCertificateSigner {
+    func freshOwnerCertificate(accountId: String) throws -> OfflineNoteKeyCertificate
 }
 
 public struct OfflineNoteLoadContext: Sendable {
@@ -1458,6 +1508,7 @@ public final class OfflineNoteWallet {
     private let proofProvider: OfflineNoteProofProvider
     private let proofVerifier: OfflineNoteProofVerifier
     private let certificateVerifier: OfflineNoteCertificateVerifier
+    private let ownerCertificateSigner: OfflineNoteOwnerCertificateSigner?
     private let randomSource: OfflineNoteRandomSource
     private let idGenerator: OfflineNoteIdGenerator
     private let bearerCashPolicy: OfflineBearerCashPolicyV1
@@ -1473,6 +1524,7 @@ public final class OfflineNoteWallet {
                 proofProvider: OfflineNoteProofProvider,
                 proofVerifier: OfflineNoteProofVerifier = Halo2OfflineNoteProofVerifier(),
                 certificateVerifier: OfflineNoteCertificateVerifier = RejectingOfflineNoteCertificateVerifier(),
+                ownerCertificateSigner: OfflineNoteOwnerCertificateSigner? = nil,
                 randomSource: OfflineNoteRandomSource = SecureOfflineNoteRandomSource(),
                 idGenerator: OfflineNoteIdGenerator = UuidOfflineNoteIdGenerator(),
                 bearerCashPolicy: OfflineBearerCashPolicyV1 = .default,
@@ -1487,6 +1539,7 @@ public final class OfflineNoteWallet {
         self.proofProvider = proofProvider
         self.proofVerifier = proofVerifier
         self.certificateVerifier = certificateVerifier
+        self.ownerCertificateSigner = ownerCertificateSigner
         self.randomSource = randomSource
         self.idGenerator = idGenerator
         self.bearerCashPolicy = bearerCashPolicy
@@ -1514,7 +1567,7 @@ public final class OfflineNoteWallet {
             assetDefinitionId: assetDefinitionId,
             amount: amount
         )
-        try requireTrustedCertificate(context.keyCertificate, expectedAccountId: accountId)
+        try requireTrustedIssuerCertificate(context.keyCertificate, expectedAccountId: accountId)
         let noteSecret = try random32()
         let origin = try OfflineNoteCommitmentOrigin.issuerLoad(OfflineNoteIssuerLoadOrigin(
             operationId: context.operationId,
@@ -1542,7 +1595,7 @@ public final class OfflineNoteWallet {
             throw OfflineNoteWalletError.issuerCommitmentMismatch
         }
         let issuedCertificate = response.keyCertificate ?? context.keyCertificate
-        try requireTrustedCertificate(issuedCertificate, expectedAccountId: accountId)
+        try requireTrustedIssuerCertificate(issuedCertificate, expectedAccountId: accountId)
         let now = clock()
         let note = try OfflineNoteWalletNote(
             chainId: chainId,
@@ -1563,8 +1616,10 @@ public final class OfflineNoteWallet {
 
     public func prepareReceive(assetDefinitionId: String, amount: String) throws -> OfflineNoteReceiveRequest {
         let paymentRequestId = idGenerator.nextId(prefix: "payment-request")
-        let keyCertificate = try attestationProvider.currentKeyCertificate()
-        try requireTrustedCertificate(keyCertificate, expectedAccountId: accountId)
+        // Receive output certs must be owner-self-signed (chain #5589); mint a fresh
+        // one on demand rather than reusing the issuer-attested attestation cert.
+        let keyCertificate = try requireOwnerCertificateSigner().freshOwnerCertificate(accountId: accountId)
+        try requireTrustedOwnerCertificate(keyCertificate, expectedAccountId: accountId)
         let assetId = walletAssetId(assetDefinitionId: assetDefinitionId, accountId: accountId)
         let noteSecret = try random32()
         let origin = try OfflineNoteCommitmentOrigin.p2pOutput(OfflineNoteP2pOutputOrigin(
@@ -1612,7 +1667,7 @@ public final class OfflineNoteWallet {
         guard receiveRequest.chainId == chainId else {
             throw OfflineNoteWalletError.chainMismatch
         }
-        try requireTrustedCertificate(receiveRequest.keyCertificate, expectedAccountId: receiveRequest.accountId)
+        try requireTrustedOwnerCertificate(receiveRequest.keyCertificate, expectedAccountId: receiveRequest.accountId)
         try rejectReusedReceiveRequest(receiveRequest.paymentRequestId)
         let createdAtMs = clock()
         let requestedAmount = try OfflineNorito.parseCanonicalNumeric(receiveRequest.amount)
@@ -1633,11 +1688,11 @@ public final class OfflineNoteWallet {
         }
 
         let senderCertificate = selected[0].keyCertificate
-        try requireTrustedCertificate(senderCertificate, expectedAccountId: accountId)
+        try requireTrustedCertificateForOrigin(senderCertificate, origin: selected[0].origin, expectedAccountId: accountId)
         let senderCertificateHash = try senderCertificate.payloadHash()
         for note in selected {
             _ = try bearerAuditTrail(for: note)
-            try requireTrustedCertificate(note.keyCertificate, expectedAccountId: accountId)
+            try requireTrustedCertificateForOrigin(note.keyCertificate, origin: note.origin, expectedAccountId: accountId)
             if try note.keyCertificate.payloadHash() != senderCertificateHash {
                 throw OfflineNoteWalletError.inputCertificateMismatch
             }
@@ -1655,6 +1710,10 @@ public final class OfflineNoteWallet {
         let tokenNonce = try random32()
         var changeNote: OfflineNoteWalletNote?
         if changeAmount.digits != "0" {
+            // Change output is a fresh P2P output → mint an owner-self-signed cert
+            // (chain #5589 requires every audit output cert to be owner-signed).
+            let changeCertificate = try requireOwnerCertificateSigner().freshOwnerCertificate(accountId: accountId)
+            try requireTrustedOwnerCertificate(changeCertificate, expectedAccountId: accountId)
             let changeSecret = try random32()
             let changeAssetId = walletAssetId(
                 assetDefinitionId: receiveRequest.assetDefinitionId,
@@ -1665,7 +1724,7 @@ public final class OfflineNoteWallet {
                 outputIndex: 1
             ))
             let changeCommitment = try deriveNoteCommitment(
-                keyCertificate: senderCertificate,
+                keyCertificate: changeCertificate,
                 assetId: changeAssetId,
                 amount: changeAmount.canonicalString,
                 noteSecret: changeSecret,
@@ -1676,7 +1735,7 @@ public final class OfflineNoteWallet {
                 accountId: accountId,
                 assetId: changeAssetId,
                 amount: changeAmount.canonicalString,
-                keyCertificate: senderCertificate,
+                keyCertificate: changeCertificate,
                 noteCommitment: changeCommitment,
                 noteSecret: changeSecret,
                 origin: changeOrigin,
@@ -1687,7 +1746,7 @@ public final class OfflineNoteWallet {
             changeNote = note
             outputClaims.append(try OfflineNoteAuditOutputClaim(
                 noteCommitment: changeCommitment,
-                keyCertificate: senderCertificate,
+                keyCertificate: changeCertificate,
                 assetId: changeAssetId,
                 amount: note.amount
             ))
@@ -1860,7 +1919,7 @@ public final class OfflineNoteWallet {
             throw OfflineNoteWalletError.invalidState
         }
         let bearerAuditTrail = try bearerAuditTrail(for: current)
-        try requireTrustedCertificate(current.keyCertificate, expectedAccountId: current.accountId)
+        try requireTrustedCertificateForOrigin(current.keyCertificate, origin: current.origin, expectedAccountId: current.accountId)
         let inputNullifier = try deriveInputNullifier(current)
         let redeemPublicInputs = try OfflineNoteRedeemPublicInputs(
             sourceNoteCommitment: current.noteCommitment,
@@ -1881,7 +1940,7 @@ public final class OfflineNoteWallet {
         )
         let redemption = try draft.replacingRecursiveProof(proofProvider.proveRedeem(draft))
         try redemption.validateProofBinding()
-        try requireTrustedCertificate(redemption.senderKeyCertificate, expectedAccountId: current.accountId)
+        try requireTrustedCertificateForOrigin(redemption.senderKeyCertificate, origin: current.origin, expectedAccountId: current.accountId)
         guard try proofVerifier.verifyRedeem(redemption) else {
             throw OfflineNoteWalletError.proofVerificationFailed
         }
@@ -2056,29 +2115,79 @@ public final class OfflineNoteWallet {
     }
 
     private func requireTrustedAuditCertificates(_ audit: OfflineNoteAuditBundle) throws {
-        try requireTrustedCertificate(audit.senderKeyCertificate)
+        try requireTrustedEitherCertificate(audit.senderKeyCertificate, expectedAccountId: nil)
         let senderHash = try audit.senderKeyCertificate.payloadHash()
         for claim in audit.inputClaims {
             guard claim.keyCertificatePayloadHash == senderHash else {
                 throw OfflineNoteWalletError.certificateVerificationFailed
             }
-            try requireTrustedCertificate(audit.senderKeyCertificate, expectedAccountId: assetAccount(from: claim.assetId))
+            try requireTrustedEitherCertificate(audit.senderKeyCertificate, expectedAccountId: assetAccount(from: claim.assetId))
         }
         for output in audit.outputClaims {
-            try requireTrustedCertificate(output.keyCertificate, expectedAccountId: assetAccount(from: output.assetId))
+            // Chain (#5589) requires P2P audit OUTPUT key certs to be owner-self-signed.
+            try requireTrustedOwnerCertificate(output.keyCertificate, expectedAccountId: assetAccount(from: output.assetId))
         }
     }
 
-    private func requireTrustedCertificate(
+    private func requireMatchingAccount(
         _ certificate: OfflineNoteKeyCertificate,
-        expectedAccountId: String? = nil
+        expectedAccountId: String?
     ) throws {
         if let expectedAccountId, certificate.accountId != expectedAccountId {
             throw OfflineNoteWalletError.certificateVerificationFailed
         }
-        guard try certificateVerifier.verifyCertificate(certificate) else {
+    }
+
+    private func requireTrustedIssuerCertificate(
+        _ certificate: OfflineNoteKeyCertificate,
+        expectedAccountId: String? = nil
+    ) throws {
+        try requireMatchingAccount(certificate, expectedAccountId: expectedAccountId)
+        guard try certificateVerifier.verifyIssuerCertificate(certificate) else {
             throw OfflineNoteWalletError.certificateVerificationFailed
         }
+    }
+
+    private func requireTrustedOwnerCertificate(
+        _ certificate: OfflineNoteKeyCertificate,
+        expectedAccountId: String? = nil
+    ) throws {
+        try requireMatchingAccount(certificate, expectedAccountId: expectedAccountId)
+        guard try certificateVerifier.verifyOwnerCertificate(certificate) else {
+            throw OfflineNoteWalletError.certificateVerificationFailed
+        }
+    }
+
+    private func requireTrustedEitherCertificate(
+        _ certificate: OfflineNoteKeyCertificate,
+        expectedAccountId: String? = nil
+    ) throws {
+        try requireMatchingAccount(certificate, expectedAccountId: expectedAccountId)
+        let trusted = try certificateVerifier.verifyIssuerCertificate(certificate)
+            || certificateVerifier.verifyOwnerCertificate(certificate)
+        guard trusted else {
+            throw OfflineNoteWalletError.certificateVerificationFailed
+        }
+    }
+
+    private func requireTrustedCertificateForOrigin(
+        _ certificate: OfflineNoteKeyCertificate,
+        origin: OfflineNoteCommitmentOrigin,
+        expectedAccountId: String?
+    ) throws {
+        switch origin {
+        case .issuerLoad:
+            try requireTrustedIssuerCertificate(certificate, expectedAccountId: expectedAccountId)
+        case .p2pOutput:
+            try requireTrustedOwnerCertificate(certificate, expectedAccountId: expectedAccountId)
+        }
+    }
+
+    private func requireOwnerCertificateSigner() throws -> OfflineNoteOwnerCertificateSigner {
+        guard let ownerCertificateSigner else {
+            throw OfflineNoteWalletError.missingOwnerCertificateSigner
+        }
+        return ownerCertificateSigner
     }
 
     private func random32() throws -> Data {

--- a/IrohaSwift/Tests/IrohaSwiftTests/OfflineNoteTests.swift
+++ b/IrohaSwift/Tests/IrohaSwiftTests/OfflineNoteTests.swift
@@ -15,7 +15,7 @@ final class OfflineNoteTests: XCTestCase {
             try sender.payloadHash().hexLowercased(),
             fixture.chainVectors.certificates.senderPayloadHash
         )
-        XCTAssertTrue(try verifier.verifyCertificate(sender))
+        XCTAssertTrue(try verifier.verifyIssuerCertificate(sender))
 
         var tamperedSignature = sender.issuerSignature
         tamperedSignature[tamperedSignature.startIndex] ^= 0x01
@@ -33,11 +33,11 @@ final class OfflineNoteTests: XCTestCase {
             oneUse: sender.oneUse,
             issuerSignature: tamperedSignature
         )
-        XCTAssertFalse(try verifier.verifyCertificate(tampered))
-        XCTAssertFalse(try RejectingOfflineNoteCertificateVerifier().verifyCertificate(sender))
+        XCTAssertFalse(try verifier.verifyIssuerCertificate(tampered))
+        XCTAssertFalse(try RejectingOfflineNoteCertificateVerifier().verifyIssuerCertificate(sender))
         XCTAssertFalse(try Ed25519OfflineNoteCertificateVerifier(
             trustedIssuerPublicKeys: [Data(repeating: 0x42, count: 32)]
-        ).verifyCertificate(sender))
+        ).verifyIssuerCertificate(sender))
     }
 
     func testOfflineNoteModelsMatchRustNoritoVectors() throws {

--- a/IrohaSwift/Tests/IrohaSwiftTests/OfflineNoteTests.swift
+++ b/IrohaSwift/Tests/IrohaSwiftTests/OfflineNoteTests.swift
@@ -40,6 +40,47 @@ final class OfflineNoteTests: XCTestCase {
         ).verifyIssuerCertificate(sender))
     }
 
+    func testOwnerCertificateVerifierAcceptsOwnerSelfSignedCertificateOnlyForOwnerPath() throws {
+        let signer = try SoftwareOwnerCertificateSigner(privateKeyByte: 0x61)
+        let certificate = try signer.freshOwnerCertificate(accountId: signer.accountId)
+        let verifier = Ed25519OfflineNoteCertificateVerifier(trustedIssuerPublicKeys: [])
+
+        XCTAssertTrue(try verifier.verifyOwnerCertificate(certificate))
+        XCTAssertFalse(try verifier.verifyIssuerCertificate(certificate))
+        XCTAssertFalse(try RejectingOfflineNoteCertificateVerifier().verifyOwnerCertificate(certificate))
+
+        let tampered = try Self.tamperedSignatureCertificate(certificate)
+        XCTAssertFalse(try verifier.verifyOwnerCertificate(tampered))
+    }
+
+    func testP2pEnabledWalletRequiresAndUsesOwnerCertificateSigner() throws {
+        let fixture = try Self.loadFixture()
+        let signer = try SoftwareOwnerCertificateSigner(privateKeyByte: 0x62)
+        let attestation = try signer.freshOwnerCertificate(accountId: signer.accountId)
+        let verifier = Ed25519OfflineNoteCertificateVerifier(trustedIssuerPublicKeys: [])
+        let wallet = OfflineNoteWallet.p2pEnabled(
+            chainId: fixture.chainVectors.derivation.chainId,
+            accountId: signer.accountId,
+            attestationProvider: StaticAttestationProvider(certificate: attestation),
+            proofProvider: BindingProofProvider(),
+            proofVerifier: BindingProofVerifier(),
+            certificateVerifier: verifier,
+            ownerCertificateSigner: signer,
+            randomSource: QueueRandomSource(values: [Data(repeating: 0x72, count: 32)]),
+            idGenerator: FixedIdGenerator(id: fixture.chainVectors.derivation.paymentRequestId),
+            clock: { 1_700_000_001_210 }
+        )
+
+        let receiveRequest = try wallet.prepareReceive(
+            assetDefinitionId: Self.assetDefinition(fromAssetId: fixture.chainVectors.issue.assetId),
+            amount: fixture.chainVectors.redeem.amount
+        )
+
+        XCTAssertEqual(receiveRequest.accountId, signer.accountId)
+        XCTAssertTrue(try verifier.verifyOwnerCertificate(receiveRequest.keyCertificate))
+        XCTAssertFalse(try verifier.verifyIssuerCertificate(receiveRequest.keyCertificate))
+    }
+
     func testOfflineNoteModelsMatchRustNoritoVectors() throws {
         let fixture = try Self.loadFixture()
 
@@ -1282,7 +1323,8 @@ final class OfflineNoteTests: XCTestCase {
             transactionSubmitter: RecordingTransactionSubmitter(),
             proofProvider: BindingProofProvider(),
             proofVerifier: BindingProofVerifier(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
+            ownerCertificateSigner: StaticOwnerCertificateSigner(certificate: recipientCertificate),
             randomSource: QueueRandomSource(values: [
                 try Self.hex(derivation.recipientNoteSecretHex)
             ]),
@@ -1349,7 +1391,8 @@ final class OfflineNoteTests: XCTestCase {
             transactionSubmitter: RecordingTransactionSubmitter(),
             proofProvider: BindingProofProvider(),
             proofVerifier: BindingProofVerifier(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
+            ownerCertificateSigner: StaticOwnerCertificateSigner(certificate: senderCertificate),
             randomSource: QueueRandomSource(values: [
                 try Self.hex(derivation.recipientNoteSecretHex)
             ]),
@@ -1393,7 +1436,8 @@ final class OfflineNoteTests: XCTestCase {
             transactionSubmitter: RecordingTransactionSubmitter(),
             proofProvider: BindingProofProvider(),
             proofVerifier: BindingProofVerifier(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
+            ownerCertificateSigner: StaticOwnerCertificateSigner(certificate: recipientCertificate),
             randomSource: QueueRandomSource(values: [
                 try Self.hex(derivation.recipientNoteSecretHex)
             ]),
@@ -1998,7 +2042,7 @@ final class OfflineNoteTests: XCTestCase {
             issuerClient: issuerClient,
             transactionSubmitter: RecordingTransactionSubmitter(),
             proofProvider: BindingProofProvider(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
             randomSource: QueueRandomSource(values: [
                 try Self.hex(derivation.sourceNoteSecretHex)
             ]),
@@ -2041,7 +2085,7 @@ final class OfflineNoteTests: XCTestCase {
             issuerClient: issuerClient,
             transactionSubmitter: RecordingTransactionSubmitter(),
             proofProvider: BindingProofProvider(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
             randomSource: QueueRandomSource(values: [
                 try Self.hex(derivation.sourceNoteSecretHex)
             ]),
@@ -2366,7 +2410,8 @@ final class OfflineNoteTests: XCTestCase {
             transactionSubmitter: RecordingTransactionSubmitter(),
             proofProvider: BindingProofProvider(),
             proofVerifier: BindingProofVerifier(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
+            ownerCertificateSigner: StaticOwnerCertificateSigner(certificate: senderCertificate),
             randomSource: QueueRandomSource(values: [
                 try Self.hex(derivation.tokenNonceHex),
                 try Self.hex(derivation.changeNoteSecretHex)
@@ -2382,7 +2427,8 @@ final class OfflineNoteTests: XCTestCase {
             transactionSubmitter: recipientSubmitter,
             proofProvider: BindingProofProvider(),
             proofVerifier: BindingProofVerifier(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
+            ownerCertificateSigner: StaticOwnerCertificateSigner(certificate: recipientCertificate),
             randomSource: QueueRandomSource(values: [
                 try Self.hex(derivation.recipientNoteSecretHex)
             ]),
@@ -2442,7 +2488,8 @@ final class OfflineNoteTests: XCTestCase {
             syncResolver: syncResolver,
             proofProvider: BindingProofProvider(),
             proofVerifier: BindingProofVerifier(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
+            ownerCertificateSigner: StaticOwnerCertificateSigner(certificate: senderCertificate),
             randomSource: QueueRandomSource(values: [
                 try Self.hex(derivation.tokenNonceHex),
                 try Self.hex(derivation.changeNoteSecretHex)
@@ -2457,7 +2504,8 @@ final class OfflineNoteTests: XCTestCase {
             transactionSubmitter: RecordingTransactionSubmitter(),
             proofProvider: BindingProofProvider(),
             proofVerifier: BindingProofVerifier(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
+            ownerCertificateSigner: StaticOwnerCertificateSigner(certificate: recipientCertificate),
             randomSource: QueueRandomSource(values: [
                 try Self.hex(derivation.recipientNoteSecretHex)
             ]),
@@ -2505,7 +2553,8 @@ final class OfflineNoteTests: XCTestCase {
             transactionSubmitter: RecordingTransactionSubmitter(),
             proofProvider: BindingProofProvider(),
             proofVerifier: BindingProofVerifier(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
+            ownerCertificateSigner: StaticOwnerCertificateSigner(certificate: senderCertificate),
             randomSource: QueueRandomSource(values: [
                 try Self.hex(derivation.tokenNonceHex),
                 try Self.hex(derivation.changeNoteSecretHex)
@@ -2520,7 +2569,8 @@ final class OfflineNoteTests: XCTestCase {
             transactionSubmitter: RecordingTransactionSubmitter(),
             proofProvider: BindingProofProvider(),
             proofVerifier: BindingProofVerifier(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
+            ownerCertificateSigner: StaticOwnerCertificateSigner(certificate: recipientCertificate),
             randomSource: QueueRandomSource(values: [
                 try Self.hex(derivation.recipientNoteSecretHex)
             ]),
@@ -2574,7 +2624,8 @@ final class OfflineNoteTests: XCTestCase {
             transactionSubmitter: RecordingTransactionSubmitter(),
             proofProvider: BindingProofProvider(),
             proofVerifier: BindingProofVerifier(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
+            ownerCertificateSigner: StaticOwnerCertificateSigner(certificate: senderCertificate),
             randomSource: QueueRandomSource(values: [
                 try Self.hex(derivation.tokenNonceHex)
             ]),
@@ -2588,7 +2639,8 @@ final class OfflineNoteTests: XCTestCase {
             transactionSubmitter: RecordingTransactionSubmitter(),
             proofProvider: BindingProofProvider(),
             proofVerifier: BindingProofVerifier(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
+            ownerCertificateSigner: StaticOwnerCertificateSigner(certificate: recipientCertificate),
             randomSource: QueueRandomSource(values: [
                 try Self.hex(derivation.recipientNoteSecretHex)
             ]),
@@ -2623,7 +2675,7 @@ final class OfflineNoteTests: XCTestCase {
             transactionSubmitter: RecordingTransactionSubmitter(),
             proofProvider: BindingProofProvider(),
             proofVerifier: BindingProofVerifier(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
             randomSource: QueueRandomSource(values: []),
             idGenerator: FixedIdGenerator(id: derivation.paymentRequestId),
             clock: { 1_700_000_002_600 }
@@ -2651,7 +2703,7 @@ final class OfflineNoteTests: XCTestCase {
             transactionSubmitter: submitter,
             proofProvider: BindingProofProvider(),
             proofVerifier: BindingProofVerifier(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
             randomSource: QueueRandomSource(values: []),
             idGenerator: FixedIdGenerator(id: derivation.paymentRequestId),
             clock: { 1_700_000_004_000 }
@@ -2695,11 +2747,29 @@ final class OfflineNoteTests: XCTestCase {
         let senderAccountId = Self.accountId(fromAssetId: fixture.chainVectors.issue.assetId)
         let assetDefinitionId = Self.assetDefinition(fromAssetId: fixture.chainVectors.issue.assetId)
 
+        let missingSignerWallet = OfflineNoteWallet(
+            chainId: derivation.chainId,
+            accountId: fixture.paymentToken.recipientAccountId,
+            attestationProvider: StaticAttestationProvider(certificate: recipientCertificate),
+            proofProvider: BindingProofProvider(),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
+            randomSource: QueueRandomSource(values: []),
+            idGenerator: FixedIdGenerator(id: derivation.paymentRequestId),
+            clock: { 1_700_000_002_690 }
+        )
+        XCTAssertThrowsError(try missingSignerWallet.prepareReceive(
+            assetDefinitionId: assetDefinitionId,
+            amount: fixture.chainVectors.redeem.amount
+        )) { error in
+            XCTAssertEqual(error as? OfflineNoteWalletError, .missingOwnerCertificateSigner)
+        }
+
         let defaultRejectingWallet = OfflineNoteWallet(
             chainId: derivation.chainId,
             accountId: fixture.paymentToken.recipientAccountId,
             attestationProvider: StaticAttestationProvider(certificate: recipientCertificate),
             proofProvider: BindingProofProvider(),
+            ownerCertificateSigner: StaticOwnerCertificateSigner(certificate: recipientCertificate),
             randomSource: QueueRandomSource(values: []),
             idGenerator: FixedIdGenerator(id: derivation.paymentRequestId),
             clock: { 1_700_000_002_700 }
@@ -2715,7 +2785,8 @@ final class OfflineNoteTests: XCTestCase {
             accountId: senderAccountId,
             attestationProvider: StaticAttestationProvider(certificate: recipientCertificate),
             proofProvider: BindingProofProvider(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
+            ownerCertificateSigner: StaticOwnerCertificateSigner(certificate: recipientCertificate),
             randomSource: QueueRandomSource(values: []),
             idGenerator: FixedIdGenerator(id: derivation.paymentRequestId),
             clock: { 1_700_000_002_710 }
@@ -2737,7 +2808,8 @@ final class OfflineNoteTests: XCTestCase {
             transactionSubmitter: RecordingTransactionSubmitter(),
             proofProvider: BindingProofProvider(),
             proofVerifier: BindingProofVerifier(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
+            ownerCertificateSigner: StaticOwnerCertificateSigner(certificate: senderCertificate),
             randomSource: QueueRandomSource(values: [
                 try Self.hex(derivation.tokenNonceHex),
                 try Self.hex(derivation.changeNoteSecretHex)
@@ -2752,7 +2824,8 @@ final class OfflineNoteTests: XCTestCase {
             transactionSubmitter: RecordingTransactionSubmitter(),
             proofProvider: BindingProofProvider(),
             proofVerifier: BindingProofVerifier(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
+            ownerCertificateSigner: StaticOwnerCertificateSigner(certificate: recipientCertificate),
             randomSource: QueueRandomSource(values: [
                 try Self.hex(derivation.recipientNoteSecretHex)
             ]),
@@ -2809,7 +2882,8 @@ final class OfflineNoteTests: XCTestCase {
             transactionSubmitter: RecordingTransactionSubmitter(),
             proofProvider: BindingProofProvider(),
             proofVerifier: BindingProofVerifier(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
+            ownerCertificateSigner: StaticOwnerCertificateSigner(certificate: senderCertificate),
             randomSource: QueueRandomSource(values: [
                 Data(repeating: 0x21, count: 32),
                 Data(repeating: 0x22, count: 32)
@@ -2834,7 +2908,7 @@ final class OfflineNoteTests: XCTestCase {
             transactionSubmitter: RecordingTransactionSubmitter(),
             proofProvider: BindingProofProvider(),
             proofVerifier: BindingProofVerifier(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
             randomSource: QueueRandomSource(values: []),
             idGenerator: FixedIdGenerator(id: derivation.paymentRequestId),
             clock: { 1_700_000_002_900 }
@@ -2852,7 +2926,7 @@ final class OfflineNoteTests: XCTestCase {
             transactionSubmitter: RecordingTransactionSubmitter(),
             proofProvider: BindingProofProvider(),
             proofVerifier: BindingProofVerifier(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
             randomSource: QueueRandomSource(values: []),
             idGenerator: FixedIdGenerator(id: derivation.paymentRequestId),
             clock: { 1_700_000_002_910 }
@@ -2870,7 +2944,8 @@ final class OfflineNoteTests: XCTestCase {
             transactionSubmitter: RecordingTransactionSubmitter(),
             proofProvider: BindingProofProvider(),
             proofVerifier: BindingProofVerifier(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
+            ownerCertificateSigner: StaticOwnerCertificateSigner(certificate: senderCertificate),
             randomSource: QueueRandomSource(values: [
                 Data(repeating: 0x31, count: 32),
                 Data(repeating: 0x32, count: 32)
@@ -2904,7 +2979,8 @@ final class OfflineNoteTests: XCTestCase {
             transactionSubmitter: RecordingTransactionSubmitter(),
             proofProvider: BindingProofProvider(),
             proofVerifier: BindingProofVerifier(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
+            ownerCertificateSigner: StaticOwnerCertificateSigner(certificate: senderCertificate),
             randomSource: QueueRandomSource(values: [
                 Data(repeating: 0x41, count: 32),
                 Data(repeating: 0x42, count: 32)
@@ -3063,7 +3139,8 @@ final class OfflineNoteTests: XCTestCase {
             transactionSubmitter: RecordingTransactionSubmitter(),
             proofProvider: BindingProofProvider(),
             proofVerifier: BindingProofVerifier(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
+            ownerCertificateSigner: StaticOwnerCertificateSigner(certificate: senderCertificate),
             randomSource: QueueRandomSource(values: [
                 try Self.hex(derivation.tokenNonceHex),
                 try Self.hex(derivation.changeNoteSecretHex)
@@ -3081,7 +3158,8 @@ final class OfflineNoteTests: XCTestCase {
             transactionSubmitter: recipientSubmitter,
             proofProvider: BindingProofProvider(),
             proofVerifier: BindingProofVerifier(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
+            ownerCertificateSigner: StaticOwnerCertificateSigner(certificate: recipientCertificate),
             randomSource: QueueRandomSource(values: [
                 try Self.hex(derivation.recipientNoteSecretHex)
             ]),
@@ -3136,7 +3214,7 @@ final class OfflineNoteTests: XCTestCase {
             transactionSubmitter: submitter,
             proofProvider: BindingProofProvider(),
             proofVerifier: BindingProofVerifier(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
             randomSource: QueueRandomSource(values: []),
             idGenerator: FixedIdGenerator(id: derivation.paymentRequestId),
             clock: { 1_700_000_003_000 }
@@ -3168,7 +3246,8 @@ final class OfflineNoteTests: XCTestCase {
             ]),
             proofProvider: BindingProofProvider(),
             proofVerifier: BindingProofVerifier(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
+            ownerCertificateSigner: StaticOwnerCertificateSigner(certificate: senderCertificate),
             randomSource: QueueRandomSource(values: [
                 try Self.hex(derivation.tokenNonceHex),
                 try Self.hex(derivation.changeNoteSecretHex)
@@ -3188,7 +3267,8 @@ final class OfflineNoteTests: XCTestCase {
             ]),
             proofProvider: BindingProofProvider(),
             proofVerifier: BindingProofVerifier(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
+            ownerCertificateSigner: StaticOwnerCertificateSigner(certificate: recipientCertificate),
             randomSource: QueueRandomSource(values: [
                 try Self.hex(derivation.recipientNoteSecretHex)
             ]),
@@ -3234,7 +3314,7 @@ final class OfflineNoteTests: XCTestCase {
             ]),
             proofProvider: BindingProofProvider(),
             proofVerifier: BindingProofVerifier(),
-            certificateVerifier: try Self.certificateVerifier(fixture),
+            certificateVerifier: try Self.fixtureOwnerCertificateVerifier(fixture),
             randomSource: QueueRandomSource(values: []),
             idGenerator: FixedIdGenerator(id: derivation.paymentRequestId),
             clock: { 1_700_000_002_600 }
@@ -4123,6 +4203,13 @@ final class OfflineNoteTests: XCTestCase {
         )
     }
 
+    private static func fixtureOwnerCertificateVerifier(
+        _ fixture: OfflineInteropFixture
+    ) throws -> OfflineNoteCertificateVerifier {
+        let delegate = try certificateVerifier(fixture)
+        return FixtureOwnerCertificateVerifier(delegate: delegate)
+    }
+
     private static func tamperedSignatureCertificate(
         _ certificate: OfflineNoteKeyCertificate
     ) throws -> OfflineNoteKeyCertificate {
@@ -4692,6 +4779,73 @@ final class OfflineNoteTests: XCTestCase {
 
         func currentKeyCertificate() throws -> OfflineNoteKeyCertificate {
             certificate
+        }
+    }
+
+    private struct StaticOwnerCertificateSigner: OfflineNoteOwnerCertificateSigner {
+        let certificate: OfflineNoteKeyCertificate
+
+        func freshOwnerCertificate(accountId: String) throws -> OfflineNoteKeyCertificate {
+            certificate
+        }
+    }
+
+    private struct FixtureOwnerCertificateVerifier: OfflineNoteCertificateVerifier {
+        let delegate: Ed25519OfflineNoteCertificateVerifier
+
+        func verifyIssuerCertificate(_ certificate: OfflineNoteKeyCertificate) throws -> Bool {
+            try delegate.verifyIssuerCertificate(certificate)
+        }
+
+        func verifyOwnerCertificate(_ certificate: OfflineNoteKeyCertificate) throws -> Bool {
+            try delegate.verifyOwnerCertificate(certificate)
+                || delegate.verifyIssuerCertificate(certificate)
+        }
+    }
+
+    private final class SoftwareOwnerCertificateSigner: OfflineNoteOwnerCertificateSigner {
+        let accountId: String
+        private let ownerKeypair: Keypair
+        private var counter: UInt8 = 1
+
+        init(privateKeyByte: UInt8) throws {
+            ownerKeypair = try Keypair(privateKeyBytes: Data(repeating: privateKeyByte, count: 32))
+            accountId = AccountId.make(publicKey: ownerKeypair.publicKey)
+        }
+
+        func freshOwnerCertificate(accountId: String) throws -> OfflineNoteKeyCertificate {
+            guard accountId == self.accountId else {
+                throw OfflineNoteWalletError.certificateVerificationFailed
+            }
+            let certificateIndex = counter
+            counter &+= 1
+            let noteKeypair = try Keypair(privateKeyBytes: Data(repeating: certificateIndex, count: 32))
+            let unsigned = try OfflineNoteKeyCertificate(
+                platform: "swift-software-ed25519",
+                keyId: "owner-key-\(certificateIndex)",
+                deviceId: "swift-test-device",
+                accountId: accountId,
+                publicKey: noteKeypair.publicKey,
+                assertionScheme: "self-signed",
+                assertionKeyAlgorithm: "ed25519",
+                assertionPublicKey: ownerKeypair.publicKey,
+                assertionUsageCountLimit: 1,
+                issuerSignature: Data(repeating: 0, count: 64)
+            )
+            return try OfflineNoteKeyCertificate(
+                version: unsigned.version,
+                platform: unsigned.platform,
+                keyId: unsigned.keyId,
+                deviceId: unsigned.deviceId,
+                accountId: unsigned.accountId,
+                publicKey: unsigned.publicKey,
+                assertionScheme: unsigned.assertionScheme,
+                assertionKeyAlgorithm: unsigned.assertionKeyAlgorithm,
+                assertionPublicKey: unsigned.assertionPublicKey,
+                assertionUsageCountLimit: unsigned.assertionUsageCountLimit,
+                oneUse: unsigned.oneUse,
+                issuerSignature: ownerKeypair.sign(unsigned.signingBytes())
+            )
         }
     }
 

--- a/IrohaSwift/Tests/IrohaSwiftTests/OfflineNoteTests.swift
+++ b/IrohaSwift/Tests/IrohaSwiftTests/OfflineNoteTests.swift
@@ -16,6 +16,7 @@ final class OfflineNoteTests: XCTestCase {
             fixture.chainVectors.certificates.senderPayloadHash
         )
         XCTAssertTrue(try verifier.verifyIssuerCertificate(sender))
+        XCTAssertFalse(try verifier.verifyOwnerCertificate(sender))
 
         var tamperedSignature = sender.issuerSignature
         tamperedSignature[tamperedSignature.startIndex] ^= 0x01
@@ -35,6 +36,7 @@ final class OfflineNoteTests: XCTestCase {
         )
         XCTAssertFalse(try verifier.verifyIssuerCertificate(tampered))
         XCTAssertFalse(try RejectingOfflineNoteCertificateVerifier().verifyIssuerCertificate(sender))
+        XCTAssertFalse(try RejectingOfflineNoteCertificateVerifier().verifyOwnerCertificate(sender))
         XCTAssertFalse(try Ed25519OfflineNoteCertificateVerifier(
             trustedIssuerPublicKeys: [Data(repeating: 0x42, count: 32)]
         ).verifyIssuerCertificate(sender))
@@ -51,6 +53,42 @@ final class OfflineNoteTests: XCTestCase {
 
         let tampered = try Self.tamperedSignatureCertificate(certificate)
         XCTAssertFalse(try verifier.verifyOwnerCertificate(tampered))
+    }
+
+    func testCertificateVerifierRejectsAdversarialOwnerAndIssuerCertificateShapes() throws {
+        let issuer = try SoftwareIssuerCertificateSigner(privateKeyByte: 0x63)
+        let owner = try SoftwareOwnerCertificateSigner(privateKeyByte: 0x64)
+        let otherOwner = try SoftwareOwnerCertificateSigner(privateKeyByte: 0x65)
+        let verifier = Ed25519OfflineNoteCertificateVerifier(trustedIssuerPublicKeys: [issuer.publicKey])
+
+        XCTAssertTrue(try verifier.verifyIssuerCertificate(try issuer.issuerCertificate(accountId: owner.accountId)))
+        XCTAssertFalse(try verifier.verifyOwnerCertificate(
+            try owner.ownerSignedCertificate(accountId: otherOwner.accountId)
+        ))
+
+        let ownerShapeMutations = try [
+            owner.ownerSignedCertificate(platform: " "),
+            owner.ownerSignedCertificate(keyId: "\n\t"),
+            owner.ownerSignedCertificate(deviceId: ""),
+            owner.ownerSignedCertificate(assertionScheme: " "),
+            owner.ownerSignedCertificate(assertionKeyAlgorithm: ""),
+            owner.ownerSignedCertificate(assertionPublicKey: Data())
+        ]
+        for certificate in ownerShapeMutations {
+            XCTAssertFalse(try verifier.verifyOwnerCertificate(certificate))
+        }
+
+        let issuerShapeMutations = try [
+            issuer.issuerCertificate(accountId: owner.accountId, platform: " "),
+            issuer.issuerCertificate(accountId: owner.accountId, keyId: ""),
+            issuer.issuerCertificate(accountId: owner.accountId, deviceId: " "),
+            issuer.issuerCertificate(accountId: owner.accountId, assertionScheme: ""),
+            issuer.issuerCertificate(accountId: owner.accountId, assertionKeyAlgorithm: "\t"),
+            issuer.issuerCertificate(accountId: owner.accountId, assertionPublicKey: Data())
+        ]
+        for certificate in issuerShapeMutations {
+            XCTAssertFalse(try verifier.verifyIssuerCertificate(certificate))
+        }
     }
 
     func testP2pEnabledWalletRequiresAndUsesOwnerCertificateSigner() throws {
@@ -79,6 +117,200 @@ final class OfflineNoteTests: XCTestCase {
         XCTAssertEqual(receiveRequest.accountId, signer.accountId)
         XCTAssertTrue(try verifier.verifyOwnerCertificate(receiveRequest.keyCertificate))
         XCTAssertFalse(try verifier.verifyIssuerCertificate(receiveRequest.keyCertificate))
+    }
+
+    func testP2pEnabledWalletUsesFreshOwnerCertificatesForOutputsAndRedeem() async throws {
+        let fixture = try Self.loadFixture()
+        let derivation = fixture.chainVectors.derivation
+        let assetDefinitionId = Self.assetDefinition(fromAssetId: fixture.chainVectors.issue.assetId)
+        let issuer = try SoftwareIssuerCertificateSigner(privateKeyByte: 0x66)
+        let verifier = Ed25519OfflineNoteCertificateVerifier(trustedIssuerPublicKeys: [issuer.publicKey])
+        let senderSigner = try SoftwareOwnerCertificateSigner(privateKeyByte: 0x67)
+        let recipientSigner = try SoftwareOwnerCertificateSigner(privateKeyByte: 0x68)
+        let senderCertificate = try issuer.issuerCertificate(accountId: senderSigner.accountId)
+        let recipientAttestation = try issuer.issuerCertificate(accountId: recipientSigner.accountId)
+        let senderStore = InMemoryOfflineNoteStore()
+        try senderStore.upsert(try Self.issuerSourceWalletNote(
+            chainId: derivation.chainId,
+            accountId: senderSigner.accountId,
+            assetDefinitionId: assetDefinitionId,
+            amount: fixture.chainVectors.issue.amount,
+            keyCertificate: senderCertificate,
+            noteCommitment: Self.validHash("production-p2p-source-commitment"),
+            noteSecret: Data(repeating: 0x92, count: 32),
+            operationSuffix: "production-p2p-source",
+            createdAtMs: 1_700_000_010_000
+        ))
+        let senderWallet = OfflineNoteWallet.p2pEnabled(
+            chainId: derivation.chainId,
+            accountId: senderSigner.accountId,
+            attestationProvider: StaticAttestationProvider(certificate: senderCertificate),
+            store: senderStore,
+            transactionSubmitter: RecordingTransactionSubmitter(),
+            proofProvider: BindingProofProvider(),
+            proofVerifier: BindingProofVerifier(),
+            certificateVerifier: verifier,
+            ownerCertificateSigner: senderSigner,
+            randomSource: QueueRandomSource(values: [
+                Data(repeating: 0x93, count: 32),
+                Data(repeating: 0x94, count: 32)
+            ]),
+            idGenerator: FixedIdGenerator(id: "\(derivation.paymentRequestId)-production"),
+            clock: { 1_700_000_010_200 }
+        )
+        let recipientStore = InMemoryOfflineNoteStore()
+        let recipientSubmitter = RecordingTransactionSubmitter()
+        let recipientWallet = OfflineNoteWallet.p2pEnabled(
+            chainId: derivation.chainId,
+            accountId: recipientSigner.accountId,
+            attestationProvider: StaticAttestationProvider(certificate: recipientAttestation),
+            store: recipientStore,
+            transactionSubmitter: recipientSubmitter,
+            proofProvider: BindingProofProvider(),
+            proofVerifier: BindingProofVerifier(),
+            certificateVerifier: verifier,
+            ownerCertificateSigner: recipientSigner,
+            randomSource: QueueRandomSource(values: [
+                Data(repeating: 0x95, count: 32)
+            ]),
+            idGenerator: FixedIdGenerator(id: "\(derivation.paymentRequestId)-production"),
+            clock: { 1_700_000_010_100 }
+        )
+
+        let receiveRequest = try recipientWallet.prepareReceive(
+            assetDefinitionId: assetDefinitionId,
+            amount: fixture.chainVectors.redeem.amount
+        )
+        XCTAssertEqual(receiveRequest.accountId, recipientSigner.accountId)
+        XCTAssertTrue(try verifier.verifyOwnerCertificate(receiveRequest.keyCertificate))
+        XCTAssertFalse(try verifier.verifyIssuerCertificate(receiveRequest.keyCertificate))
+
+        let token = try senderWallet.pay(receiveRequest)
+
+        XCTAssertEqual(token.audit.outputClaims.count, 2)
+        let recipientOutput = token.audit.outputClaims[0]
+        let changeOutput = token.audit.outputClaims[1]
+        XCTAssertEqual(recipientOutput.keyCertificate.accountId, recipientSigner.accountId)
+        XCTAssertEqual(changeOutput.keyCertificate.accountId, senderSigner.accountId)
+        XCTAssertTrue(try verifier.verifyOwnerCertificate(recipientOutput.keyCertificate))
+        XCTAssertTrue(try verifier.verifyOwnerCertificate(changeOutput.keyCertificate))
+        XCTAssertFalse(try verifier.verifyIssuerCertificate(recipientOutput.keyCertificate))
+        XCTAssertFalse(try verifier.verifyIssuerCertificate(changeOutput.keyCertificate))
+        XCTAssertNotEqual(try senderCertificate.payloadHash(), try recipientOutput.keyCertificate.payloadHash())
+        XCTAssertNotEqual(try senderCertificate.payloadHash(), try changeOutput.keyCertificate.payloadHash())
+        XCTAssertNotEqual(try recipientOutput.keyCertificate.payloadHash(), try changeOutput.keyCertificate.payloadHash())
+        XCTAssertNotEqual(recipientOutput.keyCertificate.publicKey, changeOutput.keyCertificate.publicKey)
+
+        let accepted = try recipientWallet.accept(token)
+        _ = try await recipientWallet.redeem(accepted)
+
+        XCTAssertEqual(recipientSubmitter.defunds.count, 1)
+        let defund = try XCTUnwrap(recipientSubmitter.defunds.first)
+        XCTAssertEqual(defund.bearerAuditTrail.map(\.tokenId), [token.tokenId])
+        XCTAssertTrue(try verifier.verifyOwnerCertificate(defund.redemption.senderKeyCertificate))
+    }
+
+    func testP2pEnabledWalletRejectsDuplicateOutputOwnerCertificates() throws {
+        let fixture = try Self.loadFixture()
+        let derivation = fixture.chainVectors.derivation
+        let assetDefinitionId = Self.assetDefinition(fromAssetId: fixture.chainVectors.issue.assetId)
+        let issuer = try SoftwareIssuerCertificateSigner(privateKeyByte: 0x69)
+        let signer = try SoftwareOwnerCertificateSigner(privateKeyByte: 0x6A)
+        let verifier = Ed25519OfflineNoteCertificateVerifier(trustedIssuerPublicKeys: [issuer.publicKey])
+        let issuerCertificate = try issuer.issuerCertificate(accountId: signer.accountId)
+        let reusedOwnerCertificate = try signer.freshOwnerCertificate(accountId: signer.accountId)
+        let store = InMemoryOfflineNoteStore()
+        try store.upsert(try Self.issuerSourceWalletNote(
+            chainId: derivation.chainId,
+            accountId: signer.accountId,
+            assetDefinitionId: assetDefinitionId,
+            amount: fixture.chainVectors.issue.amount,
+            keyCertificate: issuerCertificate,
+            noteCommitment: Self.validHash("duplicate-owner-certificate-source-commitment"),
+            noteSecret: Data(repeating: 0x97, count: 32),
+            operationSuffix: "duplicate-owner-certificate-source",
+            createdAtMs: 1_700_000_011_000
+        ))
+        let wallet = OfflineNoteWallet.p2pEnabled(
+            chainId: derivation.chainId,
+            accountId: signer.accountId,
+            attestationProvider: StaticAttestationProvider(certificate: issuerCertificate),
+            store: store,
+            transactionSubmitter: RecordingTransactionSubmitter(),
+            proofProvider: BindingProofProvider(),
+            proofVerifier: BindingProofVerifier(),
+            certificateVerifier: verifier,
+            ownerCertificateSigner: StaticOwnerCertificateSigner(certificate: reusedOwnerCertificate),
+            randomSource: QueueRandomSource(values: [
+                Data(repeating: 0x98, count: 32),
+                Data(repeating: 0x99, count: 32),
+                Data(repeating: 0x9A, count: 32)
+            ]),
+            idGenerator: FixedIdGenerator(id: "\(derivation.paymentRequestId)-duplicate-owner-cert"),
+            clock: { 1_700_000_011_100 }
+        )
+        let receiveRequest = try wallet.prepareReceive(
+            assetDefinitionId: assetDefinitionId,
+            amount: fixture.chainVectors.redeem.amount
+        )
+
+        XCTAssertThrowsError(try wallet.pay(receiveRequest)) { error in
+            XCTAssertEqual(error as? OfflineNoteWalletError, .certificateVerificationFailed)
+        }
+        let sourceNote = try XCTUnwrap(store.listNotes().first { $0.state == .spendable })
+        XCTAssertEqual(sourceNote.noteCommitment, Self.validHash("duplicate-owner-certificate-source-commitment"))
+    }
+
+    func testP2pEnabledWalletRejectsInboundDuplicateOutputOwnerCertificates() throws {
+        let fixture = try Self.loadFixture()
+        let derivation = fixture.chainVectors.derivation
+        let assetDefinitionId = Self.assetDefinition(fromAssetId: fixture.chainVectors.issue.assetId)
+        let issuer = try SoftwareIssuerCertificateSigner(privateKeyByte: 0x6B)
+        let signer = try SoftwareOwnerCertificateSigner(privateKeyByte: 0x6C)
+        let verifier = Ed25519OfflineNoteCertificateVerifier(trustedIssuerPublicKeys: [issuer.publicKey])
+        let issuerCertificate = try issuer.issuerCertificate(accountId: signer.accountId)
+        let store = InMemoryOfflineNoteStore()
+        try store.upsert(try Self.issuerSourceWalletNote(
+            chainId: derivation.chainId,
+            accountId: signer.accountId,
+            assetDefinitionId: assetDefinitionId,
+            amount: fixture.chainVectors.issue.amount,
+            keyCertificate: issuerCertificate,
+            noteCommitment: Self.validHash("inbound-duplicate-owner-certificate-source-commitment"),
+            noteSecret: Data(repeating: 0x9B, count: 32),
+            operationSuffix: "inbound-duplicate-owner-certificate-source",
+            createdAtMs: 1_700_000_011_200
+        ))
+        let wallet = OfflineNoteWallet.p2pEnabled(
+            chainId: derivation.chainId,
+            accountId: signer.accountId,
+            attestationProvider: StaticAttestationProvider(certificate: issuerCertificate),
+            store: store,
+            transactionSubmitter: RecordingTransactionSubmitter(),
+            proofProvider: BindingProofProvider(),
+            proofVerifier: BindingProofVerifier(),
+            certificateVerifier: verifier,
+            ownerCertificateSigner: signer,
+            randomSource: QueueRandomSource(values: [
+                Data(repeating: 0x9C, count: 32),
+                Data(repeating: 0x9D, count: 32),
+                Data(repeating: 0x9E, count: 32)
+            ]),
+            idGenerator: FixedIdGenerator(id: "\(derivation.paymentRequestId)-inbound-duplicate-owner-cert"),
+            clock: { 1_700_000_011_300 }
+        )
+        let receiveRequest = try wallet.prepareReceive(
+            assetDefinitionId: assetDefinitionId,
+            amount: fixture.chainVectors.redeem.amount
+        )
+        let token = try wallet.pay(receiveRequest)
+        XCTAssertEqual(token.audit.outputClaims.count, 2)
+
+        let duplicatedCertificate = token.audit.outputClaims[0].keyCertificate
+        let forgedToken = try Self.paymentTokenReplacingLastOutputCertificate(token, certificate: duplicatedCertificate)
+        XCTAssertThrowsError(try wallet.accept(forgedToken)) { error in
+            XCTAssertEqual(error as? OfflineNoteWalletError, .certificateVerificationFailed)
+        }
     }
 
     func testOfflineNoteModelsMatchRustNoritoVectors() throws {
@@ -4231,6 +4463,48 @@ final class OfflineNoteTests: XCTestCase {
         )
     }
 
+    private static func signedKeyCertificate(
+        signingKeypair: Keypair,
+        accountId: String,
+        publicKey: Data,
+        assertionPublicKey: Data,
+        assertionScheme: String,
+        assertionKeyAlgorithm: String = "ed25519",
+        assertionUsageCountLimit: UInt32? = 1,
+        oneUse: Bool = true,
+        platform: String,
+        keyId: String,
+        deviceId: String = "swift-test-device"
+    ) throws -> OfflineNoteKeyCertificate {
+        let unsigned = try OfflineNoteKeyCertificate(
+            platform: platform,
+            keyId: keyId,
+            deviceId: deviceId,
+            accountId: accountId,
+            publicKey: publicKey,
+            assertionScheme: assertionScheme,
+            assertionKeyAlgorithm: assertionKeyAlgorithm,
+            assertionPublicKey: assertionPublicKey,
+            assertionUsageCountLimit: assertionUsageCountLimit,
+            oneUse: oneUse,
+            issuerSignature: Data(repeating: 0, count: 64)
+        )
+        return try OfflineNoteKeyCertificate(
+            version: unsigned.version,
+            platform: unsigned.platform,
+            keyId: unsigned.keyId,
+            deviceId: unsigned.deviceId,
+            accountId: unsigned.accountId,
+            publicKey: unsigned.publicKey,
+            assertionScheme: unsigned.assertionScheme,
+            assertionKeyAlgorithm: unsigned.assertionKeyAlgorithm,
+            assertionPublicKey: unsigned.assertionPublicKey,
+            assertionUsageCountLimit: unsigned.assertionUsageCountLimit,
+            oneUse: unsigned.oneUse,
+            issuerSignature: signingKeypair.sign(unsigned.signingBytes())
+        )
+    }
+
     private static func paymentTokenReplacingFirstOutputCertificate(
         _ token: OfflineNotePaymentToken,
         certificate: OfflineNoteKeyCertificate
@@ -4630,6 +4904,10 @@ final class OfflineNoteTests: XCTestCase {
         return copy
     }
 
+    private static func validHash(_ label: String) -> Data {
+        IrohaHash.hash(Data(label.utf8))
+    }
+
     private static func paymentTokenReplacingAuditClaims(
         _ token: OfflineNotePaymentToken,
         inputClaims: [OfflineNoteIssuedClaim],
@@ -4699,6 +4977,36 @@ final class OfflineNoteTests: XCTestCase {
             state: .spendable,
             createdAtMs: 1_700_000_000_000,
             updatedAtMs: 1_700_000_000_000
+        )
+    }
+
+    private static func issuerSourceWalletNote(
+        chainId: String,
+        accountId: String,
+        assetDefinitionId: String,
+        amount: String,
+        keyCertificate: OfflineNoteKeyCertificate,
+        noteCommitment: Data,
+        noteSecret: Data,
+        operationSuffix: String,
+        createdAtMs: UInt64
+    ) throws -> OfflineNoteWalletNote {
+        try OfflineNoteWalletNote(
+            chainId: chainId,
+            accountId: accountId,
+            assetId: "\(assetDefinition(fromAssetId: assetDefinitionId))#\(accountId)",
+            amount: amount,
+            keyCertificate: keyCertificate,
+            noteCommitment: noteCommitment,
+            noteSecret: noteSecret,
+            origin: .issuerLoad(OfflineNoteIssuerLoadOrigin(
+                operationId: "issuer-load-\(operationSuffix)",
+                lineageId: "issuer-lineage-\(operationSuffix)",
+                localRevision: 1
+            )),
+            state: .spendable,
+            createdAtMs: createdAtMs,
+            updatedAtMs: createdAtMs
         )
     }
 
@@ -4806,45 +5114,81 @@ final class OfflineNoteTests: XCTestCase {
     private final class SoftwareOwnerCertificateSigner: OfflineNoteOwnerCertificateSigner {
         let accountId: String
         private let ownerKeypair: Keypair
-        private var counter: UInt8 = 1
+        private var counter: UInt8
 
         init(privateKeyByte: UInt8) throws {
             ownerKeypair = try Keypair(privateKeyBytes: Data(repeating: privateKeyByte, count: 32))
             accountId = AccountId.make(publicKey: ownerKeypair.publicKey)
+            counter = privateKeyByte &+ 1
         }
 
         func freshOwnerCertificate(accountId: String) throws -> OfflineNoteKeyCertificate {
             guard accountId == self.accountId else {
                 throw OfflineNoteWalletError.certificateVerificationFailed
             }
+            return try ownerSignedCertificate(accountId: accountId)
+        }
+
+        func ownerSignedCertificate(
+            accountId: String? = nil,
+            platform: String = "swift-software-ed25519",
+            keyId: String? = nil,
+            deviceId: String = "swift-test-device",
+            assertionScheme: String = "self-signed",
+            assertionKeyAlgorithm: String = "ed25519",
+            assertionPublicKey: Data? = nil
+        ) throws -> OfflineNoteKeyCertificate {
             let certificateIndex = counter
             counter &+= 1
             let noteKeypair = try Keypair(privateKeyBytes: Data(repeating: certificateIndex, count: 32))
-            let unsigned = try OfflineNoteKeyCertificate(
-                platform: "swift-software-ed25519",
-                keyId: "owner-key-\(certificateIndex)",
-                deviceId: "swift-test-device",
+            return try signedKeyCertificate(
+                signingKeypair: ownerKeypair,
+                accountId: accountId ?? self.accountId,
+                publicKey: noteKeypair.publicKey,
+                assertionPublicKey: assertionPublicKey ?? ownerKeypair.publicKey,
+                assertionScheme: assertionScheme,
+                assertionKeyAlgorithm: assertionKeyAlgorithm,
+                assertionUsageCountLimit: 1,
+                platform: platform,
+                keyId: keyId ?? "owner-key-\(certificateIndex)",
+                deviceId: deviceId
+            )
+        }
+    }
+
+    private final class SoftwareIssuerCertificateSigner {
+        let publicKey: Data
+        private let issuerKeypair: Keypair
+        private var counter: UInt8 = 0x80
+
+        init(privateKeyByte: UInt8) throws {
+            issuerKeypair = try Keypair(privateKeyBytes: Data(repeating: privateKeyByte, count: 32))
+            publicKey = issuerKeypair.publicKey
+        }
+
+        func issuerCertificate(
+            accountId: String,
+            platform: String = "swift-test-issuer",
+            keyId: String? = nil,
+            deviceId: String = "swift-test-device",
+            assertionScheme: String = "issuer-attested",
+            assertionKeyAlgorithm: String = "ed25519",
+            assertionPublicKey: Data? = nil
+        ) throws -> OfflineNoteKeyCertificate {
+            let certificateIndex = counter
+            counter &+= 1
+            let noteKeypair = try Keypair(privateKeyBytes: Data(repeating: certificateIndex, count: 32))
+            return try signedKeyCertificate(
+                signingKeypair: issuerKeypair,
                 accountId: accountId,
                 publicKey: noteKeypair.publicKey,
-                assertionScheme: "self-signed",
-                assertionKeyAlgorithm: "ed25519",
-                assertionPublicKey: ownerKeypair.publicKey,
+                assertionPublicKey: assertionPublicKey ?? noteKeypair.publicKey,
+                assertionScheme: assertionScheme,
+                assertionKeyAlgorithm: assertionKeyAlgorithm,
                 assertionUsageCountLimit: 1,
-                issuerSignature: Data(repeating: 0, count: 64)
-            )
-            return try OfflineNoteKeyCertificate(
-                version: unsigned.version,
-                platform: unsigned.platform,
-                keyId: unsigned.keyId,
-                deviceId: unsigned.deviceId,
-                accountId: unsigned.accountId,
-                publicKey: unsigned.publicKey,
-                assertionScheme: unsigned.assertionScheme,
-                assertionKeyAlgorithm: unsigned.assertionKeyAlgorithm,
-                assertionPublicKey: unsigned.assertionPublicKey,
-                assertionUsageCountLimit: unsigned.assertionUsageCountLimit,
-                oneUse: unsigned.oneUse,
-                issuerSignature: ownerKeypair.sign(unsigned.signingBytes())
+                platform: platform,
+                keyId: keyId ?? "issuer-key-\(certificateIndex)",
+                deviceId: deviceId
             )
         }
     }


### PR DESCRIPTION
Ports the #5589 owner-signed offline-note key-certificate model to the Swift SDK (already in Kotlin/Java/JS, enforced on-chain at `offline.rs ensure_offline_note_certificate_signature`). IrohaSwift only had a single `verifyCertificate`, so P2P receive/audit (which needs an owner-self-signed output cert) couldn't be verified.

- Split `OfflineNoteCertificateVerifier` -> `verifyIssuerCertificate` (trusted issuer roots, for load/topup) + `verifyOwnerCertificate` (self-signed: derive the Ed25519 signatory from the cert's own `accountId`, for P2P audit-output claims). Update `RejectingOfflineNoteCertificateVerifier` + `Ed25519OfflineNoteCertificateVerifier`; add `ownerSignatoryKey(accountId)` + `hasValidAttestationShape`.
- Add `OfflineNoteOwnerCertificateSigner` (app-implemented because only the app holds the owner account key). The wallet gains an optional `ownerCertificateSigner` and mints a fresh owner-self-signed cert for `prepareReceive` and change outputs; verification routes issuer/owner/either by commitment origin (IssuerLoad vs P2pOutput), matching `requireTrustedAuditCertificates` in `OfflineNoteWallet.kt`.
- Keep the low-level `OfflineNoteWallet` initializer compatible for issuer-mediated/non-P2P workflows, and add `OfflineNoteWallet.p2pEnabled(...)` as the constructor for P2P flows that must provide both `certificateVerifier` and `ownerCertificateSigner`.
- Reject duplicate P2P audit output key-certificate payload hashes in Swift wallet token validation, matching the chain/runtime invariant for output key certificates.
- All crypto is pure-Swift CryptoKit (Curve25519) over `OfflineNoteKeyCertificate.signingBytes()`; no NoritoBridge FFI change.

## Testing

- `swift test --filter 'OfflineNoteTests/testCertificateSigningBytesMatchRustVector|OfflineNoteTests/testCertificateVerifierRejectsAdversarialOwnerAndIssuerCertificateShapes|OfflineNoteTests/testP2pEnabledWalletUsesFreshOwnerCertificatesForOutputsAndRedeem|OfflineNoteTests/testP2pEnabledWalletRejectsDuplicateOutputOwnerCertificates|OfflineNoteTests/testP2pEnabledWalletRejectsInboundDuplicateOutputOwnerCertificates'` from `IrohaSwift` (5 tests passed).
- `swift test --filter OfflineNoteTests` from `IrohaSwift` (75 tests passed).
- `swift test` from `IrohaSwift` (1184 tests executed, 12 skipped, 1 local environment failure in `NativeBridgeLoaderTests.testManifestlessBridgeUsesPinnedFallbackHash`: the symlinked local `NoritoBridge` artifact hash is `d1dc2069532ff760e03ebf66fdd17811d8d7fa520dcd9f9048b61bbcbcffc3e2`, while the pinned fallback hash expects `daedce952f4e3929ec3b22bad67d3f9c9b334be95e282ecdc9fa878f1cfae26b`).
- `swift test --filter NativeBridgeLoaderTests/testManifestlessBridgeUsesPinnedFallbackHash` from `IrohaSwift` reproduces the same local bridge-hash failure.
- `git diff --check`.

Previous validation: cbdc-ios builds green, on-chain redeem passes gas-free; reviewed against the chain enforcement + the Kotlin SDK + the `signed_sample_certificate` recipe.
