### PR TITLE
[codex] Harden Kagemusha append selector gate

### DIFF
--- a/javascript/iroha_js/dist/crypto.browser.js
+++ b/javascript/iroha_js/dist/crypto.browser.js
@@ -1063,7 +1063,6 @@ export function normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outpu
 export function isSupportedKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId) {
   const normalized = normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId);
   return (
-    normalized === "" ||
     normalized === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1 ||
     normalized === KAGEMUSHA_RECURSIVE_SPEND_LINEAGE_APPEND_PROOF_CIRCUIT_ID_V1
   );
@@ -1091,9 +1090,6 @@ export function canProveKagemushaRecursiveSpendAppendOutputProofCircuitId(
     return false;
   }
   const normalized = normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId);
-  if (normalized === "") {
-    return previousHopCount < KAGEMUSHA_COMPACT_TOKEN_MAX_HOPS;
-  }
   if (normalized === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1) {
     return previousHopCount < KAGEMUSHA_COMPACT_TOKEN_MAX_HOPS;
   }
@@ -1123,8 +1119,6 @@ export function isSupportedKagemushaRecursiveSpendAppendProofTransition(
   const normalizedOutput =
     normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId);
   return (
-    (normalizedOutput === "" &&
-      isSupportedKagemushaRecursiveSpendPreviousProofCircuitId(previousProofCircuitId)) ||
     (previousProofCircuitId === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1 &&
       normalizedOutput === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1) ||
     (isKagemushaRecursiveSpendLineageProofCircuitId(previousProofCircuitId) &&

--- a/javascript/iroha_js/dist/crypto.js
+++ b/javascript/iroha_js/dist/crypto.js
@@ -1716,7 +1716,6 @@ export function normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outpu
 export function isSupportedKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId) {
   const normalized = normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId);
   return (
-    normalized === "" ||
     normalized === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1 ||
     normalized === KAGEMUSHA_RECURSIVE_SPEND_LINEAGE_APPEND_PROOF_CIRCUIT_ID_V1
   );
@@ -1744,9 +1743,6 @@ export function canProveKagemushaRecursiveSpendAppendOutputProofCircuitId(
     return false;
   }
   const normalized = normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId);
-  if (normalized === "") {
-    return previousHopCount < KAGEMUSHA_COMPACT_TOKEN_MAX_HOPS;
-  }
   if (normalized === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1) {
     return previousHopCount < KAGEMUSHA_COMPACT_TOKEN_MAX_HOPS;
   }
@@ -1776,8 +1772,6 @@ export function isSupportedKagemushaRecursiveSpendAppendProofTransition(
   const normalizedOutput =
     normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId);
   return (
-    (normalizedOutput === "" &&
-      isSupportedKagemushaRecursiveSpendPreviousProofCircuitId(previousProofCircuitId)) ||
     (previousProofCircuitId === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1 &&
       normalizedOutput === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1) ||
     (isKagemushaRecursiveSpendLineageProofCircuitId(previousProofCircuitId) &&

--- a/javascript/iroha_js/src/crypto.browser.js
+++ b/javascript/iroha_js/src/crypto.browser.js
@@ -1063,7 +1063,6 @@ export function normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outpu
 export function isSupportedKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId) {
   const normalized = normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId);
   return (
-    normalized === "" ||
     normalized === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1 ||
     normalized === KAGEMUSHA_RECURSIVE_SPEND_LINEAGE_APPEND_PROOF_CIRCUIT_ID_V1
   );
@@ -1091,9 +1090,6 @@ export function canProveKagemushaRecursiveSpendAppendOutputProofCircuitId(
     return false;
   }
   const normalized = normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId);
-  if (normalized === "") {
-    return previousHopCount < KAGEMUSHA_COMPACT_TOKEN_MAX_HOPS;
-  }
   if (normalized === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1) {
     return previousHopCount < KAGEMUSHA_COMPACT_TOKEN_MAX_HOPS;
   }
@@ -1123,8 +1119,6 @@ export function isSupportedKagemushaRecursiveSpendAppendProofTransition(
   const normalizedOutput =
     normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId);
   return (
-    (normalizedOutput === "" &&
-      isSupportedKagemushaRecursiveSpendPreviousProofCircuitId(previousProofCircuitId)) ||
     (previousProofCircuitId === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1 &&
       normalizedOutput === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1) ||
     (isKagemushaRecursiveSpendLineageProofCircuitId(previousProofCircuitId) &&

--- a/javascript/iroha_js/src/crypto.js
+++ b/javascript/iroha_js/src/crypto.js
@@ -1716,7 +1716,6 @@ export function normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outpu
 export function isSupportedKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId) {
   const normalized = normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId);
   return (
-    normalized === "" ||
     normalized === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1 ||
     normalized === KAGEMUSHA_RECURSIVE_SPEND_LINEAGE_APPEND_PROOF_CIRCUIT_ID_V1
   );
@@ -1744,9 +1743,6 @@ export function canProveKagemushaRecursiveSpendAppendOutputProofCircuitId(
     return false;
   }
   const normalized = normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId);
-  if (normalized === "") {
-    return previousHopCount < KAGEMUSHA_COMPACT_TOKEN_MAX_HOPS;
-  }
   if (normalized === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1) {
     return previousHopCount < KAGEMUSHA_COMPACT_TOKEN_MAX_HOPS;
   }
@@ -1776,8 +1772,6 @@ export function isSupportedKagemushaRecursiveSpendAppendProofTransition(
   const normalizedOutput =
     normalizeKagemushaRecursiveSpendAppendOutputProofCircuitId(outputProofCircuitId);
   return (
-    (normalizedOutput === "" &&
-      isSupportedKagemushaRecursiveSpendPreviousProofCircuitId(previousProofCircuitId)) ||
     (previousProofCircuitId === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1 &&
       normalizedOutput === KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1) ||
     (isKagemushaRecursiveSpendLineageProofCircuitId(previousProofCircuitId) &&

--- a/javascript/iroha_js/test/kagemushaRecursiveSpend.test.js
+++ b/javascript/iroha_js/test/kagemushaRecursiveSpend.test.js
@@ -6328,7 +6328,7 @@ test("Kagemusha recursive spend exports stable proof circuit ids", () => {
       KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1,
       "",
     ),
-    true,
+    false,
   );
   assert.equal(
     isSupportedKagemushaRecursiveSpendAppendProofTransition(
@@ -6479,11 +6479,11 @@ test("Kagemusha recursive spend exports stable proof circuit ids", () => {
     ),
     true,
   );
-  assert.equal(isSupportedKagemushaRecursiveSpendAppendOutputProofCircuitId(""), true);
-  assert.equal(isSupportedKagemushaRecursiveSpendAppendOutputProofCircuitId(null), true);
+  assert.equal(isSupportedKagemushaRecursiveSpendAppendOutputProofCircuitId(""), false);
+  assert.equal(isSupportedKagemushaRecursiveSpendAppendOutputProofCircuitId(null), false);
   assert.equal(
     canProveKagemushaRecursiveSpendAppendOutputProofCircuitId(undefined, 1),
-    true,
+    false,
   );
   assert.equal(
     canSelectKagemushaRecursiveSpendAppendOutputProofCircuitId(
@@ -6491,9 +6491,9 @@ test("Kagemusha recursive spend exports stable proof circuit ids", () => {
       undefined,
       1,
     ),
-    true,
+    false,
   );
-  assert.equal(canProveKagemushaRecursiveSpendAppendOutputProofCircuitId(null, 1), true);
+  assert.equal(canProveKagemushaRecursiveSpendAppendOutputProofCircuitId(null, 1), false);
   assert.equal(
     canProveKagemushaRecursiveSpendAppendOutputProofCircuitId(
       KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1,

--- a/javascript/iroha_js/test/package_dist.test.js
+++ b/javascript/iroha_js/test/package_dist.test.js
@@ -3010,7 +3010,7 @@ test("package dist entrypoint exports Kagemusha recursive spend helpers", () => 
       KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1,
       "",
     ),
-    true,
+    false,
   );
   assert.equal(
     isSupportedKagemushaRecursiveSpendAppendProofTransition(
@@ -3547,11 +3547,11 @@ test("package dist entrypoint exports Kagemusha recursive spend helpers", () => 
     ),
     true,
   );
-  assert.equal(isSupportedKagemushaRecursiveSpendAppendOutputProofCircuitId(""), true);
-  assert.equal(isSupportedKagemushaRecursiveSpendAppendOutputProofCircuitId(null), true);
+  assert.equal(isSupportedKagemushaRecursiveSpendAppendOutputProofCircuitId(""), false);
+  assert.equal(isSupportedKagemushaRecursiveSpendAppendOutputProofCircuitId(null), false);
   assert.equal(
     canProveKagemushaRecursiveSpendAppendOutputProofCircuitId(undefined, 1),
-    true,
+    false,
   );
   assert.equal(
     canSelectKagemushaRecursiveSpendAppendOutputProofCircuitId(
@@ -3559,9 +3559,9 @@ test("package dist entrypoint exports Kagemusha recursive spend helpers", () => 
       undefined,
       1,
     ),
-    true,
+    false,
   );
-  assert.equal(canProveKagemushaRecursiveSpendAppendOutputProofCircuitId(null, 1), true);
+  assert.equal(canProveKagemushaRecursiveSpendAppendOutputProofCircuitId(null, 1), false);
   assert.equal(
     canProveKagemushaRecursiveSpendAppendOutputProofCircuitId(
       KAGEMUSHA_RECURSIVE_AGGREGATION_PROOF_CIRCUIT_ID_V1,


### PR DESCRIPTION
## Summary
- remove the reintroduced empty append-output selector compatibility path from source, browser, and dist crypto entrypoints
- make empty, missing, and null append selectors negative first-release cases in source and package-dist Kagemusha tests
- keep the release contract on explicit aggregation or lineage append proof circuit IDs only

## Verification
- npm run build:dist
- node --test test/kagemushaRecursiveSpend.test.js test/package_dist.test.js
- from /Users/takemiyamakoto/dev/fearless: bash scripts/audit-plan-readiness.sh
