### PR TITLE
Enable Taira SCCP diagnostic proofs in tests

### DIFF
--- a/crates/iroha_torii/src/routing.rs
+++ b/crates/iroha_torii/src/routing.rs
@@ -9303,12 +9303,16 @@ fn sccp_message_artifact_for_material_request(
             taira_diagnostic_local_admission,
         )
     {
-        #[cfg(not(feature = "sccp-test-fixtures"))]
-        return Err(sccp_bad_request(
-            "TAIRA diagnostic local admission requires the sccp-test-fixtures feature",
-        ));
-        #[cfg(feature = "sccp-test-fixtures")]
-        return Ok(iroha_sccp::build_sccp_taira_tron_xor_diagnostic_transparent_proof(bundle));
+        #[cfg(any(test, feature = "sccp-test-fixtures"))]
+        {
+            return Ok(iroha_sccp::build_sccp_taira_tron_xor_diagnostic_transparent_proof(bundle));
+        }
+        #[cfg(not(any(test, feature = "sccp-test-fixtures")))]
+        {
+            return Err(sccp_bad_request(
+                "TAIRA TRON XOR diagnostic local-admission proofs are only available in fixture builds; production non-SORA source lanes require governed source-adapter material",
+            ));
+        }
     }
     sccp_message_artifact_for_destination_material(
         bundle,


### PR DESCRIPTION
## Context

The TAIRA TRON XOR diagnostic local-admission proof was emitted only under the `sccp-test-fixtures` feature, even though its companion admission gate `sccp_taira_tron_xor_diagnostic_fixture_local_admission_enabled` is already enabled under `#[cfg(test)]`. As a result, an ordinary `cargo test` run reached the admission branch but then fell through to the fail-closed error instead of building the proof, leaving the positive diagnostic path unexercised by unit tests.

### Solution

Broadened the gate in `sccp_message_artifact_for_material_request` from `#[cfg(feature = "sccp-test-fixtures")]` to `#[cfg(any(test, feature = "sccp-test-fixtures"))]`, so `build_sccp_taira_tron_xor_diagnostic_transparent_proof` is returned in both unit-test and fixture builds — matching the existing `#[cfg(test)]` admission helper. Production builds (neither `test` nor the feature) stay fail-closed through the `not(any(...))` arm, whose `sccp_bad_request` message now states explicitly that diagnostic proofs are fixture-only and that production non-SORA source lanes require governed source-adapter material.

---

### Review notes

- `crates/iroha_torii/src/routing.rs` — the only change is the `cfg` split in `sccp_message_artifact_for_material_request`. Confirm the diagnostic proof is returned solely under `any(test, feature = "sccp-test-fixtures")` and that the production `not(any(...))` arm still returns `sccp_bad_request` (fail-closed, no behavior change outside test/fixture builds).
- Cross-check the gate against the already-`#[cfg(test)]`-scoped `sccp_taira_tron_xor_diagnostic_fixture_local_admission_enabled` helper so admission and proof-building agree; the existing `bridge_proof_from_sccp_message_bundle_accepts_verified_taira_tron_xor_diagnostic_source_bundle` and `..._rejects_taira_tron_xor_diagnostic_even_when_allowed` tests frame the intended admit/reject behavior.