### PR TITLE
Add gas metadata to ZK instruction signers

### DIFF
--- a/crates/connect_norito_bridge/src/lib.rs
+++ b/crates/connect_norito_bridge/src/lib.rs
@@ -21447,6 +21447,37 @@ fn java_optional_text_array(
     target_os = "macos",
     target_os = "windows"
 ))]
+fn java_gas_metadata(
+    env: &mut jni::JNIEnv<'_>,
+    gas_asset_id: &jni::objects::JByteArray<'_>,
+    gas_asset_id_present: jni::sys::jboolean,
+    gas_limit: jni::sys::jlong,
+    gas_limit_present: jni::sys::jboolean,
+) -> Result<Metadata, String> {
+    let gas_asset_id =
+        java_optional_text_array(env, gas_asset_id, gas_asset_id_present, "gasAssetId")?;
+    let mut metadata = Metadata::default();
+    if let Some(asset_id) = gas_asset_id {
+        if gas_limit_present == 0 {
+            return Err("gasLimit is required when gasAssetId is set".to_owned());
+        }
+        if gas_limit <= 0 {
+            return Err("gasLimit must be positive".to_owned());
+        }
+        let name =
+            Name::from_str("gas_asset_id").map_err(|_| "invalid gas_asset_id key".to_owned())?;
+        metadata.insert(name, Json::new(asset_id));
+        iroha_data_model::transaction::insert_transaction_gas_limit(&mut metadata, gas_limit as u64);
+    }
+    Ok(metadata)
+}
+
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
 fn java_fixed_array<const N: usize>(
     env: &mut jni::JNIEnv<'_>,
     array: &jni::objects::JByteArray<'_>,
@@ -21600,6 +21631,10 @@ fn java_native_encode_shield_signed_transaction(
     payload_nonce: jni::objects::JByteArray<'_>,
     payload_ciphertext: jni::objects::JByteArray<'_>,
     private_key: jni::objects::JByteArray<'_>,
+    gas_asset_id: jni::objects::JByteArray<'_>,
+    gas_asset_id_present: jni::sys::jboolean,
+    gas_limit: jni::sys::jlong,
+    gas_limit_present: jni::sys::jboolean,
 ) -> jni::sys::jobjectArray {
     let result = (|| -> Result<jni::sys::jobjectArray, String> {
         if creation_time_ms < 0 || ttl_ms < 0 {
@@ -21627,11 +21662,20 @@ fn java_native_encode_shield_signed_transaction(
         let private_key = java_private_key(algorithm_code, &private_key, env)?;
         let ttl =
             parse_ttl(ttl_ms as u64, ttl_present != 0).map_err(|_| "invalid ttlMs".to_owned())?;
-        let (signed_bytes, hash_bytes) = encode_asset_transaction(
+        let metadata = java_gas_metadata(
+            env,
+            &gas_asset_id,
+            gas_asset_id_present,
+            gas_limit,
+            gas_limit_present,
+        )?;
+        let (signed_bytes, hash_bytes) = encode_asset_transaction_with_nonce_and_metadata(
             chain_id,
             authority,
             creation_time_ms as u64,
             ttl,
+            None,
+            metadata,
             private_key,
             || {
                 let instruction = zk::Shield::new(
@@ -21679,6 +21723,10 @@ fn java_native_encode_unshield_signed_transaction(
     proof_json: jni::objects::JByteArray<'_>,
     root_hint: jni::objects::JByteArray<'_>,
     private_key: jni::objects::JByteArray<'_>,
+    gas_asset_id: jni::objects::JByteArray<'_>,
+    gas_asset_id_present: jni::sys::jboolean,
+    gas_limit: jni::sys::jlong,
+    gas_limit_present: jni::sys::jboolean,
 ) -> jni::sys::jobjectArray {
     let result = (|| -> Result<jni::sys::jobjectArray, String> {
         if creation_time_ms < 0 || ttl_ms < 0 {
@@ -21712,11 +21760,20 @@ fn java_native_encode_unshield_signed_transaction(
         let private_key = java_private_key(algorithm_code, &private_key, env)?;
         let ttl =
             parse_ttl(ttl_ms as u64, ttl_present != 0).map_err(|_| "invalid ttlMs".to_owned())?;
-        let (signed_bytes, hash_bytes) = encode_asset_transaction(
+        let metadata = java_gas_metadata(
+            env,
+            &gas_asset_id,
+            gas_asset_id_present,
+            gas_limit,
+            gas_limit_present,
+        )?;
+        let (signed_bytes, hash_bytes) = encode_asset_transaction_with_nonce_and_metadata(
             chain_id,
             authority,
             creation_time_ms as u64,
             ttl,
+            None,
+            metadata,
             private_key,
             || {
                 let instruction = zk::Unshield::new_with_outputs(
@@ -21769,6 +21826,10 @@ fn java_native_encode_register_zk_asset_signed_transaction(
     vk_shield: jni::objects::JByteArray<'_>,
     vk_shield_present: jni::sys::jboolean,
     private_key: jni::objects::JByteArray<'_>,
+    gas_asset_id: jni::objects::JByteArray<'_>,
+    gas_asset_id_present: jni::sys::jboolean,
+    gas_limit: jni::sys::jlong,
+    gas_limit_present: jni::sys::jboolean,
 ) -> jni::sys::jobjectArray {
     let result = (|| -> Result<jni::sys::jobjectArray, String> {
         if creation_time_ms < 0 || ttl_ms < 0 {
@@ -21816,11 +21877,20 @@ fn java_native_encode_register_zk_asset_signed_transaction(
             vk_unshield,
             vk_shield,
         );
-        let (signed_bytes, hash_bytes) = encode_asset_transaction(
+        let metadata = java_gas_metadata(
+            env,
+            &gas_asset_id,
+            gas_asset_id_present,
+            gas_limit,
+            gas_limit_present,
+        )?;
+        let (signed_bytes, hash_bytes) = encode_asset_transaction_with_nonce_and_metadata(
             chain_id,
             authority,
             creation_time_ms as u64,
             ttl,
+            None,
+            metadata,
             private_key,
             move || Executable::from([InstructionBox::from(register)]),
         )
@@ -22867,6 +22937,10 @@ pub unsafe extern "system" fn Java_org_hyperledger_iroha_sdk_crypto_NativeSigner
     payload_nonce: jni::objects::JByteArray<'_>,
     payload_ciphertext: jni::objects::JByteArray<'_>,
     private_key: jni::objects::JByteArray<'_>,
+    gas_asset_id: jni::objects::JByteArray<'_>,
+    gas_asset_id_present: jni::sys::jboolean,
+    gas_limit: jni::sys::jlong,
+    gas_limit_present: jni::sys::jboolean,
 ) -> jni::sys::jobjectArray {
     java_native_encode_shield_signed_transaction(
         &mut env,
@@ -22884,6 +22958,10 @@ pub unsafe extern "system" fn Java_org_hyperledger_iroha_sdk_crypto_NativeSigner
         payload_nonce,
         payload_ciphertext,
         private_key,
+        gas_asset_id,
+        gas_asset_id_present,
+        gas_limit,
+        gas_limit_present,
     )
 }
 
@@ -22912,6 +22990,10 @@ pub unsafe extern "system" fn Java_org_hyperledger_iroha_sdk_crypto_NativeSigner
     proof_json: jni::objects::JByteArray<'_>,
     root_hint: jni::objects::JByteArray<'_>,
     private_key: jni::objects::JByteArray<'_>,
+    gas_asset_id: jni::objects::JByteArray<'_>,
+    gas_asset_id_present: jni::sys::jboolean,
+    gas_limit: jni::sys::jlong,
+    gas_limit_present: jni::sys::jboolean,
 ) -> jni::sys::jobjectArray {
     java_native_encode_unshield_signed_transaction(
         &mut env,
@@ -22929,6 +23011,10 @@ pub unsafe extern "system" fn Java_org_hyperledger_iroha_sdk_crypto_NativeSigner
         proof_json,
         root_hint,
         private_key,
+        gas_asset_id,
+        gas_asset_id_present,
+        gas_limit,
+        gas_limit_present,
     )
 }
 
@@ -22960,6 +23046,10 @@ pub unsafe extern "system" fn Java_org_hyperledger_iroha_sdk_crypto_NativeSigner
     vk_shield: jni::objects::JByteArray<'_>,
     vk_shield_present: jni::sys::jboolean,
     private_key: jni::objects::JByteArray<'_>,
+    gas_asset_id: jni::objects::JByteArray<'_>,
+    gas_asset_id_present: jni::sys::jboolean,
+    gas_limit: jni::sys::jlong,
+    gas_limit_present: jni::sys::jboolean,
 ) -> jni::sys::jobjectArray {
     java_native_encode_register_zk_asset_signed_transaction(
         &mut env,
@@ -22980,6 +23070,10 @@ pub unsafe extern "system" fn Java_org_hyperledger_iroha_sdk_crypto_NativeSigner
         vk_shield,
         vk_shield_present,
         private_key,
+        gas_asset_id,
+        gas_asset_id_present,
+        gas_limit,
+        gas_limit_present,
     )
 }
 
@@ -23079,6 +23173,10 @@ pub unsafe extern "system" fn Java_org_hyperledger_iroha_android_crypto_NativeSi
     payload_nonce: jni::objects::JByteArray<'_>,
     payload_ciphertext: jni::objects::JByteArray<'_>,
     private_key: jni::objects::JByteArray<'_>,
+    gas_asset_id: jni::objects::JByteArray<'_>,
+    gas_asset_id_present: jni::sys::jboolean,
+    gas_limit: jni::sys::jlong,
+    gas_limit_present: jni::sys::jboolean,
 ) -> jni::sys::jobjectArray {
     java_native_encode_shield_signed_transaction(
         &mut env,
@@ -23096,6 +23194,10 @@ pub unsafe extern "system" fn Java_org_hyperledger_iroha_android_crypto_NativeSi
         payload_nonce,
         payload_ciphertext,
         private_key,
+        gas_asset_id,
+        gas_asset_id_present,
+        gas_limit,
+        gas_limit_present,
     )
 }
 
@@ -23124,6 +23226,10 @@ pub unsafe extern "system" fn Java_org_hyperledger_iroha_android_crypto_NativeSi
     proof_json: jni::objects::JByteArray<'_>,
     root_hint: jni::objects::JByteArray<'_>,
     private_key: jni::objects::JByteArray<'_>,
+    gas_asset_id: jni::objects::JByteArray<'_>,
+    gas_asset_id_present: jni::sys::jboolean,
+    gas_limit: jni::sys::jlong,
+    gas_limit_present: jni::sys::jboolean,
 ) -> jni::sys::jobjectArray {
     java_native_encode_unshield_signed_transaction(
         &mut env,
@@ -23141,6 +23247,10 @@ pub unsafe extern "system" fn Java_org_hyperledger_iroha_android_crypto_NativeSi
         proof_json,
         root_hint,
         private_key,
+        gas_asset_id,
+        gas_asset_id_present,
+        gas_limit,
+        gas_limit_present,
     )
 }
 
@@ -23172,6 +23282,10 @@ pub unsafe extern "system" fn Java_org_hyperledger_iroha_android_crypto_NativeSi
     vk_shield: jni::objects::JByteArray<'_>,
     vk_shield_present: jni::sys::jboolean,
     private_key: jni::objects::JByteArray<'_>,
+    gas_asset_id: jni::objects::JByteArray<'_>,
+    gas_asset_id_present: jni::sys::jboolean,
+    gas_limit: jni::sys::jlong,
+    gas_limit_present: jni::sys::jboolean,
 ) -> jni::sys::jobjectArray {
     java_native_encode_register_zk_asset_signed_transaction(
         &mut env,
@@ -23192,6 +23306,10 @@ pub unsafe extern "system" fn Java_org_hyperledger_iroha_android_crypto_NativeSi
         vk_shield,
         vk_shield_present,
         private_key,
+        gas_asset_id,
+        gas_asset_id_present,
+        gas_limit,
+        gas_limit_present,
     )
 }
 

--- a/crates/connect_norito_bridge/src/lib.rs
+++ b/crates/connect_norito_bridge/src/lib.rs
@@ -77,7 +77,7 @@ use zeroize::Zeroizing;
 #[cfg(feature = "privacy-production-enabled")]
 mod privacy_production;
 
-const CONNECT_NORITO_BRIDGE_ABI_VERSION: u32 = 7;
+const CONNECT_NORITO_BRIDGE_ABI_VERSION: u32 = 8;
 const KAGEMUSHA_NATIVE_ARCHIVE_MAX_BYTES: usize = 64 * 1024 * 1024;
 
 const ERR_NULL_PTR: c_int = -1;
@@ -10844,7 +10844,7 @@ mod offline_note_prover_tests {
 
     #[test]
     fn bridge_abi_version_advertises_kagemusha_compact_prover() {
-        assert_eq!(unsafe { connect_norito_bridge_abi_version() }, 7);
+        assert_eq!(unsafe { connect_norito_bridge_abi_version() }, 8);
     }
 
     #[test]
@@ -21467,7 +21467,10 @@ fn java_gas_metadata(
         let name =
             Name::from_str("gas_asset_id").map_err(|_| "invalid gas_asset_id key".to_owned())?;
         metadata.insert(name, Json::new(asset_id));
-        iroha_data_model::transaction::insert_transaction_gas_limit(&mut metadata, gas_limit as u64);
+        iroha_data_model::transaction::insert_transaction_gas_limit(
+            &mut metadata,
+            gas_limit as u64,
+        );
     }
     Ok(metadata)
 }
@@ -22866,6 +22869,21 @@ pub unsafe extern "system" fn Java_org_hyperledger_iroha_sdk_crypto_NativeSigner
 ))]
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
+pub unsafe extern "system" fn Java_org_hyperledger_iroha_sdk_crypto_NativeSignerBridge_nativeBridgeAbiVersion(
+    _env: jni::JNIEnv<'_>,
+    _class: jni::objects::JClass<'_>,
+) -> jni::sys::jint {
+    CONNECT_NORITO_BRIDGE_ABI_VERSION as jni::sys::jint
+}
+
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
 pub unsafe extern "system" fn Java_org_hyperledger_iroha_sdk_crypto_NativeSignerBridge_nativeKeypairFromSeed(
     mut env: jni::JNIEnv<'_>,
     _class: jni::objects::JClass<'_>,
@@ -23092,6 +23110,21 @@ pub unsafe extern "system" fn Java_org_hyperledger_iroha_android_crypto_NativeSi
     private_key: jni::objects::JByteArray<'_>,
 ) -> jni::sys::jbyteArray {
     java_native_public_key_from_private(&mut env, algorithm_code, private_key)
+}
+
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+))]
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+pub unsafe extern "system" fn Java_org_hyperledger_iroha_android_crypto_NativeSignerBridge_nativeBridgeAbiVersion(
+    _env: jni::JNIEnv<'_>,
+    _class: jni::objects::JClass<'_>,
+) -> jni::sys::jint {
+    CONNECT_NORITO_BRIDGE_ABI_VERSION as jni::sys::jint
 }
 
 #[cfg(any(

--- a/java/iroha_android/src/main/java/org/hyperledger/iroha/android/crypto/NativeSignerBridge.java
+++ b/java/iroha_android/src/main/java/org/hyperledger/iroha/android/crypto/NativeSignerBridge.java
@@ -9,6 +9,7 @@ import org.hyperledger.iroha.android.model.instructions.UnshieldInstruction;
 /** Thin JVM/JNI wrapper around {@code connect_norito_bridge} signing helpers. */
 public final class NativeSignerBridge {
   private static final String LIBRARY_NAME = "connect_norito_bridge";
+  public static final int REQUIRED_BRIDGE_ABI_VERSION = 8;
   private static final int HASH_BYTES = 32;
   private static final boolean NATIVE_AVAILABLE = loadLibrary();
 
@@ -308,7 +309,7 @@ public final class NativeSignerBridge {
   private static boolean loadLibrary() {
     try {
       System.loadLibrary(LIBRARY_NAME);
-      return true;
+      return nativeBridgeAbiVersion() >= REQUIRED_BRIDGE_ABI_VERSION;
     } catch (final UnsatisfiedLinkError | SecurityException error) {
       return false;
     }
@@ -395,6 +396,8 @@ public final class NativeSignerBridge {
   private static byte[] optionalBytes(final byte[] value) {
     return value == null ? new byte[0] : value.clone();
   }
+
+  private static native int nativeBridgeAbiVersion();
 
   private static native byte[] nativePublicKeyFromPrivate(int algorithmCode, byte[] privateKey);
 

--- a/java/iroha_android/src/main/java/org/hyperledger/iroha/android/crypto/NativeSignerBridge.java
+++ b/java/iroha_android/src/main/java/org/hyperledger/iroha/android/crypto/NativeSignerBridge.java
@@ -97,7 +97,22 @@ public final class NativeSignerBridge {
       final Long ttlMs,
       final ShieldInstruction instruction,
       final byte[] privateKey) {
+    return encodeShieldSignedTransaction(
+        algorithm, chainId, authority, creationTimeMs, ttlMs, instruction, privateKey, null, null);
+  }
+
+  public static NativeSignedTransaction encodeShieldSignedTransaction(
+      final SigningAlgorithm algorithm,
+      final String chainId,
+      final String authority,
+      final long creationTimeMs,
+      final Long ttlMs,
+      final ShieldInstruction instruction,
+      final byte[] privateKey,
+      final String gasAssetId,
+      final Long gasLimit) {
     requireCreationTime(creationTimeMs);
+    requireGasPairing(gasAssetId, gasLimit);
     if (instruction == null) {
       throw new IllegalArgumentException("instruction must be provided");
     }
@@ -107,6 +122,7 @@ public final class NativeSignerBridge {
     final byte[] assetBytes = textBytes(instruction.asset(), "asset");
     final byte[] fromBytes = textBytes(instruction.from(), "from");
     final byte[] amountBytes = textBytes(instruction.amount(), "amount");
+    final byte[] gasAssetIdBytes = gasAssetId == null ? new byte[0] : textBytes(gasAssetId, "gasAssetId");
     final long ttl = ttlValue(ttlMs);
     final boolean hasTtl = ttlMs != null;
     requireNative();
@@ -125,7 +141,11 @@ public final class NativeSignerBridge {
             instruction.encryptedPayload().ephemeralPublicKey(),
             instruction.encryptedPayload().nonce(),
             instruction.encryptedPayload().ciphertext(),
-            key),
+            key,
+            gasAssetIdBytes,
+            gasAssetId != null,
+            gasLimit == null ? 0L : gasLimit,
+            gasLimit != null),
         "encodeShieldSignedTransaction");
   }
 
@@ -148,7 +168,22 @@ public final class NativeSignerBridge {
       final Long ttlMs,
       final UnshieldInstruction instruction,
       final byte[] privateKey) {
+    return encodeUnshieldSignedTransaction(
+        algorithm, chainId, authority, creationTimeMs, ttlMs, instruction, privateKey, null, null);
+  }
+
+  public static NativeSignedTransaction encodeUnshieldSignedTransaction(
+      final SigningAlgorithm algorithm,
+      final String chainId,
+      final String authority,
+      final long creationTimeMs,
+      final Long ttlMs,
+      final UnshieldInstruction instruction,
+      final byte[] privateKey,
+      final String gasAssetId,
+      final Long gasLimit) {
     requireCreationTime(creationTimeMs);
+    requireGasPairing(gasAssetId, gasLimit);
     if (instruction == null) {
       throw new IllegalArgumentException("instruction must be provided");
     }
@@ -162,6 +197,7 @@ public final class NativeSignerBridge {
     final byte[] outputsBytes = flattenFixed32(instruction.outputs());
     final byte[] proofJsonBytes = instruction.proof().toNativeJson().getBytes(StandardCharsets.UTF_8);
     final byte[] rootHintBytes = optionalBytes(instruction.rootHint());
+    final byte[] gasAssetIdBytes = gasAssetId == null ? new byte[0] : textBytes(gasAssetId, "gasAssetId");
     final long ttl = ttlValue(ttlMs);
     final boolean hasTtl = ttlMs != null;
     requireNative();
@@ -180,7 +216,11 @@ public final class NativeSignerBridge {
             outputsBytes,
             proofJsonBytes,
             rootHintBytes,
-            key),
+            key,
+            gasAssetIdBytes,
+            gasAssetId != null,
+            gasLimit == null ? 0L : gasLimit,
+            gasLimit != null),
         "encodeUnshieldSignedTransaction");
   }
 
@@ -203,7 +243,22 @@ public final class NativeSignerBridge {
       final Long ttlMs,
       final RegisterZkAssetInstruction instruction,
       final byte[] privateKey) {
+    return encodeRegisterZkAssetSignedTransaction(
+        algorithm, chainId, authority, creationTimeMs, ttlMs, instruction, privateKey, null, null);
+  }
+
+  public static NativeSignedTransaction encodeRegisterZkAssetSignedTransaction(
+      final SigningAlgorithm algorithm,
+      final String chainId,
+      final String authority,
+      final long creationTimeMs,
+      final Long ttlMs,
+      final RegisterZkAssetInstruction instruction,
+      final byte[] privateKey,
+      final String gasAssetId,
+      final Long gasLimit) {
     requireCreationTime(creationTimeMs);
+    requireGasPairing(gasAssetId, gasLimit);
     if (instruction == null) {
       throw new IllegalArgumentException("instruction must be provided");
     }
@@ -214,6 +269,7 @@ public final class NativeSignerBridge {
     final byte[] transferBytes = optionalTextBytes(instruction.transferVerifyingKey());
     final byte[] unshieldBytes = optionalTextBytes(instruction.unshieldVerifyingKey());
     final byte[] shieldBytes = optionalTextBytes(instruction.shieldVerifyingKey());
+    final byte[] gasAssetIdBytes = gasAssetId == null ? new byte[0] : textBytes(gasAssetId, "gasAssetId");
     final long ttl = ttlValue(ttlMs);
     final boolean hasTtl = ttlMs != null;
     requireNative();
@@ -235,7 +291,11 @@ public final class NativeSignerBridge {
             instruction.unshieldVerifyingKey() != null,
             shieldBytes,
             instruction.shieldVerifyingKey() != null,
-            key),
+            key,
+            gasAssetIdBytes,
+            gasAssetId != null,
+            gasLimit == null ? 0L : gasLimit,
+            gasLimit != null),
         "encodeRegisterZkAssetSignedTransaction");
   }
 
@@ -291,6 +351,15 @@ public final class NativeSignerBridge {
   private static void requireCreationTime(final long creationTimeMs) {
     if (creationTimeMs < 0) {
       throw new IllegalArgumentException("creationTimeMs must be non-negative");
+    }
+  }
+
+  private static void requireGasPairing(final String gasAssetId, final Long gasLimit) {
+    if ((gasAssetId == null) != (gasLimit == null)) {
+      throw new IllegalArgumentException("gasAssetId and gasLimit must be provided together");
+    }
+    if (gasLimit != null && gasLimit <= 0) {
+      throw new IllegalArgumentException("gasLimit must be positive when provided");
     }
   }
 
@@ -350,7 +419,11 @@ public final class NativeSignerBridge {
       byte[] payloadEphemeralPublicKey,
       byte[] payloadNonce,
       byte[] payloadCiphertext,
-      byte[] privateKey);
+      byte[] privateKey,
+      byte[] gasAssetId,
+      boolean gasAssetIdPresent,
+      long gasLimit,
+      boolean gasLimitPresent);
 
   private static native byte[][] nativeEncodeUnshieldSignedTransaction(
       int algorithmCode,
@@ -366,7 +439,11 @@ public final class NativeSignerBridge {
       byte[] outputs,
       byte[] proofJson,
       byte[] rootHint,
-      byte[] privateKey);
+      byte[] privateKey,
+      byte[] gasAssetId,
+      boolean gasAssetIdPresent,
+      long gasLimit,
+      boolean gasLimitPresent);
 
   private static native byte[][] nativeEncodeRegisterZkAssetSignedTransaction(
       int algorithmCode,
@@ -385,7 +462,11 @@ public final class NativeSignerBridge {
       boolean unshieldVerifyingKeyPresent,
       byte[] shieldVerifyingKey,
       boolean shieldVerifyingKeyPresent,
-      byte[] privateKey);
+      byte[] privateKey,
+      byte[] gasAssetId,
+      boolean gasAssetIdPresent,
+      long gasLimit,
+      boolean gasLimitPresent);
 
   /** Raw keypair bytes returned by the bridge. */
   public record KeypairBytes(byte[] privateKey, byte[] publicKey) {}

--- a/java/iroha_android/src/main/java/org/hyperledger/iroha/android/model/instructions/RegisterZkAssetInstruction.java
+++ b/java/iroha_android/src/main/java/org/hyperledger/iroha/android/model/instructions/RegisterZkAssetInstruction.java
@@ -77,6 +77,52 @@ public final class RegisterZkAssetInstruction implements InstructionTemplate {
     return new Builder();
   }
 
+  public static RegisterZkAssetInstruction fromArguments(final Map<String, String> arguments) {
+    final Builder builder =
+        builder()
+            .setAsset(requireArgument(arguments, "asset"))
+            .setMode(ZkAssetMode.fromWireName(requireArgument(arguments, "mode")))
+            .setAllowShield(parseBoolean(requireArgument(arguments, "allow_shield"), "allow_shield"))
+            .setAllowUnshield(
+                parseBoolean(requireArgument(arguments, "allow_unshield"), "allow_unshield"));
+    final String transfer = optionalArgument(arguments, "vk_transfer");
+    if (transfer != null) {
+      builder.setTransferVerifyingKey(transfer);
+    }
+    final String unshield = optionalArgument(arguments, "vk_unshield");
+    if (unshield != null) {
+      builder.setUnshieldVerifyingKey(unshield);
+    }
+    final String shield = optionalArgument(arguments, "vk_shield");
+    if (shield != null) {
+      builder.setShieldVerifyingKey(shield);
+    }
+    return builder.build();
+  }
+
+  private static String requireArgument(final Map<String, String> arguments, final String key) {
+    final String value = arguments.get(key);
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException("Instruction argument '" + key + "' is required");
+    }
+    return value;
+  }
+
+  private static String optionalArgument(final Map<String, String> arguments, final String key) {
+    final String value = arguments.get(key);
+    return (value == null || value.trim().isEmpty()) ? null : value;
+  }
+
+  private static boolean parseBoolean(final String value, final String name) {
+    if ("true".equals(value)) {
+      return true;
+    }
+    if ("false".equals(value)) {
+      return false;
+    }
+    throw new IllegalArgumentException(name + " must be 'true' or 'false'");
+  }
+
   public static final class Builder {
     private String asset;
     private ZkAssetMode mode = ZkAssetMode.ZK_NATIVE;

--- a/java/iroha_android/src/main/java/org/hyperledger/iroha/android/model/instructions/ShieldInstruction.java
+++ b/java/iroha_android/src/main/java/org/hyperledger/iroha/android/model/instructions/ShieldInstruction.java
@@ -69,6 +69,17 @@ public final class ShieldInstruction implements InstructionTemplate {
     return new Builder();
   }
 
+  /**
+   * Intentionally unsupported. {@code zk::Shield} carries a 32-byte note commitment and a binary
+   * X25519/XChaCha20-Poly1305 encrypted payload that cannot be reconstructed from a generic string
+   * argument map. Build instances through {@link #builder()} instead.
+   */
+  public static ShieldInstruction fromArguments(final Map<String, String> arguments) {
+    throw new UnsupportedOperationException(
+        "ShieldInstruction cannot be built from an argument map: its note commitment and "
+            + "encrypted payload are binary fields. Use ShieldInstruction.builder().");
+  }
+
   public static final class Builder {
     private String asset;
     private String from;

--- a/java/iroha_android/src/main/java/org/hyperledger/iroha/android/model/instructions/UnshieldInstruction.java
+++ b/java/iroha_android/src/main/java/org/hyperledger/iroha/android/model/instructions/UnshieldInstruction.java
@@ -80,6 +80,17 @@ public final class UnshieldInstruction implements InstructionTemplate {
     return new Builder();
   }
 
+  /**
+   * Intentionally unsupported. {@code zk::Unshield} carries binary input nullifiers, output
+   * commitments and a proof attachment that cannot be reconstructed from a generic string argument
+   * map. Build instances through {@link #builder()} instead.
+   */
+  public static UnshieldInstruction fromArguments(final Map<String, String> arguments) {
+    throw new UnsupportedOperationException(
+        "UnshieldInstruction cannot be built from an argument map: its nullifiers, commitments "
+            + "and proof attachment are binary fields. Use UnshieldInstruction.builder().");
+  }
+
   private static List<byte[]> copyList(final List<byte[]> source) {
     final ArrayList<byte[]> copy = new ArrayList<>(source.size());
     for (final byte[] value : source) {

--- a/java/iroha_android/src/test/java/org/hyperledger/iroha/android/GradleHarnessTests.java
+++ b/java/iroha_android/src/test/java/org/hyperledger/iroha/android/GradleHarnessTests.java
@@ -78,6 +78,7 @@ public final class GradleHarnessTests {
         "org.hyperledger.iroha.android.model.instructions.KaigiInstructionValidationTests",
         "org.hyperledger.iroha.android.model.instructions.TriggerInstructionUtilsTests",
         "org.hyperledger.iroha.android.model.instructions.VerifyingKeyInstructionUtilsTests",
+        "org.hyperledger.iroha.android.model.instructions.ZkAssetInstructionsTest",
         "org.hyperledger.iroha.android.nexus.SpaceDirectoryInstructionBuilderTests",
         "org.hyperledger.iroha.android.nexus.UaidJsonParserTests",
         "org.hyperledger.iroha.android.norito.NoritoCodecAdapterTests",

--- a/java/iroha_android/src/test/java/org/hyperledger/iroha/android/model/instructions/ZkAssetInstructionsTest.java
+++ b/java/iroha_android/src/test/java/org/hyperledger/iroha/android/model/instructions/ZkAssetInstructionsTest.java
@@ -2,14 +2,20 @@ package org.hyperledger.iroha.android.model.instructions;
 
 import java.util.Arrays;
 import java.util.Collections;
+import org.hyperledger.iroha.android.address.AccountAddress;
 import org.hyperledger.iroha.android.crypto.NativeSignedTransaction;
 import org.hyperledger.iroha.android.crypto.NativeSignerBridge;
 import org.hyperledger.iroha.android.crypto.SigningAlgorithm;
+import org.hyperledger.iroha.android.model.JsonValue;
+import org.hyperledger.iroha.android.model.TransactionPayload;
+import org.hyperledger.iroha.android.norito.NoritoJavaCodecAdapter;
+import org.hyperledger.iroha.android.norito.SignedTransactionEncoder;
+import org.hyperledger.iroha.android.tx.SignedTransaction;
 
 public final class ZkAssetInstructionsTest {
   private ZkAssetInstructionsTest() {}
 
-  public static void main(final String[] args) {
+  public static void main(final String[] args) throws Exception {
     confidentialEncryptedPayloadIsStrictAndDefensive();
     confidentialEncryptedPayloadMatchesRustWireFixture();
     proofAttachmentValidatesBackendAndJsonShape();
@@ -18,6 +24,7 @@ public final class ZkAssetInstructionsTest {
     registerZkAssetInstructionValidatesModeAndVerifierIds();
     nativeSignerZkMethodsRejectBadInputsBeforeNativeDispatch();
     nativeSignedTransactionCopiesInputsAndOutputs();
+    nativeSignerZkRegisterIncludesGasMetadataWhenBridgeAvailable();
     System.out.println("[IrohaAndroid] ZkAssetInstructionsTest passed.");
   }
 
@@ -252,6 +259,54 @@ public final class ZkAssetInstructionsTest {
 
     expectThrows(() -> new NativeSignedTransaction(new byte[0], fill(1, 32)));
     expectThrows(() -> new NativeSignedTransaction(new byte[] {1}, fill(1, 31)));
+  }
+
+  private static void nativeSignerZkRegisterIncludesGasMetadataWhenBridgeAvailable()
+      throws Exception {
+    assert NativeSignerBridge.REQUIRED_BRIDGE_ABI_VERSION == 8;
+    if (!NativeSignerBridge.isNativeAvailable()) {
+      return;
+    }
+
+    final byte[] seed = new byte[32];
+    for (int i = 0; i < seed.length; i++) {
+      seed[i] = (byte) (i + 1);
+    }
+    final NativeSignerBridge.KeypairBytes keypair =
+        NativeSignerBridge.keypairFromSeed(SigningAlgorithm.ED25519, seed);
+    final String authority =
+        AccountAddress.fromAccount(keypair.publicKey(), "ed25519")
+            .toI105(AccountAddress.DEFAULT_I105_DISCRIMINANT);
+    final String gasAssetId = "7EAD8EFYUx1aVKZPUU1fyKvr8dF1";
+    final long gasLimit = 1_000L;
+    final RegisterZkAssetInstruction instruction =
+        RegisterZkAssetInstruction.builder()
+            .setAsset(gasAssetId)
+            .setMode(ZkAssetMode.HYBRID)
+            .setAllowShield(true)
+            .setAllowUnshield(true)
+            .build();
+
+    final NativeSignedTransaction nativeTx =
+        NativeSignerBridge.encodeRegisterZkAssetSignedTransaction(
+            SigningAlgorithm.ED25519,
+            "00000042",
+            authority,
+            1_736_000_000_000L,
+            null,
+            instruction,
+            keypair.privateKey(),
+            gasAssetId,
+            gasLimit);
+    final SignedTransaction signed =
+        SignedTransactionEncoder.decodeVersioned(nativeTx.versionedSignedTransaction());
+    final TransactionPayload payload =
+        new NoritoJavaCodecAdapter().decodeTransaction(signed.encodedPayload());
+
+    assert JsonValue.string(gasAssetId).equals(payload.metadata().get("gas_asset_id"))
+        : "gas_asset_id metadata mismatch";
+    assert JsonValue.number(gasLimit).equals(payload.metadata().get("gas_limit"))
+        : "gas_limit metadata mismatch";
   }
 
   private static ConfidentialEncryptedPayload samplePayload() {

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -57,7 +57,7 @@ val snapshot = OfflineCashConfigurationSnapshot(
     assetDefinitionId = "pkr#sbp",
     offlinePaymentsEnabled = true,
     issuerPublicKeyBase64 = cachedIssuerKeyBase64,
-    nativeBridgeAbiVersion = 7,
+    nativeBridgeAbiVersion = 8,
     createdAtMs = cachedAtMs,
     expiresAtMs = expiresAtMs,
 )

--- a/kotlin/core-jvm/build.gradle.kts
+++ b/kotlin/core-jvm/build.gradle.kts
@@ -37,6 +37,12 @@ kotlin {
 
 tasks.test {
     useJUnitPlatform()
+
+    // Host JNI bridge (libconnect_norito_bridge) for the opt-in localnet integration tests.
+    // Build it from the iroha repo root with: cargo build -p connect_norito_bridge --lib
+    // Pure-JVM tests ignore this; the localnet tests are gated on IROHA_LOCALNET_TEST=1.
+    val hostNativeDir = rootProject.projectDir.parentFile.resolve("target/debug")
+    systemProperty("java.library.path", hostNativeDir.absolutePath)
 }
 
 publishing {

--- a/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/core/model/instructions/ZkAssetInstructions.kt
+++ b/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/core/model/instructions/ZkAssetInstructions.kt
@@ -322,6 +322,35 @@ class RegisterZkAssetInstruction private constructor(
     companion object {
         @JvmStatic
         fun builder(): Builder = Builder()
+
+        @JvmStatic
+        fun fromArguments(arguments: Map<String, String>): RegisterZkAssetInstruction {
+            val builder = builder()
+                .setAsset(requireArgument(arguments, "asset"))
+                .setMode(ZkAssetMode.fromWireName(requireArgument(arguments, "mode")))
+                .setAllowShield(parseBoolean(requireArgument(arguments, "allow_shield"), "allow_shield"))
+                .setAllowUnshield(parseBoolean(requireArgument(arguments, "allow_unshield"), "allow_unshield"))
+            optionalArgument(arguments, "vk_transfer")?.let { builder.setTransferVerifyingKey(it) }
+            optionalArgument(arguments, "vk_unshield")?.let { builder.setUnshieldVerifyingKey(it) }
+            optionalArgument(arguments, "vk_shield")?.let { builder.setShieldVerifyingKey(it) }
+            return builder.build()
+        }
+
+        private fun requireArgument(arguments: Map<String, String>, key: String): String {
+            val value = arguments[key]
+            require(!value.isNullOrBlank()) { "Instruction argument '$key' is required" }
+            return value
+        }
+
+        private fun optionalArgument(arguments: Map<String, String>, key: String): String? =
+            arguments[key]?.takeIf { it.isNotBlank() }
+
+        private fun parseBoolean(value: String, name: String): Boolean =
+            when (value) {
+                "true" -> true
+                "false" -> false
+                else -> throw IllegalArgumentException("$name must be 'true' or 'false'")
+            }
     }
 }
 
@@ -402,6 +431,18 @@ class ShieldInstruction private constructor(
     companion object {
         @JvmStatic
         fun builder(): Builder = Builder()
+
+        /**
+         * Intentionally unsupported. `zk::Shield` carries a 32-byte note commitment and a binary
+         * X25519/XChaCha20-Poly1305 encrypted payload that cannot be reconstructed from a generic
+         * string argument map. Build instances through [builder] instead.
+         */
+        @JvmStatic
+        fun fromArguments(arguments: Map<String, String>): ShieldInstruction =
+            throw UnsupportedOperationException(
+                "ShieldInstruction cannot be built from an argument map: its note commitment and " +
+                    "encrypted payload are binary fields. Use ShieldInstruction.builder().",
+            )
     }
 }
 
@@ -519,6 +560,18 @@ class UnshieldInstruction private constructor(
     companion object {
         @JvmStatic
         fun builder(): Builder = Builder()
+
+        /**
+         * Intentionally unsupported. `zk::Unshield` carries binary input nullifiers, output
+         * commitments and a proof attachment that cannot be reconstructed from a generic string
+         * argument map. Build instances through [builder] instead.
+         */
+        @JvmStatic
+        fun fromArguments(arguments: Map<String, String>): UnshieldInstruction =
+            throw UnsupportedOperationException(
+                "UnshieldInstruction cannot be built from an argument map: its nullifiers, " +
+                    "commitments and proof attachment are binary fields. Use UnshieldInstruction.builder().",
+            )
     }
 }
 

--- a/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/crypto/NativeSignerBridge.kt
+++ b/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/crypto/NativeSignerBridge.kt
@@ -82,10 +82,14 @@ class NativeSignerBridge private constructor() {
             ttlMs: Long? = null,
             instruction: ShieldInstruction?,
             privateKey: ByteArray?,
+            gasAssetId: String? = null,
+            gasLimit: Long? = null,
         ): NativeSignedTransaction {
             requireCreationTime(creationTimeMs)
+            requireGasPairing(gasAssetId, gasLimit)
             val selected = requireNotNull(instruction) { "instruction must be provided" }
             val key = requirePrivateKey(privateKey)
+            val gasAssetIdBytes = gasAssetId?.let { textBytes(it, "gasAssetId") } ?: ByteArray(0)
             val chainBytes = textBytes(chainId, "chainId")
             val authorityBytes = textBytes(authority, "authority")
             val assetBytes = textBytes(selected.asset, "asset")
@@ -110,6 +114,10 @@ class NativeSignerBridge private constructor() {
                     selected.encryptedPayload.nonce,
                     selected.encryptedPayload.ciphertext,
                     key,
+                    gasAssetIdBytes,
+                    gasAssetId != null,
+                    gasLimit ?: 0L,
+                    gasLimit != null,
                 ),
                 "encodeShieldSignedTransaction",
             )
@@ -125,10 +133,14 @@ class NativeSignerBridge private constructor() {
             ttlMs: Long? = null,
             instruction: UnshieldInstruction?,
             privateKey: ByteArray?,
+            gasAssetId: String? = null,
+            gasLimit: Long? = null,
         ): NativeSignedTransaction {
             requireCreationTime(creationTimeMs)
+            requireGasPairing(gasAssetId, gasLimit)
             val selected = requireNotNull(instruction) { "instruction must be provided" }
             val key = requirePrivateKey(privateKey)
+            val gasAssetIdBytes = gasAssetId?.let { textBytes(it, "gasAssetId") } ?: ByteArray(0)
             val chainBytes = textBytes(chainId, "chainId")
             val authorityBytes = textBytes(authority, "authority")
             val assetBytes = textBytes(selected.asset, "asset")
@@ -157,6 +169,10 @@ class NativeSignerBridge private constructor() {
                     proofJsonBytes,
                     rootHintBytes,
                     key,
+                    gasAssetIdBytes,
+                    gasAssetId != null,
+                    gasLimit ?: 0L,
+                    gasLimit != null,
                 ),
                 "encodeUnshieldSignedTransaction",
             )
@@ -172,10 +188,14 @@ class NativeSignerBridge private constructor() {
             ttlMs: Long? = null,
             instruction: RegisterZkAssetInstruction?,
             privateKey: ByteArray?,
+            gasAssetId: String? = null,
+            gasLimit: Long? = null,
         ): NativeSignedTransaction {
             requireCreationTime(creationTimeMs)
+            requireGasPairing(gasAssetId, gasLimit)
             val selected = requireNotNull(instruction) { "instruction must be provided" }
             val key = requirePrivateKey(privateKey)
+            val gasAssetIdBytes = gasAssetId?.let { textBytes(it, "gasAssetId") } ?: ByteArray(0)
             val chainBytes = textBytes(chainId, "chainId")
             val authorityBytes = textBytes(authority, "authority")
             val assetBytes = textBytes(selected.asset, "asset")
@@ -204,6 +224,10 @@ class NativeSignerBridge private constructor() {
                     shieldBytes,
                     selected.shieldVerifyingKey != null,
                     key,
+                    gasAssetIdBytes,
+                    gasAssetId != null,
+                    gasLimit ?: 0L,
+                    gasLimit != null,
                 ),
                 "encodeRegisterZkAssetSignedTransaction",
             )
@@ -241,6 +265,13 @@ class NativeSignerBridge private constructor() {
 
         private fun optionalTextBytes(value: String?): ByteArray =
             value?.toByteArray(StandardCharsets.UTF_8) ?: ByteArray(0)
+
+        private fun requireGasPairing(gasAssetId: String?, gasLimit: Long?) {
+            require((gasAssetId == null) == (gasLimit == null)) {
+                "gasAssetId and gasLimit must be provided together"
+            }
+            require(gasLimit == null || gasLimit > 0) { "gasLimit must be positive when provided" }
+        }
 
         private fun requireCreationTime(creationTimeMs: Long) {
             require(creationTimeMs >= 0) { "creationTimeMs must be non-negative" }
@@ -302,6 +333,10 @@ class NativeSignerBridge private constructor() {
             payloadNonce: ByteArray,
             payloadCiphertext: ByteArray,
             privateKey: ByteArray,
+            gasAssetId: ByteArray,
+            gasAssetIdPresent: Boolean,
+            gasLimit: Long,
+            gasLimitPresent: Boolean,
         ): Array<ByteArray?>?
 
         @JvmStatic
@@ -320,6 +355,10 @@ class NativeSignerBridge private constructor() {
             proofJson: ByteArray,
             rootHint: ByteArray,
             privateKey: ByteArray,
+            gasAssetId: ByteArray,
+            gasAssetIdPresent: Boolean,
+            gasLimit: Long,
+            gasLimitPresent: Boolean,
         ): Array<ByteArray?>?
 
         @JvmStatic
@@ -341,6 +380,10 @@ class NativeSignerBridge private constructor() {
             shieldVerifyingKey: ByteArray,
             shieldVerifyingKeyPresent: Boolean,
             privateKey: ByteArray,
+            gasAssetId: ByteArray,
+            gasAssetIdPresent: Boolean,
+            gasLimit: Long,
+            gasLimitPresent: Boolean,
         ): Array<ByteArray?>?
     }
 }

--- a/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/crypto/NativeSignerBridge.kt
+++ b/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/crypto/NativeSignerBridge.kt
@@ -11,6 +11,7 @@ import org.hyperledger.iroha.sdk.core.model.instructions.optionalBytes
 class NativeSignerBridge private constructor() {
     companion object {
         private const val LIBRARY_NAME = "connect_norito_bridge"
+        const val REQUIRED_BRIDGE_ABI_VERSION: Int = 8
         private const val HASH_BYTES = 32
         private val nativeAvailable: Boolean = loadLibrary()
 
@@ -236,7 +237,7 @@ class NativeSignerBridge private constructor() {
         private fun loadLibrary(): Boolean =
             try {
                 System.loadLibrary(LIBRARY_NAME)
-                true
+                nativeBridgeAbiVersion() >= REQUIRED_BRIDGE_ABI_VERSION
             } catch (_: UnsatisfiedLinkError) {
                 false
             } catch (_: SecurityException) {
@@ -289,6 +290,9 @@ class NativeSignerBridge private constructor() {
             require(privateKey != null && privateKey.isNotEmpty()) { "privateKey must not be empty" }
             return privateKey.copyOf()
         }
+
+        @JvmStatic
+        private external fun nativeBridgeAbiVersion(): Int
 
         @JvmStatic
         private external fun nativePublicKeyFromPrivate(

--- a/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/client/ZkAssetShieldLocalnetTest.kt
+++ b/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/client/ZkAssetShieldLocalnetTest.kt
@@ -1,0 +1,263 @@
+package org.hyperledger.iroha.sdk.client
+
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.security.SecureRandom
+import java.time.Duration
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import org.bouncycastle.crypto.params.X25519PrivateKeyParameters
+import org.hyperledger.iroha.sdk.client.transport.TransportRequest
+import org.hyperledger.iroha.sdk.core.model.instructions.ConfidentialEncryptedPayload
+import org.hyperledger.iroha.sdk.core.model.instructions.RegisterZkAssetInstruction
+import org.hyperledger.iroha.sdk.core.model.instructions.ShieldInstruction
+import org.hyperledger.iroha.sdk.core.model.instructions.ZkAssetMode
+import org.hyperledger.iroha.sdk.crypto.NativeSignerBridge
+import org.hyperledger.iroha.sdk.crypto.SigningAlgorithm
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+
+private const val PRIVATE_KEY_MULTIHASH_PREFIX = "802620"
+private const val DEFAULT_LOCALNET_DIR = "/tmp/2iroha-localnet"
+private const val GAS_LIMIT = 1_000L
+
+/**
+ * End-to-end integration test: register a ZK-capable asset and shield public funds into it through
+ * the SDK production path (typed instruction -> [NativeSignerBridge] gas-bearing encoder ->
+ * [HttpClientTransport] submission -> on-chain commit), then assert the Shield anchored a new
+ * shielded root readable via `POST /v1/zk/roots`.
+ *
+ * Opt-in: requires a running confidential-enabled localnet and is gated on `IROHA_LOCALNET_TEST=1`
+ * so the default `:core-jvm:test` run stays node-free. The host JNI bridge
+ * (`libconnect_norito_bridge`) must be built and on `java.library.path` (wired by the test task).
+ * The localnet directory defaults to [DEFAULT_LOCALNET_DIR] and can be overridden with
+ * `IROHA_LOCALNET_DIR`.
+ *
+ * Repeatable: it (re)registers the asset and retries the Shield until the chain accepts it, so it
+ * passes whether the target asset is freshly deployed or already ZK-registered from a prior run.
+ */
+@EnabledIfEnvironmentVariable(named = "IROHA_LOCALNET_TEST", matches = "1")
+class ZkAssetShieldLocalnetTest {
+
+    @Test
+    fun `register zk asset and shield anchor a new root on chain`() {
+        val localnet = localnetDir()
+        val clientToml = readSimpleToml(localnet.resolve("client.toml"))
+        val gasAssetId = gasAssetId(localnet)
+        val gasLimit = GAS_LIMIT
+
+        val chainId = clientToml.getValue("chain")
+        val toriiUrl = clientToml.getValue("torii_url")
+        val privateKey = decodePrivateKeySeed(clientToml.getValue("private_key"))
+
+        val instructions = genesisInstructions(localnet.resolve("genesis.json"))
+        val authority = aliceAccountId(instructions)
+        val asset = numericAssetId(instructions, name = "sample")
+
+        val executor = PlatformHttpTransportExecutor.createDefault()
+        val transport = HttpClientTransport(executor, ClientConfig.builder().setBaseUri(URI.create(toriiUrl)).build())
+        val confidential = ConfidentialAssetToriiClient.builder().baseUri(URI.create(toriiUrl)).build()
+
+        val rootBefore = confidential.getLatestZkAssetRoot(asset).get()
+
+        // Ensure the asset is ZK-registered. On a fresh localnet this commits; on a reused localnet
+        // it is already registered. The Shield below is the authoritative assertion: it only succeeds
+        // against a registered ZK asset with shield permitted, so it transitively proves registration.
+        val registerInstruction = RegisterZkAssetInstruction.builder()
+            .setAsset(asset)
+            .setMode(ZkAssetMode.HYBRID)
+            .setAllowShield(true)
+            .setAllowUnshield(true)
+            .build()
+        val registerTx = NativeSignerBridge.encodeRegisterZkAssetSignedTransaction(
+            algorithm = SigningAlgorithm.ED25519,
+            chainId = chainId,
+            authority = authority,
+            creationTimeMs = System.currentTimeMillis(),
+            ttlMs = null,
+            instruction = registerInstruction,
+            privateKey = privateKey,
+            gasAssetId = gasAssetId,
+            gasLimit = gasLimit,
+        )
+        val registerStatus = submitVersionedTransaction(executor, toriiUrl, registerTx.versionedSignedTransaction)
+        assertTrue(registerStatus in 200..299, "RegisterZkAsset submission rejected with HTTP $registerStatus")
+
+        val shieldInstruction = ShieldInstruction.builder()
+            .setAsset(asset)
+            .setFrom(authority)
+            .setAmount("100")
+            .setNoteCommitment(freshNoteCommitment())
+            .setEncryptedPayload(freshEncryptedPayload())
+            .build()
+        val shieldTx = NativeSignerBridge.encodeShieldSignedTransaction(
+            algorithm = SigningAlgorithm.ED25519,
+            chainId = chainId,
+            authority = authority,
+            creationTimeMs = System.currentTimeMillis(),
+            ttlMs = null,
+            instruction = shieldInstruction,
+            privateKey = privateKey,
+            gasAssetId = gasAssetId,
+            gasLimit = gasLimit,
+        )
+        val shieldStatus = submitUntilAccepted(executor, toriiUrl, shieldTx.versionedSignedTransaction)
+        assertTrue(shieldStatus in 200..299, "Shield was not accepted (last HTTP $shieldStatus); RegisterZkAsset may not have committed")
+        transport.waitForTransactionStatus(toHex(shieldTx.transactionHash), null).get()
+
+        val rootAfter = confidential.getLatestZkAssetRoot(asset).get()
+        assertNotNull(rootAfter, "shield must produce a readable shielded root")
+        val advanced = rootBefore == null || !rootAfter.contentEquals(rootBefore)
+        assertTrue(advanced, "shield must anchor a new shielded root distinct from the prior root")
+    }
+
+    private fun localnetDir(): Path =
+        Paths.get(System.getenv("IROHA_LOCALNET_DIR") ?: DEFAULT_LOCALNET_DIR)
+
+    // Posts native-encoder output (a versioned SignedTransaction in binary Norito) to the canonical
+    // Torii ingress, matching what HttpClientTransport does for typed transactions.
+    private fun submitVersionedTransaction(
+        executor: HttpTransportExecutor,
+        toriiUrl: String,
+        versionedBytes: ByteArray,
+    ): Int {
+        val request = TransportRequest.builder()
+            .setUri(URI.create(toriiUrl).resolve("v1/pipeline/transactions"))
+            .setMethod("POST")
+            .addHeader("Content-Type", "application/x-norito")
+            .addHeader("Accept", "application/json")
+            .setBody(versionedBytes)
+            .setTimeout(Duration.ofSeconds(10))
+            .build()
+        return executor.execute(request).get().statusCode
+    }
+
+    // RegisterZkAsset commits asynchronously and Shield is rejected (HTTP 403) until it lands. Retry
+    // the identical Shield submission until the chain accepts it, tolerating block latency / cold start.
+    private fun submitUntilAccepted(
+        executor: HttpTransportExecutor,
+        toriiUrl: String,
+        versionedBytes: ByteArray,
+    ): Int {
+        var status = 0
+        repeat(30) {
+            status = submitVersionedTransaction(executor, toriiUrl, versionedBytes)
+            status.takeIf { code -> code in 200..299 }?.let { return it }
+            Thread.sleep(1_000)
+        }
+        return status
+    }
+
+    private fun freshNoteCommitment(): ByteArray {
+        val commitment = ByteArray(32)
+        SecureRandom().nextBytes(commitment)
+        commitment[0] = (commitment[0].toInt() or 0x01).toByte()
+        return commitment
+    }
+
+    private fun freshEncryptedPayload(): ConfidentialEncryptedPayload {
+        val random = SecureRandom()
+        val ephemeral = X25519PrivateKeyParameters(random).generatePublicKey().encoded
+        val nonce = ByteArray(24).also { random.nextBytes(it) }
+        val ciphertext = ByteArray(48).also { random.nextBytes(it) }
+        return ConfidentialEncryptedPayload(
+            ephemeralPublicKey = ephemeral,
+            nonce = nonce,
+            ciphertext = ciphertext,
+        )
+    }
+
+    private fun decodePrivateKeySeed(multihash: String): ByteArray {
+        require(multihash.startsWith(PRIVATE_KEY_MULTIHASH_PREFIX)) {
+            "private_key must be an Iroha Ed25519 multihash"
+        }
+        return hexToBytes(multihash.substring(PRIVATE_KEY_MULTIHASH_PREFIX.length))
+    }
+
+    private fun readSimpleToml(path: Path): Map<String, String> {
+        val result = LinkedHashMap<String, String>()
+        for (raw in Files.readAllLines(path, StandardCharsets.UTF_8)) {
+            val line = raw.trim()
+            val separator = line.indexOf('=')
+            val parseable = line.isNotEmpty() && !line.startsWith("#") && !line.startsWith("[") && separator > 0
+            parseable.takeIf { it }?.let {
+                val key = line.substring(0, separator).trim()
+                val value = line.substring(separator + 1).trim().trim('"')
+                result[key] = value
+            }
+        }
+        return result
+    }
+
+    // The node's gas asset comes from `[pipeline.gas] accepted_assets` in the peer config
+    // (deploy_localnet.sh-patched localnets) or the genesis `ivm_gas_accepted_assets` custom
+    // parameter (raw kagami localnets). Support both so the test is independent of the deploy path.
+    private fun gasAssetId(localnet: Path): String =
+        gasAssetFromPeerConfig(localnet)
+            ?: gasAssetFromGenesis(localnet)
+            ?: error("no gas asset in peer0.toml accepted_assets or genesis ivm_gas_accepted_assets")
+
+    private fun gasAssetFromPeerConfig(localnet: Path): String? {
+        val line = Files.readAllLines(localnet.resolve("peer0.toml"), StandardCharsets.UTF_8)
+            .firstOrNull { it.trim().startsWith("accepted_assets") } ?: return null
+        return Regex("\"([^\"]+)\"").find(line)?.groupValues?.get(1)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun gasAssetFromGenesis(localnet: Path): String? {
+        val root = JsonParser.parse(
+            String(Files.readAllBytes(localnet.resolve("genesis.json")), StandardCharsets.UTF_8),
+        ) as Map<String, Any?>
+        return (root.getValue("transactions") as List<Any?>).firstNotNullOfOrNull { tx ->
+            val custom = ((tx as? Map<String, Any?>)?.get("parameters") as? Map<String, Any?>)
+                ?.get("custom") as? Map<String, Any?>
+            val payload = (custom?.get("ivm_gas_accepted_assets") as? Map<String, Any?>)?.get("payload")
+            (payload as? List<Any?>)?.firstOrNull() as? String
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun genesisInstructions(path: Path): List<Any?> {
+        val root = JsonParser.parse(String(Files.readAllBytes(path), StandardCharsets.UTF_8)) as Map<String, Any?>
+        val transactions = root.getValue("transactions") as List<Any?>
+        return transactions.flatMap { tx ->
+            ((tx as? Map<String, Any?>)?.get("instructions") as? List<Any?>) ?: emptyList()
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun aliceAccountId(instructions: List<Any?>): String {
+        val account = instructions.firstNotNullOf { isi ->
+            ((isi as? Map<String, Any?>)?.get("Register") as? Map<String, Any?>)?.get("Account") as? Map<String, Any?>
+        }
+        return account.getValue("id") as String
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun numericAssetId(instructions: List<Any?>, name: String): String {
+        val definition = instructions.firstNotNullOf { isi ->
+            (((isi as? Map<String, Any?>)?.get("Register") as? Map<String, Any?>)?.get("AssetDefinition") as? Map<String, Any?>)
+                ?.takeIf { it["name"] == name }
+        }
+        return definition.getValue("id") as String
+    }
+
+    private fun hexToBytes(hex: String): ByteArray {
+        require(hex.length % 2 == 0) { "hex string must have even length" }
+        return ByteArray(hex.length / 2) { index ->
+            hex.substring(index * 2, index * 2 + 2).toInt(16).toByte()
+        }
+    }
+
+    private fun toHex(bytes: ByteArray): String =
+        buildString(bytes.size * 2) {
+            for (byte in bytes) {
+                val value = byte.toInt() and 0xff
+                append("0123456789abcdef"[value ushr 4])
+                append("0123456789abcdef"[value and 0x0f])
+            }
+        }
+}

--- a/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/core/model/instructions/ZkAssetInstructionsTest.kt
+++ b/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/core/model/instructions/ZkAssetInstructionsTest.kt
@@ -357,6 +357,103 @@ class ZkAssetInstructionsTest {
         }
     }
 
+    @Test
+    fun registerZkAssetFromArgumentsRoundTrips() {
+        val original = RegisterZkAssetInstruction.builder()
+            .setAsset("rose#wonderland")
+            .setMode(ZkAssetMode.HYBRID)
+            .setAllowShield(true)
+            .setAllowUnshield(false)
+            .setTransferVerifyingKey("halo2/ipa:transfer-v2")
+            .setUnshieldVerifyingKey("halo2/ipa:unshield-v3")
+            .build()
+
+        val restored = RegisterZkAssetInstruction.fromArguments(original.arguments)
+
+        assertEquals(original.asset, restored.asset)
+        assertEquals(original.mode, restored.mode)
+        assertEquals(original.allowShield, restored.allowShield)
+        assertEquals(original.allowUnshield, restored.allowUnshield)
+        assertEquals(original.transferVerifyingKey, restored.transferVerifyingKey)
+        assertEquals(original.unshieldVerifyingKey, restored.unshieldVerifyingKey)
+        assertEquals(original.shieldVerifyingKey, restored.shieldVerifyingKey)
+        assertEquals(original.arguments, restored.arguments)
+    }
+
+    @Test
+    fun registerZkAssetFromArgumentsOmitsBlankVerifyingKeys() {
+        val original = RegisterZkAssetInstruction.builder()
+            .setAsset("rose#wonderland")
+            .setMode(ZkAssetMode.ZK_NATIVE)
+            .build()
+
+        val restored = RegisterZkAssetInstruction.fromArguments(original.arguments)
+
+        assertEquals(null, restored.transferVerifyingKey)
+        assertEquals(null, restored.unshieldVerifyingKey)
+        assertEquals(null, restored.shieldVerifyingKey)
+        assertEquals(original.arguments, restored.arguments)
+    }
+
+    @Test
+    fun registerZkAssetFromArgumentsRejectsMissingAsset() {
+        val arguments = validRegisterArguments().toMutableMap()
+        arguments.remove("asset")
+        assertFailsWith<IllegalArgumentException> {
+            RegisterZkAssetInstruction.fromArguments(arguments)
+        }
+    }
+
+    @Test
+    fun registerZkAssetFromArgumentsRejectsUnknownMode() {
+        val arguments = validRegisterArguments().toMutableMap()
+        arguments["mode"] = "Transparent"
+        assertFailsWith<IllegalArgumentException> {
+            RegisterZkAssetInstruction.fromArguments(arguments)
+        }
+    }
+
+    @Test
+    fun registerZkAssetFromArgumentsRejectsNonCanonicalBoolean() {
+        val arguments = validRegisterArguments().toMutableMap()
+        arguments["allow_shield"] = "yes"
+        assertFailsWith<IllegalArgumentException> {
+            RegisterZkAssetInstruction.fromArguments(arguments)
+        }
+    }
+
+    @Test
+    fun registerZkAssetFromArgumentsRejectsMalformedVerifyingKey() {
+        val arguments = validRegisterArguments().toMutableMap()
+        arguments["vk_transfer"] = "no-separator"
+        assertFailsWith<IllegalArgumentException> {
+            RegisterZkAssetInstruction.fromArguments(arguments)
+        }
+    }
+
+    @Test
+    fun shieldFromArgumentsIsUnsupported() {
+        assertFailsWith<UnsupportedOperationException> {
+            ShieldInstruction.fromArguments(emptyMap())
+        }
+    }
+
+    @Test
+    fun unshieldFromArgumentsIsUnsupported() {
+        assertFailsWith<UnsupportedOperationException> {
+            UnshieldInstruction.fromArguments(emptyMap())
+        }
+    }
+
+    private fun validRegisterArguments(): Map<String, String> =
+        RegisterZkAssetInstruction.builder()
+            .setAsset("rose#wonderland")
+            .setMode(ZkAssetMode.HYBRID)
+            .setAllowShield(true)
+            .setAllowUnshield(false)
+            .build()
+            .arguments
+
     private fun samplePayload(): ConfidentialEncryptedPayload =
         ConfidentialEncryptedPayload(
             ephemeralPublicKey = fill(0x11, 32),

--- a/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/core/model/instructions/ZkAssetInstructionsTest.kt
+++ b/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/core/model/instructions/ZkAssetInstructionsTest.kt
@@ -5,9 +5,13 @@ import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import org.hyperledger.iroha.sdk.address.AccountAddress
+import org.hyperledger.iroha.sdk.core.model.JsonValue
 import org.hyperledger.iroha.sdk.crypto.NativeSignedTransaction
 import org.hyperledger.iroha.sdk.crypto.NativeSignerBridge
 import org.hyperledger.iroha.sdk.crypto.SigningAlgorithm
+import org.hyperledger.iroha.sdk.tx.norito.NoritoJavaCodecAdapter
+import org.hyperledger.iroha.sdk.tx.norito.SignedTransactionEncoder
 
 class ZkAssetInstructionsTest {
     @Test
@@ -355,6 +359,43 @@ class ZkAssetInstructionsTest {
         assertFailsWith<IllegalArgumentException> {
             NativeSignedTransaction(byteArrayOf(1), fill(1, 31))
         }
+    }
+
+    @Test
+    fun nativeSignerZkRegisterIncludesGasMetadataWhenBridgeAvailable() {
+        assertEquals(8, NativeSignerBridge.REQUIRED_BRIDGE_ABI_VERSION)
+        if (!NativeSignerBridge.isNativeAvailable()) return
+
+        val (privateKey, publicKey) = NativeSignerBridge.keypairFromSeed(
+            SigningAlgorithm.ED25519,
+            ByteArray(32) { index -> (index + 1).toByte() },
+        )
+        val authority = AccountAddress.fromAccount(publicKey, "ed25519").toI105Default()
+        val gasAssetId = "7EAD8EFYUx1aVKZPUU1fyKvr8dF1"
+        val gasLimit = 1_000L
+        val instruction = RegisterZkAssetInstruction.builder()
+            .setAsset(gasAssetId)
+            .setMode(ZkAssetMode.HYBRID)
+            .setAllowShield(true)
+            .setAllowUnshield(true)
+            .build()
+
+        val native = NativeSignerBridge.encodeRegisterZkAssetSignedTransaction(
+            algorithm = SigningAlgorithm.ED25519,
+            chainId = "00000042",
+            authority = authority,
+            creationTimeMs = 1_736_000_000_000,
+            ttlMs = null,
+            instruction = instruction,
+            privateKey = privateKey,
+            gasAssetId = gasAssetId,
+            gasLimit = gasLimit,
+        )
+        val signed = SignedTransactionEncoder.decodeVersioned(native.versionedSignedTransaction)
+        val payload = NoritoJavaCodecAdapter().decodeTransaction(signed.encodedPayload())
+
+        assertEquals(JsonValue.string(gasAssetId), payload.metadata["gas_asset_id"])
+        assertEquals(JsonValue.number(gasLimit), payload.metadata["gas_limit"])
     }
 
     @Test


### PR DESCRIPTION
## Context

An Iroha node rejects any transaction missing `gas_asset_id` metadata once a gas policy is active (`Transaction rejected: missing gas_asset_id in transaction metadata`). The SDK's ZK transaction signers — `Shield`, `Unshield`, and `RegisterZkAsset` — emitted empty transaction metadata, so clients could not submit ZK-asset transactions to any gas-enforcing chain. Separately, the ZK instruction models lacked the `fromArguments` reconstruction companions that sibling instruction types already expose.

### Solution

Thread `gasAssetId`/`gasLimit` through the native `connect_norito_bridge` signer path (new `java_gas_metadata` helper writes `gas_asset_id` plus `insert_transaction_gas_limit` into the signed `TransactionPayload` metadata) and surface them as optional parameters on `NativeSignerBridge.encode{Shield,Unshield,RegisterZkAsset}SignedTransaction` in both the Kotlin (`core-jvm`) and Java (`iroha_android`) bindings, including the matching `_alg` JNI exports for the `sdk.crypto` and `android.crypto` namespaces. The parameters are additive (defaulted in Kotlin, overloads in Java), so existing callers are source-compatible. Added `RegisterZkAssetInstruction.fromArguments` (real reconstruction) plus documented `UnsupportedOperationException` `fromArguments` for `Shield`/`Unshield` (their note-commitment/encrypted-payload/proof fields are binary and cannot be rebuilt from a string map), mirroring the existing `TransferAssetInstruction`/`BurnAssetInstruction` pattern. A new opt-in localnet integration test drives the production signer path end to end.

---

### Review notes

- `crates/connect_norito_bridge/src/lib.rs` — start here. Confirm `java_gas_metadata` builds the metadata correctly and that the four gas args are threaded identically through all three encoders' glue functions and both JNI namespaces (`sdk.crypto` real args; `android.crypto` mirrored).
- `kotlin/core-jvm/.../crypto/NativeSignerBridge.kt` — optional `gasAssetId`/`gasLimit` params on the three encoders, `requireGasPairing` validation, and the updated `external` declarations (must match the JNI signatures above).
- `kotlin/core-jvm/.../core/model/instructions/ZkAssetInstructions.kt` + `ZkAssetInstructionsTest.kt` — the `fromArguments` companions and their unit coverage (round-trip, strict-boolean/missing-arg rejection, unsupported Shield/Unshield).
- `kotlin/core-jvm/.../client/ZkAssetShieldLocalnetTest.kt` — gated on `IROHA_LOCALNET_TEST=1`; verifies `RegisterZkAsset` + `Shield` commit on a real node and the shield-anchored root surfaces via `POST /v1/zk/roots`. Note the `core-jvm` test task wires `java.library.path` to the host bridge.
- `java/iroha_android/.../crypto/NativeSignerBridge.java` and the three `model/instructions/*.java` — Java mirror of the Kotlin signer overloads and `fromArguments`; diff against the Kotlin equivalents for parity.