### PR TITLE
Fix single-lane Kagemusha routing, VK namespace

### DIFF
--- a/crates/iroha_cli/src/zk.rs
+++ b/crates/iroha_cli/src/zk.rs
@@ -4006,6 +4006,8 @@ struct VkSubmissionJson {
     vk_bytes: Option<String>,
     #[norito(default)]
     status: Option<iroha::data_model::confidential::ConfidentialStatus>,
+    #[norito(default)]
+    namespace: Option<String>,
 }
 
 struct PreparedVkSubmission {
@@ -4151,7 +4153,7 @@ fn build_vk_record(
         payload.version,
         payload.circuit_id.clone(),
         None,
-        "core",
+        payload.namespace.clone().unwrap_or_else(|| "core".to_owned()),
         backend_tag,
         payload.curve.clone().unwrap_or_else(|| "unknown".into()),
         schema_hash,

--- a/crates/iroha_core/src/queue.rs
+++ b/crates/iroha_core/src/queue.rs
@@ -543,6 +543,10 @@ fn route_uses_legacy_default_public_lane(route: RoutingDecision, nexus: &Nexus) 
             .any(|lane| lane.dataspace_id == route.dataspace_id)
 }
 
+fn nexus_uses_multilane_route_catalogs(nexus: &Nexus) -> bool {
+    nexus.enabled && nexus.uses_multilane_catalogs()
+}
+
 fn resolve_routing_plan_against_nexus_at_height(
     plan: RoutingPlan,
     nexus: &Nexus,
@@ -550,7 +554,9 @@ fn resolve_routing_plan_against_nexus_at_height(
 ) -> Result<RoutingPlan, RoutingResolveError> {
     let plan =
         resolve_routing_plan_against_catalogs(plan, &nexus.lane_catalog, &nexus.dataspace_catalog)?;
-    ensure_routing_plan_active_at_height(&plan, nexus, block_height)?;
+    if nexus_uses_multilane_route_catalogs(nexus) {
+        ensure_routing_plan_active_at_height(&plan, nexus, block_height)?;
+    }
     Ok(plan)
 }
 
@@ -7162,7 +7168,7 @@ impl Queue {
     }
 
     fn nexus_uses_config_router(nexus: &Nexus) -> bool {
-        nexus.enabled && nexus.uses_multilane_catalogs()
+        nexus_uses_multilane_route_catalogs(nexus)
     }
 
     fn router_for_nexus(
@@ -13187,6 +13193,42 @@ pub mod tests {
             routing_ledger::get_plan(&hash),
             None,
             "rejected inactive state-free route must not enter the local routing ledger"
+        );
+    }
+
+    #[test]
+    fn state_backed_queue_routes_skip_catalog_validation_when_nexus_disabled() {
+        let mut state = state_with_future_created_autoscale_lane(7, 6);
+        state.nexus.get_mut().enabled = false;
+        let nexus = state.nexus_snapshot();
+        assert!(!nexus.enabled);
+        assert!(nexus.uses_multilane_catalogs());
+        assert_eq!(
+            crate::state::nexus_active_lane_dataspace_at_height(
+                LaneId::new(1),
+                &nexus,
+                state_height_for_routing(&state),
+            ),
+            None
+        );
+
+        let (_time_handle, time_source) = TimeSource::new_mock(Duration::default());
+        let queue = queue_with_state_free_future_created_router(&state, &time_source);
+        let tx = accepted_tx_by_someone(&time_source);
+        let expected =
+            RoutingPlan::single(RoutingDecision::new(LaneId::new(1), DataSpaceId::UNIVERSAL));
+
+        assert_eq!(
+            queue
+                .route_plan_with_state(&tx, &state)
+                .expect("disabled Nexus should not enforce inactive catalog lanes"),
+            expected
+        );
+        assert_eq!(
+            queue
+                .route_plan_for_gossip_with_state(&tx, &state)
+                .expect("disabled Nexus gossip routing should not enforce inactive catalog lanes"),
+            expected
         );
     }
 


### PR DESCRIPTION
## Context

Two independent gaps blocked Kagemusha on non-multilane deployments. First, when Nexus is disabled (single-lane deployments), routing-plan resolution still enforced lane-activity validation against multilane catalog state that a disabled Nexus never populates, so valid routes were rejected. Second, Kagemusha verifier keys could only be registered under the hardcoded `core` namespace via the CLI, so keys belonging to any other namespace could not be submitted.

### Solution

Extracted the `nexus_uses_multilane_route_catalogs(nexus)` predicate (`nexus.enabled && nexus.uses_multilane_catalogs()`) in `queue.rs` and gated `ensure_routing_plan_active_at_height` on it inside `resolve_routing_plan_against_nexus_at_height`, so a disabled/single-lane Nexus skips catalog-activity enforcement while multilane behavior is unchanged; `nexus_uses_config_router` now reuses the same predicate. In `zk.rs`, added an optional `namespace: Option<String>` field to `VkSubmissionJson` (`#[norito(default)]`) that `build_vk_record` uses in place of the literal `"core"`, defaulting back to `"core"` when omitted.

---

### Review notes

- `crates/iroha_core/src/queue.rs` — start with the new `nexus_uses_multilane_route_catalogs` helper and its use in `resolve_routing_plan_against_nexus_at_height`; confirm the guard only relaxes validation when Nexus is disabled/single-lane. The added test `state_backed_queue_routes_skip_catalog_validation_when_nexus_disabled` pins the behavior (disabled Nexus routes to the expected single lane for both direct and gossip paths).
- `crates/iroha_cli/src/zk.rs` — the `namespace` field on `VkSubmissionJson` and the `unwrap_or_else(|| "core".to_owned())` default in `build_vk_record`; verify omitted-namespace submissions still resolve to `core` (backward-compatible).