### PR TITLE
Add ISSUE_PENDING state to guard note spendability until issuance commits

### DIFF
--- a/IrohaSwift/README.md
+++ b/IrohaSwift/README.md
@@ -663,7 +663,11 @@ wallet flows.
 `OfflineNoteWallet` remains available for historical model and fixture
 compatibility, but its default issuer and transaction submitter surfaces fail
 closed for classic note issue, audit, redeem, and defund paths. Production
-offline payments use Kagemusha flows.
+offline payments use Kagemusha flows. When an injected compatibility issuer
+path is used, `load` records issued notes as `.issuePending` until `sync()`
+observes matching `IssueOfflineNote` finality; rejected issue outcomes cancel
+the pending note.
+
 `KagemushaCompactPaymentTokenProver` exposes the native record-backed compact
 token prover for shielded offline-offline payments. Pass a Norito-encoded
 `KagemushaVerifiedFoldRecordBundle`; the bridge verifies each private hop proof

--- a/IrohaSwift/Sources/IrohaSwift/OfflineNoteWallet.swift
+++ b/IrohaSwift/Sources/IrohaSwift/OfflineNoteWallet.swift
@@ -6,6 +6,7 @@ import Security
 
 public enum OfflineNoteWalletNoteState: String, Sendable {
     case spendable
+    case issuePending
     case receivePending
     case spent
     case redeemPending
@@ -1279,10 +1280,26 @@ public final class OfflineNoteOutcomeIndex: @unchecked Sendable {
         let transactionHashHex: String?
     }
 
+    private var committedIssues: [String: OutcomeHit] = [:]
+    private var rejectedIssues: [String: OutcomeHit] = [:]
     private var committedRedeems: [String: OutcomeHit] = [:]
     private var rejectedRedeems: [String: OutcomeHit] = [:]
 
     public init() {}
+
+    @discardableResult
+    public func recordCommittedIssue(_ issue: OfflineNoteIssue,
+                                     transactionHashHex: String? = nil) -> OfflineNoteOutcomeIndex {
+        putFirst(&committedIssues, key: issue.noteCommitment, value: transactionHashHex)
+        return self
+    }
+
+    @discardableResult
+    public func recordRejectedIssue(_ issue: OfflineNoteIssue,
+                                    transactionHashHex: String? = nil) -> OfflineNoteOutcomeIndex {
+        putFirst(&rejectedIssues, key: issue.noteCommitment, value: transactionHashHex)
+        return self
+    }
 
     @discardableResult
     public func recordCommittedAudit(_ audit: OfflineNoteAuditBundle,
@@ -1312,11 +1329,24 @@ public final class OfflineNoteOutcomeIndex: @unchecked Sendable {
 
     public func resolve(_ note: OfflineNoteWalletNote) throws -> OfflineNoteSyncResolution? {
         switch note.state {
+        case .issuePending:
+            return resolveIssuePending(note)
         case .redeemPending:
             return resolveRedeemPending(note)
         default:
             return nil
         }
+    }
+
+    private func resolveIssuePending(_ note: OfflineNoteWalletNote) -> OfflineNoteSyncResolution? {
+        let commitmentKey = note.noteCommitmentHex
+        if let hit = committedIssues[commitmentKey] {
+            return OfflineNoteSyncResolution(state: .spendable, transactionHashHex: hit.transactionHashHex)
+        }
+        if let hit = rejectedIssues[commitmentKey] {
+            return OfflineNoteSyncResolution(state: .cancelled, transactionHashHex: hit.transactionHashHex)
+        }
+        return nil
     }
 
     private func resolveRedeemPending(_ note: OfflineNoteWalletNote) -> OfflineNoteSyncResolution? {
@@ -1344,7 +1374,14 @@ public final class OfflineNoteOutcomeIndex: @unchecked Sendable {
             let committed = status == "committed"
             let rejected = status == "rejected"
             guard committed || rejected else { continue }
-            if outcome.kind.caseInsensitiveCompare(kindAudit) == .orderedSame {
+            if outcome.kind.caseInsensitiveCompare(kindIssue) == .orderedSame {
+                let issue = try OfflineNoteDecoding.decodeIssueInstruction(outcome.encodedInstruction)
+                if committed {
+                    index.recordCommittedIssue(issue, transactionHashHex: outcome.transactionHashHex)
+                } else {
+                    index.recordRejectedIssue(issue, transactionHashHex: outcome.transactionHashHex)
+                }
+            } else if outcome.kind.caseInsensitiveCompare(kindAudit) == .orderedSame {
                 let audit = try OfflineNoteDecoding.decodeAuditInstruction(outcome.encodedInstruction)
                 if committed {
                     index.recordCommittedAudit(audit, transactionHashHex: outcome.transactionHashHex)
@@ -1389,9 +1426,10 @@ public final class ToriiOfflineNoteOutcomeProvider: OfflineNoteOutcomeProvider {
     }
 
     public func listOutcomes() async throws -> [OfflineNoteExplorerInstructionOutcome] {
+        let issue = try await fetch(kind: OfflineNoteOutcomeIndex.kindIssue)
         let audit = try await fetch(kind: OfflineNoteOutcomeIndex.kindAudit)
         let redeem = try await fetch(kind: OfflineNoteOutcomeIndex.kindRedeem)
-        return audit + redeem
+        return issue + audit + redeem
     }
 
     private func fetch(kind: String) async throws -> [OfflineNoteExplorerInstructionOutcome] {
@@ -1628,7 +1666,7 @@ public final class OfflineNoteWallet {
             noteCommitment: commitment,
             noteSecret: noteSecret,
             origin: origin,
-            state: .spendable,
+            state: .issuePending,
             createdAtMs: now,
             updatedAtMs: now
         )
@@ -2245,7 +2283,7 @@ private func draftPlaceholderProof(publicInputsHash: Data) throws -> OfflineNote
 private extension OfflineNoteWalletNoteState {
     var isPending: Bool {
         switch self {
-        case .redeemPending:
+        case .issuePending, .redeemPending:
             return true
         case .receivePending, .spendable, .spent, .redeemed, .cancelled:
             return false

--- a/IrohaSwift/Tests/IrohaSwiftTests/OfflineNoteTests.swift
+++ b/IrohaSwift/Tests/IrohaSwiftTests/OfflineNoteTests.swift
@@ -3788,7 +3788,7 @@ final class OfflineNoteTests: XCTestCase {
 
         XCTAssertEqual(note.noteCommitmentHex, derivation.sourceNoteCommitment)
         XCTAssertEqual(issuerClient.lastIssueRequest?.noteCommitment.hexLowercased(), derivation.sourceNoteCommitment)
-        XCTAssertEqual(note.state, .spendable)
+        XCTAssertEqual(note.state, .issuePending)
     }
 
     /// Regression: `Wallet.load(assetDefinitionId:)` must forward the
@@ -5296,7 +5296,12 @@ final class OfflineNoteTests: XCTestCase {
         let derivation = fixture.chainVectors.derivation
         let recipientCertificate = try Self.certificate(fixture.paymentToken.recipientKeyCertificate)
         let audit = try Self.audit(fixture)
+        let issue = try Self.issue(fixture)
         let redeem = try Self.redeem(fixture)
+        let issuePending = try Self.sourceWalletNote(
+            fixture,
+            certificate: Self.certificate(fixture.paymentToken.senderKeyCertificate)
+        ).withState(.issuePending, updatedAtMs: 1_700_000_003_000)
         let redeemPending = try OfflineNoteWalletNote(
             chainId: derivation.chainId,
             accountId: fixture.paymentToken.recipientAccountId,
@@ -5316,6 +5321,12 @@ final class OfflineNoteTests: XCTestCase {
 
         let committed = try OfflineNoteOutcomeIndex.fromExplorerOutcomes([
             OfflineNoteExplorerInstructionOutcome(
+                kind: OfflineNoteOutcomeIndex.kindIssue,
+                transactionStatus: "Committed",
+                transactionHashHex: "issue-tx",
+                encodedInstruction: try Self.issueInstructionEnvelope(issue)
+            ),
+            OfflineNoteExplorerInstructionOutcome(
                 kind: OfflineNoteOutcomeIndex.kindAudit,
                 transactionStatus: "Committed",
                 transactionHashHex: "audit-tx",
@@ -5329,15 +5340,24 @@ final class OfflineNoteTests: XCTestCase {
             ),
         ])
 
+        XCTAssertEqual(try committed.resolve(issuePending), OfflineNoteSyncResolution(
+            state: .spendable,
+            transactionHashHex: "issue-tx"
+        ))
         XCTAssertEqual(try committed.resolve(redeemPending), OfflineNoteSyncResolution(
             state: .redeemed,
             transactionHashHex: "redeem-tx"
         ))
 
         let rejected = OfflineNoteOutcomeIndex()
+            .recordRejectedIssue(issue, transactionHashHex: "issue-rejected")
             .recordRejectedAudit(audit, transactionHashHex: "audit-rejected")
             .recordRejectedRedeem(redeem, transactionHashHex: "redeem-rejected")
 
+        XCTAssertEqual(try rejected.resolve(issuePending), OfflineNoteSyncResolution(
+            state: .cancelled,
+            transactionHashHex: "issue-rejected"
+        ))
         XCTAssertEqual(try rejected.resolve(redeemPending), OfflineNoteSyncResolution(
             state: .spendable,
             transactionHashHex: "redeem-rejected"

--- a/java/iroha_android/README.md
+++ b/java/iroha_android/README.md
@@ -1395,8 +1395,10 @@ instead of ignoring smuggled JSON.
 on every committed wallet-state revision and rejects app-data rollback or
 cloned preference snapshots after the old revision key has been deleted. Legacy
 `SPEND_PENDING` records decode as `SPENT`, and legacy `CHANGE_PENDING` records
-decode as `SPENDABLE`.
-the core module includes an in-memory store and `ToriiOfflineNoteIssuerClient`
+decode as `SPENDABLE`. Wallet `load` records newly issued local notes as
+`ISSUE_PENDING` until sync observes the matching `IssueOfflineNote` commit;
+rejected issue outcomes cancel the pending note. The core module includes an
+in-memory store and `ToriiOfflineNoteIssuerClient`
 for body-signed key-refill in tests and JVM tooling. Legacy note issue and
 `IrohaOfflineNoteTransactionSubmitter` audit/redeem/defund submissions remain
 for source compatibility, but fail closed; production offline payments use

--- a/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/OfflineNoteOutcomeIndex.java
+++ b/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/OfflineNoteOutcomeIndex.java
@@ -11,8 +11,22 @@ public final class OfflineNoteOutcomeIndex {
   public static final String KIND_REDEEM = "RedeemOfflineNote";
   public static final String KIND_AUDIT = "AuditOfflineNote";
 
+  private final Map<String, String> committedIssues = new LinkedHashMap<>();
+  private final Map<String, String> rejectedIssues = new LinkedHashMap<>();
   private final Map<String, String> committedRedeems = new LinkedHashMap<>();
   private final Map<String, String> rejectedRedeems = new LinkedHashMap<>();
+
+  public OfflineNoteOutcomeIndex recordCommittedIssue(
+      final OfflineNote.Issue issue, final String transactionHashHex) {
+    putFirst(committedIssues, issue.noteCommitment(), transactionHashHex);
+    return this;
+  }
+
+  public OfflineNoteOutcomeIndex recordRejectedIssue(
+      final OfflineNote.Issue issue, final String transactionHashHex) {
+    putFirst(rejectedIssues, issue.noteCommitment(), transactionHashHex);
+    return this;
+  }
 
   public OfflineNoteOutcomeIndex recordCommittedAudit(
       final OfflineNote.AuditBundle audit, final String transactionHashHex) {
@@ -38,9 +52,23 @@ public final class OfflineNoteOutcomeIndex {
 
   public OfflineNoteSyncResolution resolve(final OfflineNoteWalletNote note) {
     return switch (note.state()) {
+      case ISSUE_PENDING -> resolveIssuePending(note);
       case REDEEM_PENDING -> resolveRedeemPending(note);
       default -> null;
     };
+  }
+
+  private OfflineNoteSyncResolution resolveIssuePending(final OfflineNoteWalletNote note) {
+    final String commitmentKey = note.noteCommitmentHex();
+    if (committedIssues.containsKey(commitmentKey)) {
+      return new OfflineNoteSyncResolution(
+          OfflineNoteWalletNoteState.SPENDABLE, committedIssues.get(commitmentKey));
+    }
+    if (rejectedIssues.containsKey(commitmentKey)) {
+      return new OfflineNoteSyncResolution(
+          OfflineNoteWalletNoteState.CANCELLED, rejectedIssues.get(commitmentKey));
+    }
+    return null;
   }
 
   private OfflineNoteSyncResolution resolveRedeemPending(final OfflineNoteWalletNote note) {
@@ -74,7 +102,15 @@ public final class OfflineNoteOutcomeIndex {
       if (!committed && !rejected) {
         continue;
       }
-      if (KIND_AUDIT.equalsIgnoreCase(outcome.kind())) {
+      if (KIND_ISSUE.equalsIgnoreCase(outcome.kind())) {
+        final OfflineNote.Issue issue =
+            OfflineNote.decodeIssueInstruction(outcome.encodedInstruction());
+        if (committed) {
+          index.recordCommittedIssue(issue, outcome.transactionHashHex());
+        } else {
+          index.recordRejectedIssue(issue, outcome.transactionHashHex());
+        }
+      } else if (KIND_AUDIT.equalsIgnoreCase(outcome.kind())) {
         final OfflineNote.AuditBundle audit =
             OfflineNote.decodeAuditInstruction(outcome.encodedInstruction());
         if (committed) {

--- a/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/OfflineNoteWallet.java
+++ b/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/OfflineNoteWallet.java
@@ -503,7 +503,7 @@ public final class OfflineNoteWallet {
                                                   noteCommitment,
                                                   noteSecret,
                                                   origin,
-                                                  OfflineNoteWalletNoteState.SPENDABLE,
+                                                  OfflineNoteWalletNoteState.ISSUE_PENDING,
                                                   now,
                                                   now);
                                           store.upsert(note);
@@ -1161,7 +1161,8 @@ public final class OfflineNoteWallet {
   }
 
   private static boolean isPendingState(final OfflineNoteWalletNoteState state) {
-    return state == OfflineNoteWalletNoteState.REDEEM_PENDING;
+    return state == OfflineNoteWalletNoteState.ISSUE_PENDING
+        || state == OfflineNoteWalletNoteState.REDEEM_PENDING;
   }
 
   private static String walletAssetId(final String assetDefinitionId, final String accountId) {

--- a/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/OfflineNoteWalletNoteState.java
+++ b/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/OfflineNoteWalletNoteState.java
@@ -3,6 +3,7 @@ package org.hyperledger.iroha.android.offline;
 /** State persisted for a wallet-owned Offline Note note. */
 public enum OfflineNoteWalletNoteState {
   SPENDABLE,
+  ISSUE_PENDING,
   RECEIVE_PENDING,
   SPENT,
   REDEEM_PENDING,

--- a/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/ToriiOfflineNoteOutcomeProvider.java
+++ b/java/iroha_android/src/main/java/org/hyperledger/iroha/android/offline/ToriiOfflineNoteOutcomeProvider.java
@@ -59,14 +59,17 @@ public final class ToriiOfflineNoteOutcomeProvider implements OfflineNoteOutcome
 
   @Override
   public CompletableFuture<List<OfflineNoteExplorerInstructionOutcome>> listOutcomes() {
+    final CompletableFuture<List<OfflineNoteExplorerInstructionOutcome>> issue =
+        fetchKind(OfflineNoteOutcomeIndex.KIND_ISSUE);
     final CompletableFuture<List<OfflineNoteExplorerInstructionOutcome>> audit =
         fetchKind(OfflineNoteOutcomeIndex.KIND_AUDIT);
     final CompletableFuture<List<OfflineNoteExplorerInstructionOutcome>> redeem =
         fetchKind(OfflineNoteOutcomeIndex.KIND_REDEEM);
-    return CompletableFuture.allOf(audit, redeem)
+    return CompletableFuture.allOf(issue, audit, redeem)
         .thenApply(
             ignored -> {
               final List<OfflineNoteExplorerInstructionOutcome> outcomes = new ArrayList<>();
+              outcomes.addAll(issue.join());
               outcomes.addAll(audit.join());
               outcomes.addAll(redeem.join());
               return outcomes;

--- a/java/iroha_android/src/test/java/org/hyperledger/iroha/android/offline/OfflineNoteTest.java
+++ b/java/iroha_android/src/test/java/org/hyperledger/iroha/android/offline/OfflineNoteTest.java
@@ -3173,7 +3173,7 @@ public final class OfflineNoteTest {
         issuerClient.lastIssueRequest.noteCommitmentHex(),
         "issuer request note commitment");
     assertEquals(
-        OfflineNoteWalletNoteState.SPENDABLE.name(),
+        OfflineNoteWalletNoteState.ISSUE_PENDING.name(),
         note.state().name(),
         "loaded note state");
   }
@@ -4511,9 +4511,13 @@ public final class OfflineNoteTest {
     final Map<String, Object> redeemVector = obj(chain, "redeem");
     final Map<String, Object> payment = obj(fixture, "payment_token");
     final OfflineNote.AuditBundle audit = audit(fixture);
+    final OfflineNote.Issue issue = issue(fixture);
     final OfflineNote.Redeem redeem = redeem(fixture);
     final OfflineNote.KeyCertificate recipientCertificate =
         certificate(obj(payment, "recipient_key_certificate"));
+    final OfflineNoteWalletNote issuePending =
+        sourceWalletNote(fixture, certificate(obj(payment, "sender_key_certificate")))
+            .withState(OfflineNoteWalletNoteState.ISSUE_PENDING, 1_700_000_003_000L);
     final OfflineNoteWalletNote redeemPending =
         new OfflineNoteWalletNote(
             string(derivation, "chain_id"),
@@ -4533,6 +4537,13 @@ public final class OfflineNoteTest {
         OfflineNoteOutcomeIndex.fromExplorerOutcomes(
             List.of(
                 new OfflineNoteExplorerInstructionOutcome(
+                    OfflineNoteOutcomeIndex.KIND_ISSUE,
+                    "Committed",
+                    "issue-tx",
+                    rawInstructionPair(
+                        OfflineNote.ISSUE_INSTRUCTION_SCHEMA,
+                        wirePayloadBytes(OfflineNote.issueInstruction(issue)))),
+                new OfflineNoteExplorerInstructionOutcome(
                     OfflineNoteOutcomeIndex.KIND_AUDIT,
                     "Committed",
                     "audit-tx",
@@ -4546,6 +4557,10 @@ public final class OfflineNoteTest {
                     rawInstructionPair(
                         OfflineNote.REDEEM_INSTRUCTION_SCHEMA,
                         wirePayloadBytes(OfflineNote.redeemInstruction(redeem))))));
+    assertEquals(
+        OfflineNoteWalletNoteState.SPENDABLE.name(),
+        committed.resolve(issuePending).state().name(),
+        "committed issue");
     assertTrue(
         committed.resolve(sourceWalletNote(fixture, certificate(obj(payment, "sender_key_certificate"))))
             == null,
@@ -4557,8 +4572,13 @@ public final class OfflineNoteTest {
 
     final OfflineNoteOutcomeIndex rejected =
         new OfflineNoteOutcomeIndex()
+            .recordRejectedIssue(issue, "issue-rejected")
             .recordRejectedAudit(audit, "audit-rejected")
             .recordRejectedRedeem(redeem, "redeem-rejected");
+    assertEquals(
+        OfflineNoteWalletNoteState.CANCELLED.name(),
+        rejected.resolve(issuePending).state().name(),
+        "rejected issue");
     assertEquals(
         OfflineNoteWalletNoteState.SPENDABLE.name(),
         rejected.resolve(redeemPending).state().name(),

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -264,8 +264,10 @@ for diagnostics and cross-language parity: `STATUS_ERROR`,
 `production_disabled = 4`, and `invalid_request = 5`; treat them as
 sanitized status metadata, not proof success.
 
-Legacy `SPEND_PENDING` records are migrated to `SPENT`, and legacy
-`CHANGE_PENDING` records are migrated to `SPENDABLE`.
+Wallet `load` persists newly issued local notes as `ISSUE_PENDING` until sync
+observes the matching `IssueOfflineNote` transaction commit; rejected issue
+outcomes cancel the pending note. Legacy `SPEND_PENDING` records are migrated
+to `SPENT`, and legacy `CHANGE_PENDING` records are migrated to `SPENDABLE`.
 `OfflineNoteTransferHandoff` exposes one integration surface for local token
 handoff modalities: `qrStreamingFrameBytes(token)` for animated/binary QR,
 `nfcFrameBytes(token)` for APDU-sized NFC frame exchange, and

--- a/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/offline/OfflineNoteWallet.kt
+++ b/kotlin/core-jvm/src/main/java/org/hyperledger/iroha/sdk/offline/OfflineNoteWallet.kt
@@ -40,6 +40,7 @@ import org.hyperledger.iroha.sdk.tx.norito.NoritoJavaCodecAdapter
 /** State persisted for a wallet-owned Offline Note note. */
 enum class OfflineNoteWalletNoteState {
     SPENDABLE,
+    ISSUE_PENDING,
     RECEIVE_PENDING,
     SPENT,
     REDEEM_PENDING,
@@ -933,8 +934,20 @@ interface OfflineNoteOutcomeProvider {
 
 /** Outcome index that maps committed/rejected Offline Note instructions to note states. */
 class OfflineNoteOutcomeIndex {
+    private val committedIssues = LinkedHashMap<String, String?>()
+    private val rejectedIssues = LinkedHashMap<String, String?>()
     private val committedRedeems = LinkedHashMap<String, String?>()
     private val rejectedRedeems = LinkedHashMap<String, String?>()
+
+    fun recordCommittedIssue(issue: OfflineNote.Issue, transactionHashHex: String?): OfflineNoteOutcomeIndex {
+        putFirst(committedIssues, issue.noteCommitment(), transactionHashHex)
+        return this
+    }
+
+    fun recordRejectedIssue(issue: OfflineNote.Issue, transactionHashHex: String?): OfflineNoteOutcomeIndex {
+        putFirst(rejectedIssues, issue.noteCommitment(), transactionHashHex)
+        return this
+    }
 
     fun recordCommittedAudit(audit: OfflineNote.AuditBundle, transactionHashHex: String?): OfflineNoteOutcomeIndex {
         return this
@@ -956,9 +969,21 @@ class OfflineNoteOutcomeIndex {
 
     fun resolve(note: OfflineNoteWalletNote): OfflineNoteSyncResolution? =
         when (note.state) {
+            OfflineNoteWalletNoteState.ISSUE_PENDING -> resolveIssuePending(note)
             OfflineNoteWalletNoteState.REDEEM_PENDING -> resolveRedeemPending(note)
             else -> null
         }
+
+    private fun resolveIssuePending(note: OfflineNoteWalletNote): OfflineNoteSyncResolution? {
+        val key = note.noteCommitmentHex()
+        return when {
+            committedIssues.containsKey(key) ->
+                OfflineNoteSyncResolution(OfflineNoteWalletNoteState.SPENDABLE, committedIssues[key])
+            rejectedIssues.containsKey(key) ->
+                OfflineNoteSyncResolution(OfflineNoteWalletNoteState.CANCELLED, rejectedIssues[key])
+            else -> null
+        }
+    }
 
     private fun resolveRedeemPending(note: OfflineNoteWalletNote): OfflineNoteSyncResolution? {
         val commitmentKey = note.noteCommitmentHex()
@@ -997,6 +1022,14 @@ class OfflineNoteOutcomeIndex {
                 val rejected = outcome.transactionStatus.equals("rejected", ignoreCase = true)
                 if (!committed && !rejected) continue
                 when {
+                    outcome.kind.equals(KIND_ISSUE, ignoreCase = true) -> {
+                        val issue = OfflineNote.decodeIssueInstruction(outcome.encodedInstruction())
+                        if (committed) {
+                            index.recordCommittedIssue(issue, outcome.transactionHashHex)
+                        } else {
+                            index.recordRejectedIssue(issue, outcome.transactionHashHex)
+                        }
+                    }
                     outcome.kind.equals(KIND_AUDIT, ignoreCase = true) -> {
                         val audit = OfflineNote.decodeAuditInstruction(outcome.encodedInstruction())
                         if (committed) {
@@ -1043,10 +1076,11 @@ class ToriiOfflineNoteOutcomeProvider @JvmOverloads constructor(
     private val observers: List<ClientObserver> = observers.toList()
 
     override fun listOutcomes(): CompletableFuture<List<OfflineNoteExplorerInstructionOutcome>> {
+        val issue = fetchKind(OfflineNoteOutcomeIndex.KIND_ISSUE)
         val audit = fetchKind(OfflineNoteOutcomeIndex.KIND_AUDIT)
         val redeem = fetchKind(OfflineNoteOutcomeIndex.KIND_REDEEM)
-        return CompletableFuture.allOf(audit, redeem).thenApply {
-            audit.join() + redeem.join()
+        return CompletableFuture.allOf(issue, audit, redeem).thenApply {
+            issue.join() + audit.join() + redeem.join()
         }
     }
 
@@ -1443,7 +1477,7 @@ class OfflineNoteWallet @JvmOverloads constructor(
                                     noteCommitment = noteCommitment,
                                     noteSecret = noteSecret,
                                     origin = origin,
-                                    state = OfflineNoteWalletNoteState.SPENDABLE,
+                                    state = OfflineNoteWalletNoteState.ISSUE_PENDING,
                                     createdAtMs = now,
                                     updatedAtMs = now,
                                 )
@@ -2049,6 +2083,7 @@ private fun ensureSuccess(response: ClientResponse) {
 }
 
 private fun isPendingState(state: OfflineNoteWalletNoteState): Boolean = when (state) {
+    OfflineNoteWalletNoteState.ISSUE_PENDING,
     OfflineNoteWalletNoteState.REDEEM_PENDING -> true
     OfflineNoteWalletNoteState.RECEIVE_PENDING,
     OfflineNoteWalletNoteState.SPENDABLE,

--- a/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/offline/OfflineNoteTest.kt
+++ b/kotlin/core-jvm/src/test/kotlin/org/hyperledger/iroha/sdk/offline/OfflineNoteTest.kt
@@ -2764,7 +2764,7 @@ class OfflineNoteTest {
             string(derivation, "source_note_commitment"),
             issuerClient.lastIssueRequest?.noteCommitmentHex(),
         )
-        assertEquals(OfflineNoteWalletNoteState.SPENDABLE, note.state)
+        assertEquals(OfflineNoteWalletNoteState.ISSUE_PENDING, note.state)
     }
 
     @Test
@@ -3587,6 +3587,277 @@ class OfflineNoteTest {
 
         submitter.completeAccepted()
         assertEquals(OfflineNoteWalletNoteState.REDEEM_PENDING, redeeming.get(1, TimeUnit.SECONDS).state)
+    }
+
+    @Test
+    fun walletLoadStoresIssuePending() {
+        val fixture = loadFixture()
+        val chain = obj(fixture, "chain_vectors")
+        val derivation = obj(chain, "derivation")
+        val issue = obj(chain, "issue")
+        val senderCertificate = certificate(obj(obj(fixture, "payment_token"), "sender_key_certificate"))
+        val loadContext = OfflineNoteLoadContext(
+            operationId = string(derivation, "issuer_load_operation_id"),
+            lineageId = string(derivation, "issuer_load_lineage_id"),
+            localRevision = long(derivation, "issuer_load_local_revision"),
+            keyCertificate = senderCertificate,
+        )
+        val store = InMemoryOfflineNoteStore()
+        val wallet = OfflineNoteWallet(
+            chainId = string(derivation, "chain_id"),
+            accountId = accountFromAssetId(string(issue, "asset_id")),
+            attestationProvider = StaticAttestationProvider(senderCertificate),
+            ownerCertificateSigner = TestOwnerCertificateSigner(),
+            issuerClient = RecordingIssuerClient(loadContext),
+            store = store,
+            transactionSubmitter = RecordingTransactionSubmitter(),
+            proofProvider = BindingProofProvider,
+            proofVerifier = BindingProofVerifier,
+            certificateVerifier = certificateVerifier(fixture),
+            randomSource = QueueRandomSource(listOf(hexBytes(string(derivation, "source_note_secret_hex")))),
+            idGenerator = FixedIdGenerator(string(derivation, "payment_request_id")),
+            clock = { 1_700_000_001_000L },
+        )
+
+        val note = wallet.load(assetDefinitionFromAssetId(string(issue, "asset_id")), string(issue, "amount")).get()
+
+        assertEquals(OfflineNoteWalletNoteState.ISSUE_PENDING, note.state)
+        assertEquals(OfflineNoteWalletNoteState.ISSUE_PENDING, store.findNote(note.noteCommitment())?.state)
+    }
+
+    @Test
+    fun issuePendingNoteCannotBePaid() {
+        val fixture = loadFixture()
+        val chain = obj(fixture, "chain_vectors")
+        val derivation = obj(chain, "derivation")
+        val chainIssue = obj(chain, "issue")
+        val chainRedeem = obj(chain, "redeem")
+        val chainId = string(derivation, "chain_id")
+        val assetDefinitionId = assetDefinitionFromAssetId(string(chainIssue, "asset_id"))
+        val testIssuer = TestIssuerCertificateSigner()
+        val verifier = Ed25519OfflineNoteCertificateVerifier(listOf(testIssuer.publicKey))
+        val senderSigner = TestOwnerCertificateSigner()
+        val recipientSigner = TestOwnerCertificateSigner()
+        val senderStore = InMemoryOfflineNoteStore()
+        val pendingNote = issuerSourceWalletNote(
+            chainId = chainId,
+            accountId = senderSigner.accountId,
+            assetDefinitionId = assetDefinitionId,
+            amount = string(chainIssue, "amount"),
+            issuerCertificate = testIssuer.issuerCertificate(senderSigner.accountId),
+            noteSecret = ByteArray(32) { 0x11.toByte() },
+            operationSuffix = "issue-pending-pay",
+            createdAtMs = 1_700_000_000_000L,
+        ).withState(OfflineNoteWalletNoteState.ISSUE_PENDING, 1_700_000_000_000L)
+        senderStore.upsert(pendingNote)
+        val senderWallet = OfflineNoteWallet(
+            chainId = chainId,
+            accountId = senderSigner.accountId,
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(senderSigner.accountId)),
+            ownerCertificateSigner = senderSigner,
+            store = senderStore,
+            transactionSubmitter = RecordingTransactionSubmitter(),
+            proofProvider = BindingProofProvider,
+            proofVerifier = BindingProofVerifier,
+            certificateVerifier = verifier,
+            randomSource = QueueRandomSource(emptyList()),
+            clock = { 1_700_000_002_000L },
+        )
+        val recipientSigner2 = TestOwnerCertificateSigner()
+        val recipientWallet = OfflineNoteWallet(
+            chainId = chainId,
+            accountId = recipientSigner2.accountId,
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(recipientSigner2.accountId)),
+            ownerCertificateSigner = recipientSigner2,
+            transactionSubmitter = RecordingTransactionSubmitter(),
+            proofProvider = BindingProofProvider,
+            proofVerifier = BindingProofVerifier,
+            certificateVerifier = verifier,
+            randomSource = QueueRandomSource(listOf(ByteArray(32) { 0x37.toByte() })),
+            idGenerator = FixedIdGenerator(string(derivation, "payment_request_id")),
+            clock = { 1_700_000_002_100L },
+        )
+        val receiveRequest = recipientWallet.prepareReceive(
+            assetDefinitionId = assetDefinitionId,
+            amount = string(chainRedeem, "amount"),
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            senderWallet.pay(receiveRequest)
+        }
+    }
+
+    @Test
+    fun issuePendingNoteCannotBeRedeemed() {
+        val fixture = loadFixture()
+        val chain = obj(fixture, "chain_vectors")
+        val derivation = obj(chain, "derivation")
+        val chainIssue = obj(chain, "issue")
+        val chainId = string(derivation, "chain_id")
+        val assetDefinitionId = assetDefinitionFromAssetId(string(chainIssue, "asset_id"))
+        val testIssuer = TestIssuerCertificateSigner()
+        val verifier = Ed25519OfflineNoteCertificateVerifier(listOf(testIssuer.publicKey))
+        val senderSigner = TestOwnerCertificateSigner()
+        val store = InMemoryOfflineNoteStore()
+        val pendingNote = issuerSourceWalletNote(
+            chainId = chainId,
+            accountId = senderSigner.accountId,
+            assetDefinitionId = assetDefinitionId,
+            amount = string(chainIssue, "amount"),
+            issuerCertificate = testIssuer.issuerCertificate(senderSigner.accountId),
+            noteSecret = ByteArray(32) { 0x12.toByte() },
+            operationSuffix = "issue-pending-redeem",
+            createdAtMs = 1_700_000_000_000L,
+        ).withState(OfflineNoteWalletNoteState.ISSUE_PENDING, 1_700_000_000_000L)
+        store.upsert(pendingNote)
+        val wallet = OfflineNoteWallet(
+            chainId = chainId,
+            accountId = senderSigner.accountId,
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(senderSigner.accountId)),
+            ownerCertificateSigner = senderSigner,
+            store = store,
+            transactionSubmitter = RecordingTransactionSubmitter(),
+            proofProvider = BindingProofProvider,
+            proofVerifier = BindingProofVerifier,
+            certificateVerifier = verifier,
+            randomSource = QueueRandomSource(emptyList()),
+            clock = { 1_700_000_002_000L },
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            wallet.redeem(pendingNote).get()
+        }
+    }
+
+    @Test
+    fun syncPromotesCommittedIssuePendingToSpendable() {
+        val fixture = loadFixture()
+        val chain = obj(fixture, "chain_vectors")
+        val derivation = obj(chain, "derivation")
+        val chainIssue = obj(chain, "issue")
+        val chainId = string(derivation, "chain_id")
+        val assetDefinitionId = assetDefinitionFromAssetId(string(chainIssue, "asset_id"))
+        val testIssuer = TestIssuerCertificateSigner()
+        val verifier = Ed25519OfflineNoteCertificateVerifier(listOf(testIssuer.publicKey))
+        val senderSigner = TestOwnerCertificateSigner()
+        val store = InMemoryOfflineNoteStore()
+        val pendingNote = issuerSourceWalletNote(
+            chainId = chainId,
+            accountId = senderSigner.accountId,
+            assetDefinitionId = assetDefinitionId,
+            amount = string(chainIssue, "amount"),
+            issuerCertificate = testIssuer.issuerCertificate(senderSigner.accountId),
+            noteSecret = ByteArray(32) { 0x13.toByte() },
+            operationSuffix = "issue-pending-committed",
+            createdAtMs = 1_700_000_000_000L,
+        ).withState(OfflineNoteWalletNoteState.ISSUE_PENDING, 1_700_000_000_000L)
+        store.upsert(pendingNote)
+        val resolutions = linkedMapOf(pendingNote.noteCommitmentHex() to OfflineNoteWalletNoteState.SPENDABLE)
+        val wallet = OfflineNoteWallet(
+            chainId = chainId,
+            accountId = senderSigner.accountId,
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(senderSigner.accountId)),
+            ownerCertificateSigner = senderSigner,
+            store = store,
+            transactionSubmitter = RecordingTransactionSubmitter(),
+            syncResolver = RecordingSyncResolver(resolutions),
+            proofProvider = BindingProofProvider,
+            proofVerifier = BindingProofVerifier,
+            certificateVerifier = verifier,
+            randomSource = QueueRandomSource(emptyList()),
+            clock = { 1_700_000_002_000L },
+        )
+
+        wallet.sync().get()
+
+        assertEquals(OfflineNoteWalletNoteState.SPENDABLE, store.findNote(pendingNote.noteCommitment())?.state)
+    }
+
+    @Test
+    fun syncCancelsRejectedIssuePending() {
+        val fixture = loadFixture()
+        val chain = obj(fixture, "chain_vectors")
+        val derivation = obj(chain, "derivation")
+        val chainIssue = obj(chain, "issue")
+        val chainId = string(derivation, "chain_id")
+        val assetDefinitionId = assetDefinitionFromAssetId(string(chainIssue, "asset_id"))
+        val testIssuer = TestIssuerCertificateSigner()
+        val verifier = Ed25519OfflineNoteCertificateVerifier(listOf(testIssuer.publicKey))
+        val senderSigner = TestOwnerCertificateSigner()
+        val store = InMemoryOfflineNoteStore()
+        val pendingNote = issuerSourceWalletNote(
+            chainId = chainId,
+            accountId = senderSigner.accountId,
+            assetDefinitionId = assetDefinitionId,
+            amount = string(chainIssue, "amount"),
+            issuerCertificate = testIssuer.issuerCertificate(senderSigner.accountId),
+            noteSecret = ByteArray(32) { 0x14.toByte() },
+            operationSuffix = "issue-pending-rejected",
+            createdAtMs = 1_700_000_000_000L,
+        ).withState(OfflineNoteWalletNoteState.ISSUE_PENDING, 1_700_000_000_000L)
+        store.upsert(pendingNote)
+        val resolutions = linkedMapOf(pendingNote.noteCommitmentHex() to OfflineNoteWalletNoteState.CANCELLED)
+        val wallet = OfflineNoteWallet(
+            chainId = chainId,
+            accountId = senderSigner.accountId,
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(senderSigner.accountId)),
+            ownerCertificateSigner = senderSigner,
+            store = store,
+            transactionSubmitter = RecordingTransactionSubmitter(),
+            syncResolver = RecordingSyncResolver(resolutions),
+            proofProvider = BindingProofProvider,
+            proofVerifier = BindingProofVerifier,
+            certificateVerifier = verifier,
+            randomSource = QueueRandomSource(emptyList()),
+            clock = { 1_700_000_002_000L },
+        )
+
+        wallet.sync().get()
+
+        assertEquals(OfflineNoteWalletNoteState.CANCELLED, store.findNote(pendingNote.noteCommitment())?.state)
+    }
+
+    @Test
+    fun syncLeavesIssuePendingWithoutOutcome() {
+        val fixture = loadFixture()
+        val chain = obj(fixture, "chain_vectors")
+        val derivation = obj(chain, "derivation")
+        val chainIssue = obj(chain, "issue")
+        val chainId = string(derivation, "chain_id")
+        val assetDefinitionId = assetDefinitionFromAssetId(string(chainIssue, "asset_id"))
+        val testIssuer = TestIssuerCertificateSigner()
+        val verifier = Ed25519OfflineNoteCertificateVerifier(listOf(testIssuer.publicKey))
+        val senderSigner = TestOwnerCertificateSigner()
+        val store = InMemoryOfflineNoteStore()
+        val pendingNote = issuerSourceWalletNote(
+            chainId = chainId,
+            accountId = senderSigner.accountId,
+            assetDefinitionId = assetDefinitionId,
+            amount = string(chainIssue, "amount"),
+            issuerCertificate = testIssuer.issuerCertificate(senderSigner.accountId),
+            noteSecret = ByteArray(32) { 0x15.toByte() },
+            operationSuffix = "issue-pending-no-outcome",
+            createdAtMs = 1_700_000_000_000L,
+        ).withState(OfflineNoteWalletNoteState.ISSUE_PENDING, 1_700_000_000_000L)
+        store.upsert(pendingNote)
+        val wallet = OfflineNoteWallet(
+            chainId = chainId,
+            accountId = senderSigner.accountId,
+            attestationProvider = StaticAttestationProvider(testIssuer.issuerCertificate(senderSigner.accountId)),
+            ownerCertificateSigner = senderSigner,
+            store = store,
+            transactionSubmitter = RecordingTransactionSubmitter(),
+            syncResolver = RecordingSyncResolver(emptyMap()),
+            proofProvider = BindingProofProvider,
+            proofVerifier = BindingProofVerifier,
+            certificateVerifier = verifier,
+            randomSource = QueueRandomSource(emptyList()),
+            clock = { 1_700_000_002_000L },
+        )
+
+        wallet.sync().get()
+
+        assertEquals(OfflineNoteWalletNoteState.ISSUE_PENDING, store.findNote(pendingNote.noteCommitment())?.state)
     }
 
     @Test


### PR DESCRIPTION
## Context

The offline-note wallet marked a loaded note `SPENDABLE` as soon as the issuer's HTTP issue response returned — before the on-chain `IssueOfflineNote` transaction was committed. If that settlement was later rejected (e.g. the holder concurrently spent the same transparent balance), the wallet held a locally-spendable note with no on-chain backing; spending it offline to a counterparty produced a note whose later redemption would fail.

### Solution

Introduce an `OfflineNoteWalletNoteState.ISSUE_PENDING` state. `load()` now stores issued notes as `ISSUE_PENDING`, so they are excluded from `pay()`, `redeem()`, and balance until confirmed. `isPendingState()` includes `ISSUE_PENDING` so `wallet.sync()` reconciles it, mirroring the existing `REDEEM_PENDING` flow: `OfflineNoteOutcomeIndex` gains `committedIssues`/`rejectedIssues`, `recordCommittedIssue`/`recordRejectedIssue`, and `resolveIssuePending` (committed → `SPENDABLE`, rejected → `CANCELLED`, no outcome → stays `ISSUE_PENDING`), plus a `KIND_ISSUE` branch in `fromExplorerOutcomes`; `ToriiOfflineNoteOutcomeProvider.listOutcomes()` now also fetches `KIND_ISSUE`.


---

### Review notes

- `OfflineNoteWallet.kt` — start with the enum addition, the `load()` `SPENDABLE` → `ISSUE_PENDING` change, and `isPendingState()`; this is the core guard that keeps an unconfirmed note out of `pay()`/`redeem()`/balance.
- `OfflineNoteWallet.kt` (`OfflineNoteOutcomeIndex` + `ToriiOfflineNoteOutcomeProvider`) — verify `resolveIssuePending`, the `KIND_ISSUE` branch in `fromExplorerOutcomes`, and the added `listOutcomes()` fetch mirror the existing `REDEEM_PENDING`/`KIND_REDEEM` reconciliation exactly (committed/rejected/absent handling, including "absent → stay pending").
- `OfflineNoteTest.kt` — six new tests: `walletLoadStoresIssuePending`, `issuePendingNoteCannotBePaid`, `issuePendingNoteCannotBeRedeemed`, and the three `sync` outcomes (`syncPromotesCommittedIssuePendingToSpendable`, `syncCancelsRejectedIssuePending`, `syncLeavesIssuePendingWithoutOutcome`).