### PR TITLE
[codex] Support legacy Kagemusha append selector

### DIFF
--- a/javascript/iroha_js/dist/crypto.browser.js
+++ b/javascript/iroha_js/dist/crypto.browser.js
@@ -1066,6 +1066,7 @@ export function normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outpu
 export function isSupportedKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId) {
   const normalized = normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId);
   return (
+    normalized === "" ||
     normalized === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1 ||
     normalized === KAGEMUSHA_RECURSIVE_SPEND_LINEAGE_APPEND_PROOF_CIRCUIT_ID_V1
   );
@@ -1093,6 +1094,9 @@ export function canProveKagemushaRecursiveSpendAppendOutputProofCircuitId(
     return false;
   }
   const normalized = normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId);
+  if (normalized === "") {
+    return previousHopCount < KAGEMUSHA_COMPACT_TOKEN_MAX_HOPS;
+  }
   if (normalized === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1) {
     return previousHopCount < KAGEMUSHA_COMPACT_TOKEN_MAX_HOPS;
   }
@@ -1122,6 +1126,8 @@ export function isSupportedKagemushaRecursiveSpendAppendProofTransition(
   const normalizedOutput =
     normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId);
   return (
+    (normalizedOutput === "" &&
+      isSupportedKagemushaRecursiveSpendPreviousProofCircuitId(previousProofCircuitId)) ||
     (previousProofCircuitId === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1 &&
       normalizedOutput === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1) ||
     (isKagemushaRecursiveSpendLineageProofCircuitId(previousProofCircuitId) &&

--- a/javascript/iroha_js/dist/crypto.js
+++ b/javascript/iroha_js/dist/crypto.js
@@ -1719,6 +1719,7 @@ export function normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outpu
 export function isSupportedKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId) {
   const normalized = normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId);
   return (
+    normalized === "" ||
     normalized === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1 ||
     normalized === KAGEMUSHA_RECURSIVE_SPEND_LINEAGE_APPEND_PROOF_CIRCUIT_ID_V1
   );
@@ -1746,6 +1747,9 @@ export function canProveKagemushaRecursiveSpendAppendOutputProofCircuitId(
     return false;
   }
   const normalized = normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId);
+  if (normalized === "") {
+    return previousHopCount < KAGEMUSHA_COMPACT_TOKEN_MAX_HOPS;
+  }
   if (normalized === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1) {
     return previousHopCount < KAGEMUSHA_COMPACT_TOKEN_MAX_HOPS;
   }
@@ -1775,6 +1779,8 @@ export function isSupportedKagemushaRecursiveSpendAppendProofTransition(
   const normalizedOutput =
     normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId);
   return (
+    (normalizedOutput === "" &&
+      isSupportedKagemushaRecursiveSpendPreviousProofCircuitId(previousProofCircuitId)) ||
     (previousProofCircuitId === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1 &&
       normalizedOutput === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1) ||
     (isKagemushaRecursiveSpendLineageProofCircuitId(previousProofCircuitId) &&

--- a/javascript/iroha_js/src/crypto.browser.js
+++ b/javascript/iroha_js/src/crypto.browser.js
@@ -1066,6 +1066,7 @@ export function normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outpu
 export function isSupportedKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId) {
   const normalized = normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId);
   return (
+    normalized === "" ||
     normalized === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1 ||
     normalized === KAGEMUSHA_RECURSIVE_SPEND_LINEAGE_APPEND_PROOF_CIRCUIT_ID_V1
   );
@@ -1093,6 +1094,9 @@ export function canProveKagemushaRecursiveSpendAppendOutputProofCircuitId(
     return false;
   }
   const normalized = normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId);
+  if (normalized === "") {
+    return previousHopCount < KAGEMUSHA_COMPACT_TOKEN_MAX_HOPS;
+  }
   if (normalized === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1) {
     return previousHopCount < KAGEMUSHA_COMPACT_TOKEN_MAX_HOPS;
   }
@@ -1122,6 +1126,8 @@ export function isSupportedKagemushaRecursiveSpendAppendProofTransition(
   const normalizedOutput =
     normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId);
   return (
+    (normalizedOutput === "" &&
+      isSupportedKagemushaRecursiveSpendPreviousProofCircuitId(previousProofCircuitId)) ||
     (previousProofCircuitId === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1 &&
       normalizedOutput === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1) ||
     (isKagemushaRecursiveSpendLineageProofCircuitId(previousProofCircuitId) &&

--- a/javascript/iroha_js/src/crypto.js
+++ b/javascript/iroha_js/src/crypto.js
@@ -1719,6 +1719,7 @@ export function normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outpu
 export function isSupportedKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId) {
   const normalized = normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId);
   return (
+    normalized === "" ||
     normalized === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1 ||
     normalized === KAGEMUSHA_RECURSIVE_SPEND_LINEAGE_APPEND_PROOF_CIRCUIT_ID_V1
   );
@@ -1746,6 +1747,9 @@ export function canProveKagemushaRecursiveSpendAppendOutputProofCircuitId(
     return false;
   }
   const normalized = normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId);
+  if (normalized === "") {
+    return previousHopCount < KAGEMUSHA_COMPACT_TOKEN_MAX_HOPS;
+  }
   if (normalized === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1) {
     return previousHopCount < KAGEMUSHA_COMPACT_TOKEN_MAX_HOPS;
   }
@@ -1775,6 +1779,8 @@ export function isSupportedKagemushaRecursiveSpendAppendProofTransition(
   const normalizedOutput =
     normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId);
   return (
+    (normalizedOutput === "" &&
+      isSupportedKagemushaRecursiveSpendPreviousProofCircuitId(previousProofCircuitId)) ||
     (previousProofCircuitId === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1 &&
       normalizedOutput === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1) ||
     (isKagemushaRecursiveSpendLineageProofCircuitId(previousProofCircuitId) &&

--- a/javascript/iroha_js/test/kagemushaRecursiveSpend.test.js
+++ b/javascript/iroha_js/test/kagemushaRecursiveSpend.test.js
@@ -6328,7 +6328,7 @@ test("Kagemusha recursive spend exports stable proof circuit ids", () => {
       KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1,
       "",
     ),
-    false,
+    true,
   );
   assert.equal(
     isSupportedKagemushaRecursiveSpendAppendProofTransition(
@@ -6479,11 +6479,11 @@ test("Kagemusha recursive spend exports stable proof circuit ids", () => {
     ),
     true,
   );
-  assert.equal(isSupportedKagemushaRecursiveSpendAppendOutputProofCircuitId(""), false);
-  assert.equal(isSupportedKagemushaRecursiveSpendAppendOutputProofCircuitId(null), false);
+  assert.equal(isSupportedKagemushaRecursiveSpendAppendOutputProofCircuitId(""), true);
+  assert.equal(isSupportedKagemushaRecursiveSpendAppendOutputProofCircuitId(null), true);
   assert.equal(
     canProveKagemushaRecursiveSpendAppendOutputProofCircuitId(undefined, 1),
-    false,
+    true,
   );
   assert.equal(
     canSelectKagemushaRecursiveSpendAppendOutputProofCircuitId(
@@ -6491,9 +6491,9 @@ test("Kagemusha recursive spend exports stable proof circuit ids", () => {
       undefined,
       1,
     ),
-    false,
+    true,
   );
-  assert.equal(canProveKagemushaRecursiveSpendAppendOutputProofCircuitId(null, 1), false);
+  assert.equal(canProveKagemushaRecursiveSpendAppendOutputProofCircuitId(null, 1), true);
   assert.equal(
     canProveKagemushaRecursiveSpendAppendOutputProofCircuitId(
       KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1,

--- a/javascript/iroha_js/test/package_dist.test.js
+++ b/javascript/iroha_js/test/package_dist.test.js
@@ -3010,7 +3010,7 @@ test("package dist entrypoint exports Kagemusha recursive spend helpers", () => 
       KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1,
       "",
     ),
-    false,
+    true,
   );
   assert.equal(
     isSupportedKagemushaRecursiveSpendAppendProofTransition(
@@ -3547,11 +3547,11 @@ test("package dist entrypoint exports Kagemusha recursive spend helpers", () => 
     ),
     true,
   );
-  assert.equal(isSupportedKagemushaRecursiveSpendAppendOutputProofCircuitId(""), false);
-  assert.equal(isSupportedKagemushaRecursiveSpendAppendOutputProofCircuitId(null), false);
+  assert.equal(isSupportedKagemushaRecursiveSpendAppendOutputProofCircuitId(""), true);
+  assert.equal(isSupportedKagemushaRecursiveSpendAppendOutputProofCircuitId(null), true);
   assert.equal(
     canProveKagemushaRecursiveSpendAppendOutputProofCircuitId(undefined, 1),
-    false,
+    true,
   );
   assert.equal(
     canSelectKagemushaRecursiveSpendAppendOutputProofCircuitId(
@@ -3559,9 +3559,9 @@ test("package dist entrypoint exports Kagemusha recursive spend helpers", () => 
       undefined,
       1,
     ),
-    false,
+    true,
   );
-  assert.equal(canProveKagemushaRecursiveSpendAppendOutputProofCircuitId(null, 1), false);
+  assert.equal(canProveKagemushaRecursiveSpendAppendOutputProofCircuitId(null, 1), true);
   assert.equal(
     canProveKagemushaRecursiveSpendAppendOutputProofCircuitId(
       KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1,


### PR DESCRIPTION
## Summary

- Treat legacy empty Kagemusha append-output selectors (`undefined`, `null`, and `""`) as supported semantic append selectors for valid positive hop counts.
- Apply the behavior consistently across source, browser source, and checked-in dist entrypoints.
- Update source and package-dist regression tests for legacy empty selector support.

## Why

The Fearless root release-readiness audit now requires backward-compatible empty append-output selector handling so older callers that omit the selector can still use the semantic append path instead of failing production readiness.

## Validation

- `npm run build:dist`
- `node --test test/kagemushaRecursiveSpend.test.js test/package_dist.test.js`
- `bash scripts/audit-plan-readiness.sh` from `/Users/takemiyamakoto/dev/fearless`
- `git diff --check`
