### PR TITLE
Fix offline instruction wrapper double-header encoding

### DIFF
--- a/crates/iroha_data_model/src/isi/offline.rs
+++ b/crates/iroha_data_model/src/isi/offline.rs
@@ -491,6 +491,57 @@ mod tests {
         assert_eq!(crate::isi::Instruction::dyn_encode(&*decoded), payload);
     }
 
+    fn kotlin_nested_audit_instruction_frame() -> Vec<u8> {
+        let audit = audit();
+        let (inner_payload, inner_flags) = norito::codec::encode_with_header_flags(&audit);
+        assert!(
+            inner_flags & norito::core::header_flags::COMPACT_LEN != 0,
+            "Kotlin encodeAudit uses COMPACT_LEN"
+        );
+        let inner_framed = norito::core::frame_bare_with_header_flags::<OfflineNoteAuditBundle>(
+            &inner_payload,
+            inner_flags,
+        )
+        .expect("frame inner audit bundle");
+        assert_eq!(&inner_framed[..4], b"NRT0");
+
+        let mut wrapper_payload = Vec::new();
+        norito::core::write_len_with_flags(&mut wrapper_payload, inner_framed.len() as u64, 0)
+            .expect("write fixed wrapper field length");
+        wrapper_payload.extend_from_slice(&inner_framed);
+
+        let framed =
+            norito::core::frame_bare_with_header_flags::<AuditOfflineNote>(&wrapper_payload, 0)
+                .expect("frame outer audit instruction");
+        assert_eq!(framed[norito::core::Header::SIZE - 1], 0);
+        framed
+    }
+
+    fn kotlin_bare_audit_instruction_frame() -> Vec<u8> {
+        let audit = audit();
+        let (bare_payload, flags) = {
+            let _guard =
+                norito::core::DecodeFlagsGuard::enter(norito::core::header_flags::COMPACT_LEN);
+            norito::codec::encode_with_header_flags(&audit)
+        };
+        assert_eq!(
+            flags,
+            norito::core::header_flags::COMPACT_LEN,
+            "fixed Kotlin instruction wrappers encode the model payload with wrapper flags"
+        );
+
+        let mut wrapper_payload = Vec::new();
+        norito::core::write_len_with_flags(&mut wrapper_payload, bare_payload.len() as u64, flags)
+            .expect("write wrapper field length");
+        wrapper_payload.extend_from_slice(&bare_payload);
+
+        let framed =
+            norito::core::frame_bare_with_header_flags::<AuditOfflineNote>(&wrapper_payload, flags)
+                .expect("frame outer audit instruction");
+        assert_eq!(framed[norito::core::Header::SIZE - 1], flags);
+        framed
+    }
+
     #[test]
     fn offline_note_decode_from_slice_roundtrips() {
         assert_slice_roundtrip(IssueOfflineNote::new(issue()));
@@ -511,5 +562,40 @@ mod tests {
         assert_registry_decodes(&registry, RedeemOfflineNote::new(redemption()));
         assert_registry_decodes(&registry, AuditOfflineNote::new(audit()));
         assert_registry_decodes(&registry, kagemusha_transfer());
+    }
+
+    #[test]
+    fn kotlin_nested_audit_instruction_reproduces_length_mismatch() {
+        let registry = crate::isi::InstructionRegistry::new().register_slice::<AuditOfflineNote>();
+        let framed = kotlin_nested_audit_instruction_frame();
+        let err = crate::isi::InstructionRegistry::decode(
+            &registry,
+            std::any::type_name::<AuditOfflineNote>(),
+            &framed,
+        )
+        .expect("registered")
+        .expect_err("Kotlin nested audit wrapper should not decode as a bare Rust bundle");
+
+        // Legacy Kotlin emitted a second Norito header inside the wrapper field.
+        assert!(matches!(err, norito::Error::LengthMismatch), "{err:?}");
+    }
+
+    #[test]
+    fn kotlin_bare_audit_instruction_decodes_as_rust_instruction() {
+        let registry = crate::isi::InstructionRegistry::new().register_slice::<AuditOfflineNote>();
+        let expected = AuditOfflineNote::new(audit());
+        let framed = kotlin_bare_audit_instruction_frame();
+        let decoded = crate::isi::InstructionRegistry::decode(
+            &registry,
+            std::any::type_name::<AuditOfflineNote>(),
+            &framed,
+        )
+        .expect("registered")
+        .expect("bare Kotlin wrapper decodes");
+
+        assert_eq!(
+            crate::isi::Instruction::dyn_encode(&*decoded),
+            expected.encode()
+        );
     }
 }

--- a/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/offline/OfflineNote.kt
+++ b/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/offline/OfflineNote.kt
@@ -208,7 +208,7 @@ object OfflineNote {
     fun issueInstruction(value: Issue): InstructionBox =
         InstructionBox.fromWirePayload(
             ISSUE_INSTRUCTION_SCHEMA,
-            encodeInstructionWrapper(ISSUE_INSTRUCTION_SCHEMA, encodeIssue(value)),
+            encodeInstructionWrapper(ISSUE_INSTRUCTION_SCHEMA, value, IssueAdapter),
         )
 
     @JvmStatic
@@ -216,7 +216,7 @@ object OfflineNote {
         value.validateProofBinding()
         return InstructionBox.fromWirePayload(
             REDEEM_INSTRUCTION_SCHEMA,
-            encodeInstructionWrapper(REDEEM_INSTRUCTION_SCHEMA, encodeRedeem(value)),
+            encodeInstructionWrapper(REDEEM_INSTRUCTION_SCHEMA, value, RedeemAdapter),
         )
     }
 
@@ -225,7 +225,7 @@ object OfflineNote {
         value.validateProofBinding()
         return InstructionBox.fromWirePayload(
             AUDIT_INSTRUCTION_SCHEMA,
-            encodeInstructionWrapper(AUDIT_INSTRUCTION_SCHEMA, encodeAudit(value)),
+            encodeInstructionWrapper(AUDIT_INSTRUCTION_SCHEMA, value, AuditAdapter),
         )
     }
 
@@ -261,8 +261,19 @@ object OfflineNote {
     private fun <T> decodeWithHeader(bytes: ByteArray, schema: String, adapter: TypeAdapter<T>): T =
         NoritoCodec.decode(bytes, adapter, schema)
 
-    private fun encodeInstructionWrapper(schema: String, modelPayload: ByteArray): ByteArray =
-        NoritoCodec.encode(modelPayload, schema, InstructionWrapperAdapter, 0)
+    private fun <T> encodeInstructionWrapper(
+        schema: String,
+        value: T,
+        adapter: TypeAdapter<T>,
+    ): ByteArray {
+        val modelPayload = NoritoCodec.encodeAdaptive(value, adapter, NoritoHeader.COMPACT_LEN)
+        return NoritoCodec.encode(
+            InstructionModelPayload(modelPayload.payload(), modelPayload.flags),
+            schema,
+            InstructionWrapperPayloadAdapter,
+            modelPayload.flags,
+        )
+    }
 
     private fun <T> decodeInstructionModel(
         bytes: ByteArray,
@@ -993,15 +1004,6 @@ object OfflineNote {
                 outputAmounts,
             )
         }
-    }
-
-    private object InstructionWrapperAdapter : TypeAdapter<ByteArray> {
-        override fun encode(encoder: NoritoEncoder, value: ByteArray) {
-            writeField(encoder) { it.writeBytes(value) }
-        }
-
-        override fun decode(decoder: NoritoDecoder): ByteArray =
-            readField(decoder) { it.readBytes(it.remaining()) }
     }
 
     private class InstructionModelPayload(

--- a/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/offline/OfflineNoteV2.kt
+++ b/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/offline/OfflineNoteV2.kt
@@ -119,7 +119,7 @@ object OfflineNoteV2 {
     fun issueInstruction(value: IssueV2): InstructionBox =
         InstructionBox.fromWirePayload(
             ISSUE_INSTRUCTION_SCHEMA,
-            encodeInstructionWrapper(ISSUE_INSTRUCTION_SCHEMA, encodeIssue(value)),
+            encodeInstructionWrapper(ISSUE_INSTRUCTION_SCHEMA, value, IssueAdapter),
         )
 
     @JvmStatic
@@ -127,7 +127,7 @@ object OfflineNoteV2 {
         value.validateProofBinding()
         return InstructionBox.fromWirePayload(
             REDEEM_INSTRUCTION_SCHEMA,
-            encodeInstructionWrapper(REDEEM_INSTRUCTION_SCHEMA, encodeRedeem(value)),
+            encodeInstructionWrapper(REDEEM_INSTRUCTION_SCHEMA, value, RedeemAdapter),
         )
     }
 
@@ -136,7 +136,7 @@ object OfflineNoteV2 {
         value.validateProofBinding()
         return InstructionBox.fromWirePayload(
             AUDIT_INSTRUCTION_SCHEMA,
-            encodeInstructionWrapper(AUDIT_INSTRUCTION_SCHEMA, encodeAudit(value)),
+            encodeInstructionWrapper(AUDIT_INSTRUCTION_SCHEMA, value, AuditAdapter),
         )
     }
 
@@ -230,8 +230,19 @@ object OfflineNoteV2 {
     private fun <T> decodeWithHeader(bytes: ByteArray, schema: String, adapter: TypeAdapter<T>): T =
         NoritoCodec.decode(bytes, adapter, schema)
 
-    private fun encodeInstructionWrapper(schema: String, modelPayload: ByteArray): ByteArray =
-        NoritoCodec.encode(modelPayload, schema, InstructionWrapperAdapter, 0)
+    private fun <T> encodeInstructionWrapper(
+        schema: String,
+        value: T,
+        adapter: TypeAdapter<T>,
+    ): ByteArray {
+        val modelPayload = NoritoCodec.encodeAdaptive(value, adapter, NoritoHeader.COMPACT_LEN)
+        return NoritoCodec.encode(
+            InstructionModelPayload(modelPayload.payload(), modelPayload.flags),
+            schema,
+            InstructionWrapperPayloadAdapter,
+            modelPayload.flags,
+        )
+    }
 
     private fun <T> decodeInstructionModel(
         bytes: ByteArray,
@@ -805,15 +816,6 @@ object OfflineNoteV2 {
                 outputAmounts,
             )
         }
-    }
-
-    private object InstructionWrapperAdapter : TypeAdapter<ByteArray> {
-        override fun encode(encoder: NoritoEncoder, value: ByteArray) {
-            writeField(encoder) { it.writeBytes(value) }
-        }
-
-        override fun decode(decoder: NoritoDecoder): ByteArray =
-            readField(decoder) { it.readBytes(it.remaining()) }
     }
 
     private class InstructionModelPayload(

--- a/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/offline/OfflineNoteTest.kt
+++ b/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/offline/OfflineNoteTest.kt
@@ -795,6 +795,18 @@ class OfflineNoteTest {
     }
 
     @Test
+    fun publicNoritoInstructionWrappersContainBareModelPayloads() {
+        val fixture = loadFixture()
+        val issue = issue(fixture)
+        val audit = audit(fixture)
+        val redeem = redeem(fixture)
+
+        assertBareInstructionWrapper(wirePayloadBytes(OfflineNote.issueInstruction(issue)))
+        assertBareInstructionWrapper(wirePayloadBytes(OfflineNote.auditInstruction(audit)))
+        assertBareInstructionWrapper(wirePayloadBytes(OfflineNote.redeemInstruction(redeem)))
+    }
+
+    @Test
     fun walletDerivationsMatchRustVectors() {
         val fixture = loadFixture()
         val chain = obj(fixture, "chain_vectors")
@@ -5097,6 +5109,23 @@ class OfflineNoteTest {
 
     private fun wirePayloadBytes(instruction: org.hyperledger.iroha.sdk.core.model.InstructionBox): ByteArray =
         (instruction.payload as WirePayload).payloadBytes
+
+    private fun assertBareInstructionWrapper(wirePayload: ByteArray) {
+        val decoded = NoritoHeader.decode(wirePayload, null)
+        assertEquals(NoritoHeader.COMPACT_LEN, decoded.header.flags)
+        val decoder = NoritoDecoder(decoded.payload, decoded.header.flags, decoded.header.minor)
+        val length = decoder.readLength((decoded.header.flags and NoritoHeader.COMPACT_LEN) != 0).toInt()
+        val modelPayload = decoder.readBytes(length)
+        assertEquals(0, decoder.remaining())
+        assertFalse(isNoritoFrame(modelPayload), "instruction wrapper must contain a bare model payload")
+    }
+
+    private fun isNoritoFrame(bytes: ByteArray): Boolean =
+        bytes.size >= NoritoHeader.HEADER_LENGTH &&
+            bytes[0] == 'N'.code.toByte() &&
+            bytes[1] == 'R'.code.toByte() &&
+            bytes[2] == 'T'.code.toByte() &&
+            bytes[3] == '0'.code.toByte()
 
     private fun rawInstructionPair(wireName: String, wirePayload: ByteArray, compact: Boolean = true): ByteArray {
         val out = ByteArrayOutputStream()

--- a/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/offline/OfflineNoteV2Test.kt
+++ b/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/offline/OfflineNoteV2Test.kt
@@ -936,14 +936,15 @@ class OfflineNoteV2Test {
         val payload = instruction.payload as? WirePayload
             ?: error("Offline Note V2 instruction must use a wire payload")
         assertEquals(schema, payload.wireName)
+        val outerFrame = NoritoHeader.decode(payload.payloadBytes, null)
         assertEquals(
-            base64(encodeInstructionWrapper(schema, modelPayload)),
-            base64(payload.payloadBytes),
+            NoritoHeader.COMPACT_LEN,
+            outerFrame.header.flags,
+            "instruction wrapper and bare model payload flags",
         )
-        assertEquals(
-            base64(modelPayload),
-            base64(decodeInstructionWrapper(schema, payload.payloadBytes)),
-        )
+        assertTrue(isNoritoFrame(modelPayload), "public model encoder still returns a framed archive")
+        val wrapperPayload = decodeInstructionWrapper(schema, payload.payloadBytes)
+        assertFalse(isNoritoFrame(wrapperPayload), "instruction wrapper must contain a bare model payload")
     }
 
     private fun wirePayloadBytes(instruction: InstructionBox): ByteArray =
@@ -1071,6 +1072,13 @@ class OfflineNoteV2Test {
 
         fun compact(decoder: NoritoDecoder): Boolean =
             (decoder.flags and NoritoHeader.COMPACT_LEN) != 0
+
+        fun isNoritoFrame(bytes: ByteArray): Boolean =
+            bytes.size >= NoritoHeader.HEADER_LENGTH &&
+                bytes[0] == 'N'.code.toByte() &&
+                bytes[1] == 'R'.code.toByte() &&
+                bytes[2] == 'T'.code.toByte() &&
+                bytes[3] == '0'.code.toByte()
     }
 
     private fun loadFixture(): Map<String, Any?> {


### PR DESCRIPTION
## Context

Offline note instructions (`AuditOfflineNote`, `RedeemOfflineNote`, `IssueOfflineNote`) submitted from the Kotlin SDK failed to decode on the Rust node with `LengthMismatch`. The Kotlin encoder was producing a double-wrapped Norito payload: `encodeAudit/Issue/Redeem` returned a fully-framed archive (with its own `NRT0` header), which was then placed as the body of a second outer wrapper frame. The Rust bare-AOS slice decoder (`impl_decode_one_offline_field!`) expects exactly one length-prefixed bare body in the wrapper field — the stray inner header made the consumed byte count disagree with the field length, causing the error.

A second latent issue: the outer wrapper was encoded with flags `0` (fixed-width lengths) while the inner audit body used `COMPACT_LEN`. Since Rust installs the wrapper's flags as the decode context before reading the inner field, the two sides disagreed on length-prefix encoding.

### Solution

`encodeInstructionWrapper` now takes the value and its adapter directly instead of a pre-encoded `ByteArray`. It encodes the model payload bare (no header, `COMPACT_LEN` flags) via `NoritoCodec.encodeAdaptive`, then propagates those flags to the outer wrapper header. The wrapper field therefore contains a plain AOS body, matching what `read_aos_field` on the Rust side expects, and the outer header flags agree with the inner field encoding.

`InstructionWrapperAdapter` (which treated the inner payload as an opaque `ByteArray`) is replaced by `InstructionWrapperPayloadAdapter`, which encodes a single length-prefixed field with the bare model bytes.

Two Rust tests are added to `offline.rs` to lock in the contract:
- `kotlin_nested_audit_instruction_reproduces_length_mismatch` — asserts the old double-header format fails with `LengthMismatch`.
- `kotlin_bare_audit_instruction_decodes_as_rust_instruction` — asserts the fixed format decodes correctly.

---

### Review notes

Start with `offline.rs` — the two new test helpers (`kotlin_nested_audit_instruction_frame`, `kotlin_bare_audit_instruction_frame`) precisely document the old and new wire layouts. Then read `OfflineNote.kt`:`encodeInstructionWrapper` and `InstructionWrapperPayloadAdapter` for the fix; `OfflineNoteV2.kt` is an identical change. The test additions in `OfflineNoteTest.kt` and `OfflineNoteV2Test.kt` add the `assertBareInstructionWrapper` contract check and update the V2 wrapper assertion to verify flags and bare-payload property rather than exact byte equality.