### PR TITLE
Fix stale callers against current API

### DIFF
--- a/crates/iroha_cli/src/main_shared.rs
+++ b/crates/iroha_cli/src/main_shared.rs
@@ -7191,7 +7191,7 @@ mod settlement {
         #[arg(long)]
         pub destination_asset: AssetDefinitionId,
         /// Allowed destination account-alias domain (repeat for each FI domain).
-        #[arg(long = "allowed-destination-alias-domain", required = true)]
+        #[arg(long = "allowed-destination-alias-domain", required = true, value_parser = parse_domain_id_literal)]
         pub allowed_destination_alias_domains: Vec<DomainId>,
         /// Destination/source rate numerator
         #[arg(long)]

--- a/crates/iroha_kagami/src/kagemusha.rs
+++ b/crates/iroha_kagami/src/kagemusha.rs
@@ -66,7 +66,7 @@ const REPORT_ARTIFACT_PURPOSES: [&str; 6] = [
     "step_ep_verifying_key",
 ];
 const REPORT_ROSTER_PURPOSE: &str = "topup_finality_roster";
-const REPORT_ARTIFACT_PURPOSES_V4: [&str; 10] = KAGEMUSHA_RECURSIVE_SPEND_ARTIFACT_ROLES_V4;
+const REPORT_ARTIFACT_PURPOSES_V4: [&str; 8] = KAGEMUSHA_RECURSIVE_SPEND_ARTIFACT_ROLES_V4;
 
 /// Kagemusha release-management command group.
 #[derive(Debug, ClapArgs)]
@@ -388,7 +388,7 @@ fn verify_release_directory_v4(
         .flat_map(|profile| profile.artifacts.iter())
         .collect();
     if descriptors.len() != REPORT_ARTIFACT_PURPOSES_V4.len() {
-        bail!("Kagemusha V4 release does not contain the exact ten-artifact inventory");
+        bail!("Kagemusha V4 release does not contain the exact eight-artifact inventory");
     }
     let mut validated = Vec::with_capacity(descriptors.len());
     for descriptor in &descriptors {
@@ -412,16 +412,14 @@ fn verify_release_directory_v4(
     }
     let [
         step_eq_parameters,
-        step_eq_circuit_params,
         step_eq_proving_key,
         step_eq_verifying_key,
         step_eq_bootstrap_witness,
         step_ep_parameters,
-        step_ep_circuit_params,
         step_ep_proving_key,
         step_ep_verifying_key,
         step_ep_bootstrap_witness,
-    ]: [KagemushaValidatedArtifactPayloadV4; 10] = validated
+    ]: [KagemushaValidatedArtifactPayloadV4; 8] = validated
         .try_into()
         .map_err(|_| eyre!("Kagemusha V4 artifact inventory length changed"))?;
 
@@ -452,12 +450,10 @@ fn verify_release_directory_v4(
     let material = KagemushaPastaCycleProverArtifactsV4::new(
         &authenticated,
         step_eq_parameters,
-        step_eq_circuit_params,
         step_eq_proving_key,
         step_eq_verifying_key,
         step_eq_bootstrap_witness,
         step_ep_parameters,
-        step_ep_circuit_params,
         step_ep_proving_key,
         step_ep_verifying_key,
         step_ep_bootstrap_witness,


### PR DESCRIPTION
## Summary

Two independent build-breaks where CLI/tool call sites were left behind after upstream data-model changes on `optimizations`. Both are pure compile fixes — no behavior change, no new logic.

## Changes

### `iroha_cli`: add `value_parser` for the domain-alias corridor arg
`SetFxCorridorPolicyArgs::allowed_destination_alias_domains: Vec<DomainId>` had `#[arg(long, required = true)]` but no `value_parser`. `DomainId` implements neither `FromStr` nor clap's `ValueParserFactory` (it's a structured `{ name: Name, dataspace: Name }` requiring the `domain.dataspace` format), so clap's derive cannot synthesize a parser and the field fails to compile.

Fix: `value_parser = parse_domain_id_literal` — the same helper the four other `DomainId` args in this file already use (`main_shared.rs:1875, 1888, 6011, 6459`). It routes through `DomainId::parse_fully_qualified` for real validation and maps the error to `String`. This arg was simply added without the attribute its siblings all carry.

### `iroha_kagami`: update caller for the reduced V4 artifact inventory
`KagemushaPastaCycleVerifierArtifactsV4`/`ProverArtifactsV4` were reduced upstream from a 5-role-per-profile to a 4-role-per-profile shape — `circuit_params` moved from an on-disk file artifact to inline profile metadata (`KagemushaPastaCycleProofProfileV4.circuit_params`, "authenticated inline, never as a file"). The canonical `KAGEMUSHA_RECURSIVE_SPEND_ARTIFACT_ROLES_V4` constant is now `[&str; 8]`, and the constructor now takes 9 args (release + 8), but `verify_release_directory_v4` still used the old 10-role shape:
- `REPORT_ARTIFACT_PURPOSES_V4: [&str; 10]` assigned an `[&str; 8]` value (E0308 size mismatch)
- a 10-element array destructure / `try_into::<[_; 10]>`
- an 11-arg `KagemushaPastaCycleProverArtifactsV4::new(...)` call

Fix: drop the two `step_{eq,ep}_circuit_params` bindings and update the counts to 8 to match the current producer API. Error text updated ("ten-artifact" → "eight-artifact").

## Testing

Both crates build clean: `cargo build -p iroha_kagami -p irohad -p iroha_cli --bin kagami --bin irohad --bin iroha` succeeds (exit 0). No runtime behavior changes — the CLI parser and the release-verification inventory count now simply match the current data model.