### PR TITLE
Fix SoraFS gateway stream-token limit exports

### DIFF
--- a/crates/sorafs_car/src/gateway.rs
+++ b/crates/sorafs_car/src/gateway.rs
@@ -1818,7 +1818,7 @@ fn parse_manifest_response(
     if manifest_digest_hex != computed_digest_hex {
         return Err(GatewayManifestError::DigestMismatch {
             provider: provider.to_string(),
-            expected: manifest_digest_hex,
+            expected: manifest_digest_hex.to_string(),
             actual: computed_digest_hex,
         });
     }

--- a/crates/sorafs_manifest/src/lib.rs
+++ b/crates/sorafs_manifest/src/lib.rs
@@ -395,7 +395,10 @@ pub use reputation::{
     build_reputation_snapshot, build_reputation_snapshot_with_trust_edges,
     compute_reputation_merkle_root, score_provider_reputation,
 };
-pub use token::{STREAM_TOKEN_MAX_TTL_SECS_V1, StreamTokenBodyV1, StreamTokenError, StreamTokenV1};
+pub use token::{
+    STREAM_TOKEN_MAX_BASE64_BYTES_V1, STREAM_TOKEN_MAX_TTL_SECS_V1, STREAM_TOKEN_MAX_WIRE_BYTES_V1,
+    StreamTokenBodyV1, StreamTokenError, StreamTokenV1,
+};
 pub use validation::{
     ManifestValidationError, PinPolicyConstraints, validate_chunker_handle, validate_manifest,
     validate_pin_policy,


### PR DESCRIPTION
## Context

`sorafs_car`'s gateway enforces stream-token size limits using `STREAM_TOKEN_MAX_BASE64_BYTES_V1` and `STREAM_TOKEN_MAX_WIRE_BYTES_V1` from `sorafs_manifest`, but the manifest crate's public API only re-exported `STREAM_TOKEN_MAX_TTL_SECS_V1`. As a result the two byte-limit constants were unresolvable and `sorafs_car` failed to compile.

### Solution

Re-export `STREAM_TOKEN_MAX_BASE64_BYTES_V1` and `STREAM_TOKEN_MAX_WIRE_BYTES_V1` from `sorafs_manifest`'s top-level `pub use token::{…}`, alongside the existing `STREAM_TOKEN_MAX_TTL_SECS_V1`. Also convert the borrowed `manifest_digest_hex` to an owned `String` in `parse_manifest_response` so `GatewayManifestError::DigestMismatch` can be constructed without holding a borrow into the decoded JSON.

---

### Review notes

- `crates/sorafs_manifest/src/lib.rs` — the one-line change to the `pub use token::{…}` re-export; confirm both new constants (`STREAM_TOKEN_MAX_BASE64_BYTES_V1`, `STREAM_TOKEN_MAX_WIRE_BYTES_V1`) come from the `token` module and are the ones the gateway consumes.
- `crates/sorafs_car/src/gateway.rs` — the constants are already imported at the top of the file (this PR makes that import resolve); the only edit here is `manifest_digest_hex.to_string()` in the `DigestMismatch` arm of `parse_manifest_response`, making the error value owned.