### PR TITLE
[codex] Enforce canonical Kagemusha append selectors

### DIFF
--- a/javascript/iroha_js/dist/crypto.browser.js
+++ b/javascript/iroha_js/dist/crypto.browser.js
@@ -1057,9 +1057,6 @@ export function canAppendKagemushaRecursiveSpendWitnesslessLineage(previousHopCo
 }
 
 export function normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId) {
-  if (outputProofCircuitId === undefined || outputProofCircuitId === null || outputProofCircuitId === "") {
-    return "";
-  }
   return outputProofCircuitId;
 }
 

--- a/javascript/iroha_js/dist/crypto.js
+++ b/javascript/iroha_js/dist/crypto.js
@@ -1710,9 +1710,6 @@ export function canAppendKagemushaRecursiveSpendWitnesslessLineage(previousHopCo
 }
 
 export function normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId) {
-  if (outputProofCircuitId === undefined || outputProofCircuitId === null || outputProofCircuitId === "") {
-    return "";
-  }
   return outputProofCircuitId;
 }
 

--- a/javascript/iroha_js/src/crypto.browser.js
+++ b/javascript/iroha_js/src/crypto.browser.js
@@ -1057,9 +1057,6 @@ export function canAppendKagemushaRecursiveSpendWitnesslessLineage(previousHopCo
 }
 
 export function normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId) {
-  if (outputProofCircuitId === undefined || outputProofCircuitId === null || outputProofCircuitId === "") {
-    return "";
-  }
   return outputProofCircuitId;
 }
 

--- a/javascript/iroha_js/src/crypto.js
+++ b/javascript/iroha_js/src/crypto.js
@@ -1710,9 +1710,6 @@ export function canAppendKagemushaRecursiveSpendWitnesslessLineage(previousHopCo
 }
 
 export function normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId) {
-  if (outputProofCircuitId === undefined || outputProofCircuitId === null || outputProofCircuitId === "") {
-    return "";
-  }
   return outputProofCircuitId;
 }
 

--- a/javascript/iroha_js/test/kagemushaRecursiveSpend.test.js
+++ b/javascript/iroha_js/test/kagemushaRecursiveSpend.test.js
@@ -5648,11 +5648,11 @@ test("Kagemusha recursive spend exports stable proof circuit ids", () => {
   );
   assert.equal(
     normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(),
-    "",
+    undefined,
   );
   assert.equal(
     normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(null),
-    "",
+    null,
   );
   assert.equal(
     normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(""),
@@ -6533,6 +6533,9 @@ test("Kagemusha recursive spend exports stable proof circuit ids", () => {
     [KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1, 0],
     [KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1, KAGEMUSHA_COMPACT_TOKEN_MAX_HOPS],
     [KAGEMUSHA_RECURSIVE_SPEND_LINEAGE_PROOF_CIRCUIT_ID_V1, 64],
+    [undefined, 1],
+    [null, 1],
+    ["", 1],
     ["unknown-kagemusha-recursive-spend-circuit", 1],
     [whitespaceLineageOutputCircuitId, 1],
     [KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1, 1.5],

--- a/javascript/iroha_js/test/package_dist.test.js
+++ b/javascript/iroha_js/test/package_dist.test.js
@@ -3049,11 +3049,11 @@ test("package dist entrypoint exports Kagemusha recursive spend helpers", () => 
   );
   assert.equal(
     normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(),
-    "",
+    undefined,
   );
   assert.equal(
     normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(null),
-    "",
+    null,
   );
   assert.equal(
     normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(""),
@@ -3625,6 +3625,12 @@ test("package dist entrypoint exports Kagemusha recursive spend helpers", () => 
     ),
     false,
   );
+  for (const outputProofCircuitId of [undefined, null, ""]) {
+    assert.equal(
+      canProveKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId, 1),
+      false,
+    );
+  }
   for (const previousHopCount of [
     1.5,
     Number.NaN,


### PR DESCRIPTION
## Summary
- remove missing/null/empty append-output proof selector normalization
- keep first-release Kagemusha append selection on explicit canonical circuit IDs only
- add source and package-dist negative coverage for missing/null/empty selectors

## Verification
- npm run build:dist
- node --test test/kagemushaRecursiveSpend.test.js test/package_dist.test.js