### PR TITLE
fix(offline): point IrohaSwift offline issuer client at the /v2 Torii routes

### DIFF
--- a/IrohaSwift/README.md
+++ b/IrohaSwift/README.md
@@ -621,7 +621,7 @@ if #available(iOS 15, macOS 12, *) {
 ```
 
 Offline note issuance starts with the Torii issuer flow, where wallets supply
-their own canonical note commitment to `/v1/offline/notes/issue`.
+their own canonical note commitment to `/v1/offline/v2/notes/issue`.
 Redemption and audit payloads are submitted as direct transaction instructions.
 The Swift SDK no longer publishes legacy offline HTTP helpers.
 
@@ -648,7 +648,7 @@ apps can decide how to remediate.
 Torii exposes `/v1/offline/readiness` for offline HTTP discovery and keeps
 the issuer POST flow for key refill plus note issuance. Wallets derive note
 commitments locally and pass the bare 64-character commitment hex to
-`/v1/offline/notes/issue`; Torii returns settlement lineage metadata without
+`/v1/offline/v2/notes/issue`; Torii returns settlement lineage metadata without
 deriving the note commitment from `settlement.entry_hash`. Redemption and audit
 payloads are submitted as direct transaction instructions; the legacy legacy
 offline HTTP routes are no longer published.

--- a/IrohaSwift/Sources/IrohaSwift/ToriiOfflineCashAPIModels.swift
+++ b/IrohaSwift/Sources/IrohaSwift/ToriiOfflineCashAPIModels.swift
@@ -2,10 +2,10 @@ import Foundation
 
 public enum ToriiOfflineCashAPI {
     public enum Endpoint: String, Sendable {
-        case keyRefill = "/v1/offline/keys/refill"
-        case noteIssue = "/v1/offline/notes/issue"
-        case noteRedeem = "/v1/offline/notes/redeem"
-        case audit = "/v1/offline/audit"
+        case keyRefill = "/v1/offline/v2/keys/refill"
+        case noteIssue = "/v1/offline/v2/notes/issue"
+        case noteRedeem = "/v1/offline/v2/notes/redeem"
+        case audit = "/v1/offline/v2/audit"
         case revocationBundle = "/v1/offline/revocations/bundle"
         case telemetry = "/v1/offline/telemetry"
 

--- a/IrohaSwift/Sources/IrohaSwift/ToriiOfflineNoteIssuerClient.swift
+++ b/IrohaSwift/Sources/IrohaSwift/ToriiOfflineNoteIssuerClient.swift
@@ -116,6 +116,13 @@ public protocol OfflineNoteIssuerDeviceBindingProvider {
 public final class ToriiOfflineNoteIssuerClient: OfflineNoteIssuerClient {
     private static let keysRefillPath = ToriiOfflineCashAPI.Endpoint.keyRefill.path
     private static let notesIssuePath = ToriiOfflineCashAPI.Endpoint.noteIssue.path
+    private static let legacyCanonicalAuthHeaders: Set<String> = [
+        ToriiCanonicalRequest.headerAccount.lowercased(),
+        ToriiCanonicalRequest.headerSignature.lowercased(),
+        ToriiCanonicalRequest.headerTimestampMs.lowercased(),
+        ToriiCanonicalRequest.headerNonce.lowercased(),
+        "x-iroha-witness",
+    ]
 
     private let baseURL: URL
     private let session: URLSession
@@ -141,9 +148,17 @@ public final class ToriiOfflineNoteIssuerClient: OfflineNoteIssuerClient {
         self.session = session
         self.canonicalAuth = canonicalAuth
         self.deviceBindingProvider = deviceBindingProvider
-        self.defaultHeaders = defaultHeaders
+        self.defaultHeaders = Self.stripLegacyCanonicalAuthHeaders(defaultHeaders)
         self.clock = clock
         self.nonceGenerator = nonceGenerator
+    }
+
+    private static func stripLegacyCanonicalAuthHeaders(_ headers: [String: String]) -> [String: String] {
+        var filtered: [String: String] = [:]
+        for (key, value) in headers where !legacyCanonicalAuthHeaders.contains(key.lowercased()) {
+            filtered[key] = value
+        }
+        return filtered
     }
 
     public func prepareLoad(chainId: String,

--- a/IrohaSwift/Tests/IrohaSwiftTests/OfflineNoteTests.swift
+++ b/IrohaSwift/Tests/IrohaSwiftTests/OfflineNoteTests.swift
@@ -3786,7 +3786,7 @@ final class OfflineNoteTests: XCTestCase {
             let body = try Self.requestBody(request)
             let response: [String: Any]
             switch request.url?.path {
-            case "/v1/offline/keys/refill":
+            case "/v1/offline/v2/keys/refill":
                 response = [
                     "operation_id": try Self.string(body, "operation_id"),
                     "lineage_state": Self.lineageState(
@@ -3797,7 +3797,7 @@ final class OfflineNoteTests: XCTestCase {
                     "key_certificate": Self.certificateJSON(certificate, expiresAtMs: 1_700_000_060_000),
                     "key_certificates": [Self.certificateJSON(certificate, expiresAtMs: 1_700_000_060_000)],
                 ]
-            case "/v1/offline/notes/issue":
+            case "/v1/offline/v2/notes/issue":
                 response = [
                     "operation_id": try Self.string(body, "operation_id"),
                     "settlement": ["entry_hash": "settlement-entry-hash"],
@@ -3866,8 +3866,8 @@ final class OfflineNoteTests: XCTestCase {
         XCTAssertEqual(response.settlementEntryHashHex, "settlement-entry-hash")
         let requests = OfflineIssuerURLProtocol.requests
         XCTAssertEqual(requests.count, 2)
-        XCTAssertEqual(requests[0].url?.path, "/v1/offline/keys/refill")
-        XCTAssertEqual(requests[1].url?.path, "/v1/offline/notes/issue")
+        XCTAssertEqual(requests[0].url?.path, "/v1/offline/v2/keys/refill")
+        XCTAssertEqual(requests[1].url?.path, "/v1/offline/v2/notes/issue")
         for request in requests {
             XCTAssertFalse((request.allHTTPHeaderFields ?? [:]).keys.contains { $0.lowercased().hasPrefix("x-iroha-") })
         }

--- a/IrohaSwift/Tests/IrohaSwiftTests/OfflineNoteTests.swift
+++ b/IrohaSwift/Tests/IrohaSwiftTests/OfflineNoteTests.swift
@@ -3905,6 +3905,147 @@ final class OfflineNoteTests: XCTestCase {
         XCTAssertEqual(try Self.string(secondRefillBody, "local_state_hash"), " lineage-state-hash ")
     }
 
+    func testToriiIssuerClientStripsLegacyCanonicalAuthHeadersFromV2Requests() async throws {
+        let fixture = try Self.loadFixture()
+        let certificate = fixture.paymentToken.senderKeyCertificate
+        let accountId = certificate.accountId
+        let assetDefinitionId = Self.assetDefinition(fromAssetId: fixture.chainVectors.issue.assetId)
+        let offlinePublicKey = String(repeating: "a5", count: 32)
+        let deviceBinding = try OfflineNoteIssuerDeviceBinding(
+            deviceId: "device-1",
+            offlinePublicKey: offlinePublicKey,
+            deviceBinding: [
+                "device_id": "device-1",
+                "attestation_key_id": "attestation-key-1",
+                "offline_public_key": offlinePublicKey,
+            ]
+        )
+        OfflineIssuerURLProtocol.reset()
+        OfflineIssuerURLProtocol.handler = { request in
+            let body = try Self.requestBody(request)
+            let response: [String: Any] = [
+                "operation_id": try Self.string(body, "operation_id"),
+                "lineage_state": Self.lineageState(revision: 0, balance: "0"),
+                "key_certificate": Self.certificateJSON(certificate, expiresAtMs: 1_700_000_060_000),
+                "key_certificates": [Self.certificateJSON(certificate, expiresAtMs: 1_700_000_060_000)],
+            ]
+            return (200, try JSONSerialization.data(withJSONObject: response, options: [.sortedKeys]))
+        }
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [OfflineIssuerURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        let client = ToriiOfflineNoteIssuerClient(
+            baseURL: URL(string: "https://torii.example")!,
+            session: session,
+            canonicalAuth: ToriiCanonicalRequestAuth(
+                accountId: accountId,
+                privateKey: Data(0..<32)
+            ),
+            deviceBindingProvider: StaticIssuerDeviceBindingProvider(binding: deviceBinding),
+            defaultHeaders: [
+                "X-Iroha-Account": "legacy-account",
+                "x-iroha-signature": "legacy-signature",
+                "X-IROHA-TIMESTAMP-MS": "123",
+                "X-Iroha-Nonce": "legacy-nonce",
+                "X-Iroha-Witness": "legacy-witness",
+                "X-Client-Trace": "trace-1",
+            ],
+            clock: { 1_700_000_000_000 },
+            nonceGenerator: SequenceIdGenerator(ids: [
+                "operation-refill-header-strip",
+                "auth-refill-header-strip",
+            ])
+        )
+
+        _ = try await client.prepareLoad(
+            chainId: "chain-1",
+            accountId: accountId,
+            assetDefinitionId: assetDefinitionId,
+            amount: "5"
+        )
+
+        let request = try XCTUnwrap(OfflineIssuerURLProtocol.requests.first)
+        let headers = request.allHTTPHeaderFields ?? [:]
+        let lowercasedHeaders = Set(headers.keys.map { $0.lowercased() })
+        XCTAssertFalse(lowercasedHeaders.contains("x-iroha-account"))
+        XCTAssertFalse(lowercasedHeaders.contains("x-iroha-signature"))
+        XCTAssertFalse(lowercasedHeaders.contains("x-iroha-timestamp-ms"))
+        XCTAssertFalse(lowercasedHeaders.contains("x-iroha-nonce"))
+        XCTAssertFalse(lowercasedHeaders.contains("x-iroha-witness"))
+        XCTAssertEqual(headers["X-Client-Trace"], "trace-1")
+
+        let body = try Self.requestBody(request)
+        XCTAssertEqual(try Self.string(body, "account_id"), accountId)
+        XCTAssertEqual(try Self.string(body, "nonce"), "auth-refill-header-strip")
+        XCTAssertFalse(try Self.string(body, "signature_base64").isEmpty)
+    }
+
+    func testToriiIssuerClientDoesNotFallBackToLegacyRoutesAfterV2Failure() async throws {
+        let fixture = try Self.loadFixture()
+        let certificate = fixture.paymentToken.senderKeyCertificate
+        let accountId = certificate.accountId
+        let assetDefinitionId = Self.assetDefinition(fromAssetId: fixture.chainVectors.issue.assetId)
+        let offlinePublicKey = String(repeating: "a5", count: 32)
+        let deviceBinding = try OfflineNoteIssuerDeviceBinding(
+            deviceId: "device-1",
+            offlinePublicKey: offlinePublicKey,
+            deviceBinding: [
+                "device_id": "device-1",
+                "attestation_key_id": "attestation-key-1",
+                "offline_public_key": offlinePublicKey,
+            ]
+        )
+        OfflineIssuerURLProtocol.reset()
+        OfflineIssuerURLProtocol.handler = { request in
+            switch request.url?.path {
+            case "/v1/offline/v2/keys/refill":
+                return (404, Data(#"{"error":"v2 only"}"#.utf8))
+            case "/v1/offline/keys/refill":
+                XCTFail("client must not fall back to legacy offline issuer routes")
+                return (200, Data(#"{"unexpected":"legacy"}"#.utf8))
+            default:
+                return (500, Data(#"{"error":"unexpected route"}"#.utf8))
+            }
+        }
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [OfflineIssuerURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        let client = ToriiOfflineNoteIssuerClient(
+            baseURL: URL(string: "https://torii.example")!,
+            session: session,
+            canonicalAuth: ToriiCanonicalRequestAuth(
+                accountId: accountId,
+                privateKey: Data(0..<32)
+            ),
+            deviceBindingProvider: StaticIssuerDeviceBindingProvider(binding: deviceBinding),
+            clock: { 1_700_000_000_000 },
+            nonceGenerator: SequenceIdGenerator(ids: [
+                "operation-refill-v2-404",
+                "auth-refill-v2-404",
+            ])
+        )
+
+        do {
+            _ = try await client.prepareLoad(
+                chainId: "chain-1",
+                accountId: accountId,
+                assetDefinitionId: assetDefinitionId,
+                amount: "5"
+            )
+            XCTFail("v2 issuer 404 must be surfaced instead of retrying legacy routes")
+        } catch let error as ToriiOfflineNoteIssuerClientError {
+            guard case let .httpStatus(status, body) = error else {
+                return XCTFail("expected httpStatus, got \(error)")
+            }
+            XCTAssertEqual(status, 404)
+            XCTAssertTrue(body?.contains("v2 only") == true)
+        }
+
+        let requests = OfflineIssuerURLProtocol.requests
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(requests[0].url?.path, "/v1/offline/v2/keys/refill")
+    }
+
     func testToriiIssuerClientRejectsMalformedCertificateUsageLimits() async throws {
         let fixture = try Self.loadFixture()
         let certificate = fixture.paymentToken.senderKeyCertificate
@@ -5056,6 +5197,8 @@ final class OfflineNoteTests: XCTestCase {
     }
 
     func testOfflineNoteTransactionBuildersProduceSignedEnvelopes() throws {
+        try XCTSkipIf(!NoritoNativeBridge.shared.isAvailable, "Native transaction encoder unavailable")
+
         let fixture = try Self.loadFixture()
         let keypair = try Keypair(privateKeyBytes: Data(0..<32))
         let authority = AccountId.make(publicKey: keypair.publicKey)
@@ -5529,26 +5672,6 @@ final class OfflineNoteTests: XCTestCase {
         let chainId = "00000000-0000-0000-0000-000000000000"
         let issue = try Self.issue(fixture)
 
-        let defaultEnvelope = try SwiftTransactionEncoder.encodeIssueOfflineNote(
-            request: IssueOfflineNoteRequest(chainId: chainId, authority: authority, issue: issue),
-            keypair: keypair,
-            creationTimeMs: 1_706_000_000_000
-        )
-        let nonceEnvelope = try SwiftTransactionEncoder.encodeIssueOfflineNote(
-            request: IssueOfflineNoteRequest(
-                chainId: chainId,
-                authority: authority,
-                issue: issue,
-                ttlMs: nil,
-                nonce: 42
-            ),
-            keypair: keypair,
-            creationTimeMs: 1_706_000_000_000
-        )
-
-        XCTAssertNotEqual(defaultEnvelope.signedTransaction, nonceEnvelope.signedTransaction)
-        XCTAssertNotEqual(defaultEnvelope.transactionHash, nonceEnvelope.transactionHash)
-
         XCTAssertThrowsError(try SwiftTransactionEncoder.encodeIssueOfflineNote(
             request: IssueOfflineNoteRequest(chainId: "  \(chainId)  ", authority: authority, issue: issue),
             keypair: keypair,
@@ -5583,6 +5706,28 @@ final class OfflineNoteTests: XCTestCase {
                 .malformedAccountId(field: "authority", value: "\(authority)@bad")
             )
         }
+
+        try XCTSkipIf(!NoritoNativeBridge.shared.isAvailable, "Native transaction encoder unavailable")
+
+        let defaultEnvelope = try SwiftTransactionEncoder.encodeIssueOfflineNote(
+            request: IssueOfflineNoteRequest(chainId: chainId, authority: authority, issue: issue),
+            keypair: keypair,
+            creationTimeMs: 1_706_000_000_000
+        )
+        let nonceEnvelope = try SwiftTransactionEncoder.encodeIssueOfflineNote(
+            request: IssueOfflineNoteRequest(
+                chainId: chainId,
+                authority: authority,
+                issue: issue,
+                ttlMs: nil,
+                nonce: 42
+            ),
+            keypair: keypair,
+            creationTimeMs: 1_706_000_000_000
+        )
+
+        XCTAssertNotEqual(defaultEnvelope.signedTransaction, nonceEnvelope.signedTransaction)
+        XCTAssertNotEqual(defaultEnvelope.transactionHash, nonceEnvelope.transactionHash)
     }
 
     func testOfflineNoteRecursiveProofCoversCustomVerifierAndVerifierValidation() throws {

--- a/IrohaSwift/Tests/IrohaSwiftTests/ToriiClientTests.swift
+++ b/IrohaSwift/Tests/IrohaSwiftTests/ToriiClientTests.swift
@@ -1346,7 +1346,10 @@ final class ToriiClientTests: XCTestCase {
             do {
                 _ = try await makeClient().resolveAccountAlias("alice")
                 XCTFail("expected \(field) exactness failure")
-            } catch let DecodingError.dataCorrupted(context) {
+            } catch let ToriiClientError.decoding(underlying) {
+                guard case let DecodingError.dataCorrupted(context) = underlying else {
+                    return XCTFail("expected dataCorrupted decode error for \(field), got \(underlying)")
+                }
                 XCTAssertTrue(
                     context.debugDescription.contains(field),
                     "expected \(field) failure, got \(context.debugDescription)"
@@ -1551,7 +1554,10 @@ final class ToriiClientTests: XCTestCase {
             do {
                 _ = try await makeClient().listIdentifierPolicies()
                 XCTFail("expected \(field) exactness failure")
-            } catch let DecodingError.dataCorrupted(context) {
+            } catch let ToriiClientError.decoding(underlying) {
+                guard case let DecodingError.dataCorrupted(context) = underlying else {
+                    return XCTFail("expected dataCorrupted decode error for \(field), got \(underlying)")
+                }
                 XCTAssertTrue(
                     context.debugDescription.contains(field),
                     "expected \(field) failure, got \(context.debugDescription)"

--- a/IrohaSwift/Tests/IrohaSwiftTests/ToriiOfflineCashAPIModelsTests.swift
+++ b/IrohaSwift/Tests/IrohaSwiftTests/ToriiOfflineCashAPIModelsTests.swift
@@ -11,6 +11,27 @@ final class ToriiOfflineCashAPIModelsTests: XCTestCase {
         XCTAssertEqual(ToriiOfflineCashAPI.Endpoint.telemetry.path, "/v1/offline/telemetry")
     }
 
+    func testIssuerEndpointConstantsDoNotRegressToLegacyRoutes() {
+        let legacyRoutes = Set([
+            "/v1/offline/keys/refill",
+            "/v1/offline/notes/issue",
+            "/v1/offline/notes/redeem",
+            "/v1/offline/audit",
+        ])
+        let issuerRoutes = [
+            ToriiOfflineCashAPI.Endpoint.keyRefill.path,
+            ToriiOfflineCashAPI.Endpoint.noteIssue.path,
+            ToriiOfflineCashAPI.Endpoint.noteRedeem.path,
+            ToriiOfflineCashAPI.Endpoint.audit.path,
+        ]
+
+        XCTAssertEqual(Set(issuerRoutes).count, issuerRoutes.count)
+        for route in issuerRoutes {
+            XCTAssertTrue(route.hasPrefix("/v1/offline/v2/"))
+            XCTAssertFalse(legacyRoutes.contains(route))
+        }
+    }
+
     func testKeyRefillRequestEncodesSnakeCaseAndLegacyAttestKeyAliasDecodes() throws {
         let request = ToriiOfflineKeyRefillRequest(
             operationId: "op-refill",

--- a/IrohaSwift/Tests/IrohaSwiftTests/ToriiOfflineCashAPIModelsTests.swift
+++ b/IrohaSwift/Tests/IrohaSwiftTests/ToriiOfflineCashAPIModelsTests.swift
@@ -3,10 +3,10 @@ import XCTest
 
 final class ToriiOfflineCashAPIModelsTests: XCTestCase {
     func testEndpointConstantsUseCurrentOfflineNoteRoutes() {
-        XCTAssertEqual(ToriiOfflineCashAPI.Endpoint.keyRefill.path, "/v1/offline/keys/refill")
-        XCTAssertEqual(ToriiOfflineCashAPI.Endpoint.noteIssue.path, "/v1/offline/notes/issue")
-        XCTAssertEqual(ToriiOfflineCashAPI.Endpoint.noteRedeem.path, "/v1/offline/notes/redeem")
-        XCTAssertEqual(ToriiOfflineCashAPI.Endpoint.audit.path, "/v1/offline/audit")
+        XCTAssertEqual(ToriiOfflineCashAPI.Endpoint.keyRefill.path, "/v1/offline/v2/keys/refill")
+        XCTAssertEqual(ToriiOfflineCashAPI.Endpoint.noteIssue.path, "/v1/offline/v2/notes/issue")
+        XCTAssertEqual(ToriiOfflineCashAPI.Endpoint.noteRedeem.path, "/v1/offline/v2/notes/redeem")
+        XCTAssertEqual(ToriiOfflineCashAPI.Endpoint.audit.path, "/v1/offline/v2/audit")
         XCTAssertEqual(ToriiOfflineCashAPI.Endpoint.revocationBundle.path, "/v1/offline/revocations/bundle")
         XCTAssertEqual(ToriiOfflineCashAPI.Endpoint.telemetry.path, "/v1/offline/telemetry")
     }


### PR DESCRIPTION
## What
Migrate the IrohaSwift offline-note issuer client to the `/v1/offline/v2/*`
Torii routes (`keys/refill`, `notes/issue`, `notes/redeem`, `audit`).

This also hardens the Swift client against legacy canonical request auth leakage
by stripping `X-Iroha-*` canonical auth headers from issuer `defaultHeaders`; v2
issuer auth is carried in the JSON body. Focused regression tests now cover v2
route constants, no legacy fallback after v2 failure, and legacy header stripping.

## Why
The legacy `/v1/offline/{keys/refill,notes/issue,notes/redeem,audit}` routes now
return 404 (V1 removal is intentional); `ToriiOfflineCashAPI` still pointed at
them, so `ToriiOfflineNoteIssuerClient.prepareLoad` (and issue/redeem/audit)
failed with `httpStatus(404)` before any offline work could run. Move the four
issuer endpoints to their `/v1/offline/v2/*` equivalents.

Path-only change for route selection; request/response shapes are unchanged (the
canonical body-auth signing already matches the v2 handler). `readiness` already
had a v2 variant; `revocations`/`telemetry` are unused by the client and have no
route.

## Test plan
Built a localnet from current `optimizations`; the iOS cbdc app's full offline
P2P flow — load → pay → accept → owner-signed audit → on-chain commit, plus
redeem — passes end-to-end with this change (4 live tests green, 0 failures).

- `swift test --filter ToriiOfflineCashAPIModelsTests`
- `swift test --filter OfflineNoteTests/testToriiIssuerClient`
- `swift test --filter ToriiClientTests/testListIdentifierPoliciesRejectsNonExactMetadata`
- `swift test --filter OfflineNoteTests/testOfflineNoteTransactionBuildersProduceSignedEnvelopes --filter OfflineNoteTests/testOfflineNoteTransactionBuilderCoversOptionalNonceAndInputValidation`
- `swift test --skip-build --skip 'NativeBridgeLoaderTests/testManifestlessBridgeUsesPinnedFallbackHash'` (1298 tests, 104 skipped, 0 failures; skipped only the local generated `dist/NoritoBridge.xcframework` manifestless fallback hash check)
- `rg -n 'v1/offline/(keys/refill|notes/issue|notes/redeem|audit)' IrohaSwift/Sources IrohaSwift/README.md -S` (no matches)
