### PR TITLE
Add VerifyingKeyBox Norito codec to Kotlin SDK

### DIFF
--- a/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/offline/OfflineNote.kt
+++ b/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/offline/OfflineNote.kt
@@ -60,6 +60,7 @@ object OfflineNote {
         "iroha_data_model::offline::model::OfflineNoteAuditOutputClaim"
     private const val RECURSIVE_PROOF_SCHEMA =
         "iroha_data_model::offline::model::OfflineNoteRecursiveProof"
+    private const val VERIFYING_KEY_BOX_SCHEMA = "iroha_data_model::proof::VerifyingKeyBox"
     private const val REDEEM_SCHEMA = "iroha_data_model::offline::model::OfflineNoteRedeem"
     private const val REDEEM_PUBLIC_INPUTS_SCHEMA =
         "iroha_data_model::offline::model::OfflineNoteRedeemPublicInputs"
@@ -99,6 +100,10 @@ object OfflineNote {
     @JvmStatic
     fun encodeRedeem(value: Redeem): ByteArray =
         encodeWithHeader(value, REDEEM_SCHEMA, RedeemAdapter)
+
+    @JvmStatic
+    fun encodeVerifyingKeyBox(value: VerifyingKeyBox): ByteArray =
+        encodeWithHeader(value, VERIFYING_KEY_BOX_SCHEMA, VerifyingKeyBoxAdapter)
 
     @JvmStatic
     fun encodeRedeemPublicInputs(value: RedeemPublicInputs): ByteArray =
@@ -141,12 +146,12 @@ object OfflineNote {
         decodeWithHeader(bytes, ISSUED_CLAIM_SCHEMA, IssuedClaimAdapter)
 
     @JvmStatic
-    fun decodeRecursiveProof(bytes: ByteArray): RecursiveProof =
-        decodeWithHeader(bytes, RECURSIVE_PROOF_SCHEMA, RecursiveProofAdapter)
-
-    @JvmStatic
     fun decodeRedeem(bytes: ByteArray): Redeem =
         decodeWithHeader(bytes, REDEEM_SCHEMA, RedeemAdapter)
+
+    @JvmStatic
+    fun decodeRecursiveProof(bytes: ByteArray): RecursiveProof =
+        decodeWithHeader(bytes, RECURSIVE_PROOF_SCHEMA, RecursiveProofAdapter)
 
     @JvmStatic
     fun decodeRedeemPublicInputs(bytes: ByteArray): RedeemPublicInputs =
@@ -365,6 +370,21 @@ object OfflineNote {
         }
 
         fun bytes(): ByteArray = _bytes.copyOf()
+    }
+
+    class VerifyingKeyBox(backend: String, bytes: ByteArray) {
+        val backend: String
+        private val _bytes = bytes.copyOf()
+
+        init {
+            val normalizedBackend = backend.trim()
+            require(normalizedBackend.isNotEmpty()) { "verifying key backend must not be empty" }
+            require(_bytes.isNotEmpty()) { "verifying key bytes must not be empty" }
+            this.backend = normalizedBackend
+        }
+
+        fun bytes(): ByteArray = _bytes.copyOf()
+        fun noritoEncoded(): ByteArray = encodeVerifyingKeyBox(this)
     }
 
     class RecursiveProof @JvmOverloads constructor(
@@ -1077,6 +1097,19 @@ object OfflineNote {
                 verifierKeyId = readField(decoder) { readVerifyingKeyId(it) },
                 publicInputsHash = readField(decoder) { readHash(it, "public_inputs_hash") },
                 proof = readField(decoder) { readProofBox(it) },
+            )
+    }
+
+    private object VerifyingKeyBoxAdapter : TypeAdapter<VerifyingKeyBox> {
+        override fun encode(encoder: NoritoEncoder, value: VerifyingKeyBox) {
+            writeField(encoder) { writeString(it, value.backend) }
+            writeField(encoder) { writeBytesVec(it, value.bytes()) }
+        }
+
+        override fun decode(decoder: org.hyperledger.iroha.sdk.norito.NoritoDecoder): VerifyingKeyBox =
+            VerifyingKeyBox(
+                backend = readField(decoder) { readString(it) },
+                bytes = readField(decoder) { readBytesVec(it) },
             )
     }
 

--- a/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/offline/OfflineNoteTest.kt
+++ b/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/offline/OfflineNoteTest.kt
@@ -274,6 +274,31 @@ class OfflineNoteTest {
     }
 
     @Test
+    fun verifyingKeyBoxCanonicalEncodingMatchesStandaloneCodec() {
+        val sourceBytes = byteArrayOf(1, 2, 3)
+        val verifyingKey = OfflineNote.VerifyingKeyBox(" halo2/ipa ", sourceBytes)
+        sourceBytes[0] = 0x7f.toByte()
+
+        assertEquals("halo2/ipa", verifyingKey.backend)
+        assertContentEquals(byteArrayOf(1, 2, 3), verifyingKey.bytes())
+
+        val returnedBytes = verifyingKey.bytes()
+        returnedBytes[1] = 0x7e.toByte()
+        assertContentEquals(byteArrayOf(1, 2, 3), verifyingKey.bytes())
+
+        val expected = VerifyingKeyBoxCodec.encodeNorito("halo2/ipa", byteArrayOf(1, 2, 3))
+        assertContentEquals(expected, OfflineNote.encodeVerifyingKeyBox(verifyingKey))
+        assertContentEquals(expected, verifyingKey.noritoEncoded())
+
+        assertIllegalArgumentContains("verifying key backend must not be empty") {
+            OfflineNote.VerifyingKeyBox(" ", byteArrayOf(1))
+        }
+        assertIllegalArgumentContains("verifying key bytes must not be empty") {
+            OfflineNote.VerifyingKeyBox("halo2/ipa", ByteArray(0))
+        }
+    }
+
+    @Test
     fun kagemushaRecursiveSpendNativeProverValidatesInput() {
         assertEquals(
             "recursive_spend_v1",


### PR DESCRIPTION
## Context

The Kotlin SDK `OfflineNote` codec had no representation of `VerifyingKeyBox` — the Norito-encoded structure that pairs a chain-supplied verifying key with its backend identifier. Clients needing to frame the verifying key for the prover FFI had no SDK-level codec to rely on and were forced to build the Norito payload themselves.

### Solution

Add `VerifyingKeyBox` as a value type inside `OfflineNote`, with non-empty preconditions on both `backend` and `bytes` enforced in `init`, and copy-on-read semantics via `copyOf()`. Wire it to a private `VerifyingKeyBoxAdapter` that serializes the backend string then the key bytes using the established `writeField` helpers. Expose `encodeVerifyingKeyBox` as a `@JvmStatic` entry point on `OfflineNote` (schema: `iroha_data_model::proof::VerifyingKeyBox`), matching the pattern of `encodeRedeem` / `encodeRecursiveProof`. Add a `noritoEncoded()` convenience method on `VerifyingKeyBox` itself that delegates to `encodeVerifyingKeyBox`.

---

### Review notes

- `OfflineNote.VerifyingKeyBox` (~ line 372): verify `init` guards and that both the constructor copy and `bytes()` return `copyOf()` — same pattern as `RecursiveProof`. Note that `backend` is trimmed before the emptiness check.
- `VerifyingKeyBoxAdapter` (~ line 1100): confirm field-write order (`backend` string → `bytes` vec) matches the Rust `VerifyingKeyBox` struct layout. Diff against `RecursiveProofAdapter` as the nearest structural peer.
- `encodeVerifyingKeyBox` / `noritoEncoded()`: `noritoEncoded()` calls back into `encodeVerifyingKeyBox(this)` — no circular risk, but worth a quick read to confirm. Only encoding is exposed at the `@JvmStatic` layer; the adapter ships decode capability for future use.