### PR TITLE
fix(offline-sdk): bound NoritoBridge manifest ascent to avoid an unbounded loop

### DIFF
--- a/IrohaSwift/Sources/IrohaSwift/NativeBridge.swift
+++ b/IrohaSwift/Sources/IrohaSwift/NativeBridge.swift
@@ -265,12 +265,23 @@ enum NoritoBridgeLoader {
         return nil
     }
 
-    private static func candidateArtifactManifestURLs(near binaryURL: URL) -> [URL] {
+    private static let artifactManifestMaxAscents = 64
+
+    static func candidateArtifactManifestURLsForTests(near binaryURL: URL, maxAscents: Int) -> [URL] {
+        candidateArtifactManifestURLs(near: binaryURL, maxAscents: maxAscents)
+    }
+
+    private static func candidateArtifactManifestURLs(
+        near binaryURL: URL,
+        maxAscents: Int = artifactManifestMaxAscents
+    ) -> [URL] {
         var seen = Set<String>()
         var candidates: [URL] = []
         var cursor = binaryURL.deletingLastPathComponent()
 
-        while true {
+        // Bound the ascent because Foundation URL normalization may not converge
+        // at the filesystem root on every platform.
+        for _ in 0..<max(0, maxAscents) {
             if cursor.pathExtension == "xcframework" {
                 let urls = [
                     cursor.appendingPathComponent("NoritoBridge.artifacts.json"),

--- a/IrohaSwift/Tests/IrohaSwiftTests/NativeBridgeLoaderTests.swift
+++ b/IrohaSwift/Tests/IrohaSwiftTests/NativeBridgeLoaderTests.swift
@@ -139,6 +139,28 @@ final class NativeBridgeLoaderTests: XCTestCase {
         XCTAssertEqual(status, .valid(path: bridgeURL.path, identifier: original.identifier))
     }
 
+    func testArtifactManifestCandidateSearchHonorsAscentLimit() {
+        let binaryURL = URL(fileURLWithPath:
+            "/tmp/NoritoBridge.xcframework/ios-arm64/Library/Frameworks/libNoritoBridge.a")
+        let xcframeworkManifest = URL(fileURLWithPath:
+            "/tmp/NoritoBridge.xcframework/NoritoBridge.artifacts.json")
+        let siblingManifest = URL(fileURLWithPath: "/tmp/NoritoBridge.artifacts.json")
+
+        let limited = NoritoBridgeLoader.candidateArtifactManifestURLsForTests(
+            near: binaryURL,
+            maxAscents: 1
+        )
+        XCTAssertFalse(limited.contains(xcframeworkManifest))
+        XCTAssertFalse(limited.contains(siblingManifest))
+
+        let full = NoritoBridgeLoader.candidateArtifactManifestURLsForTests(
+            near: binaryURL,
+            maxAscents: 4
+        )
+        XCTAssertTrue(full.contains(xcframeworkManifest))
+        XCTAssertTrue(full.contains(siblingManifest))
+    }
+
     private func bundledBridgeBinary() throws -> (url: URL, identifier: String) {
         #if os(macOS)
         let identifier = "macos-arm64"


### PR DESCRIPTION
## Problem
`NoritoBridgeLoader.candidateArtifactManifestURLs(near:)` (IrohaSwift/Sources/IrohaSwift/NativeBridge.swift) ascends the directory tree with `while true`, relying solely on the `parent.path == cursor.path` "reached filesystem root" fixpoint to terminate.

`URL.deletingLastPathComponent()` is **not guaranteed to converge at `/`**: depending on how Foundation normalizes `..` in `.path` (which varies by OS/toolchain version), past root it can keep accreting `..` (`/..`, `/../..`, …), so neither `.path` equality nor `pathComponents.count` ever settles. The loop then spins forever on the **main thread**, and because it is reached lazily from `NoritoNativeBridge.init` via `dispatch_once` on the first address decode, the process **hangs at startup** before any app/network/ZK code runs.

Observed on the **iOS 26 simulator**, confirmed via `sample` (100% of stacks in `candidateArtifactManifestURLs` → `deletingLastPathComponent` → `CFURLCreateCopyDeletingLastPathComponent`, process state `Rs`). **Not necessarily simulator-only** — any platform/OS build whose Foundation leaves `..` un-normalized in `.path` is exposed.

## Fix
Cap the ascent at 64 levels (a binary path is only a handful deep) to guarantee termination on every platform, keeping the existing root break which still fires early where `.path` converges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)